### PR TITLE
remove legacy tests folder

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,3 +1,0 @@
-module github.com/xyz/pulumi-xyz/tests/v3
-
-go 1.16


### PR DESCRIPTION
The `tests` directory is no longer used. We use the `examples/` instead to run integration tests.