### PR TITLE
Rename provider from `pulumi-service` to `pulumiservice`

### DIFF
--- a/provider/cmd/pulumi-gen-pulumiservice/main.go
+++ b/provider/cmd/pulumi-gen-pulumiservice/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	providerVersion "github.com/pulumi/pulumi-pulumi-service/provider/pkg/version"
+	providerVersion "github.com/pulumi/pulumi-pulumiservice/provider/pkg/version"
 	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
 	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	nodejsgen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"

--- a/provider/cmd/pulumi-resource-pulumiservice/main.go
+++ b/provider/cmd/pulumi-resource-pulumiservice/main.go
@@ -15,11 +15,11 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-pulumi-service/provider/pkg/provider"
-	"github.com/pulumi/pulumi-pulumi-service/provider/pkg/version"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/provider"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/version"
 )
 
-var providerName = "pulumi-service"
+var providerName = "pulumiservice"
 
 func main() {
 	provider.Serve(providerName, version.Version)

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -1,9 +1,9 @@
 {
-  "name": "pulumi-service",
+  "name": "pulumiservice",
   "displayName": "Pulumi Service",
   "description": "A native Pulumi package for creating and managing Pulumi Service constructs",
   "homepage": "https://pulumi.com",
-  "repository": "https://github.com/pulumi/pulumi-pulumi-service",
+  "repository": "https://github.com/pulumi/pulumi-pulumiservice",
   "keywords": [
     "pulumi",
     "kind/native",
@@ -35,7 +35,7 @@
     }
   },
   "resources": {
-    "pulumi-service:index:AccessToken": {
+    "pulumiservice:index:AccessToken": {
       "description": "Access tokens allow a user to authenticate against the Pulumi Service",
       "properties": {
         "tokenId": {
@@ -62,7 +62,7 @@
         "description"
       ]
     },
-    "pulumi-service:index:Team": {
+    "pulumiservice:index:Team": {
       "description": "The Pulumi Service offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.",
       "properties": {
         "type": {
@@ -128,7 +128,7 @@
         "type"
       ]
     },
-    "pulumi-service:index:Webhook": {
+    "pulumiservice:index:Webhook": {
       "description": "Pulumi Webhooks allow you to notify external services of events happening within your Pulumi organization or stack. For example, you can trigger a notification whenever a stack is updated. Whenever an event occurs, Pulumi will send an HTTP POST request to all registered webhooks. The webhook can then be used to emit some notification, start running integration tests, or even update additional stacks.",
       "properties": {
         "name": {
@@ -191,7 +191,7 @@
   "language": {
     "csharp": {
       "namespaces": {
-        "pulumi-service": "PulumiService"
+        "pulumiservice": "PulumiService"
       },
       "packageReferences": {
         "Pulumi": "3.*"
@@ -199,14 +199,16 @@
     },
     "go": {
       "generateResourceContainerTypes": true,
-      "importBasePath": "github.com/pulumi/pulumi-pulumi-service/sdk/go/pulumi-service"
+      "importBasePath": "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice"
     },
     "nodejs": {
+      "packageName": "@pulumi/pulumi-service",
       "dependencies": {
         "@pulumi/pulumi": "^3.0.0"
       }
     },
     "python": {
+      "packageName": "pulumi_service",
       "requires": {
         "pulumi": ">=3.0.0,<4.0.0"
       }

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-pulumi-service/provider
+module github.com/pulumi/pulumi-pulumiservice/provider
 
 go 1.17
 
@@ -94,7 +94,6 @@ require (
 	github.com/spf13/cobra v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
 	github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.22.1+incompatible // indirect
@@ -139,5 +138,6 @@ require (
 	github.com/pierskarsenbarg/pulumi-apiclient v0.0.1
 	github.com/pulumi/pulumi/pkg/v3 v3.29.0
 	github.com/pulumi/pulumi/sdk/v3 v3.29.0
+	github.com/stretchr/testify v1.7.1
 	google.golang.org/grpc v1.45.0
 )

--- a/provider/pkg/provider/accesstoken.go
+++ b/provider/pkg/provider/accesstoken.go
@@ -36,7 +36,7 @@ func (t *PulumiServiceAccessTokenResource) ToPulumiServiceAccessTokenInput(input
 }
 
 func (c PulumiServiceAccessTokenResource) Name() string {
-	return "pulumi-service:index:AccessToken"
+	return "pulumiservice:index:AccessToken"
 }
 
 func (c *PulumiServiceAccessTokenResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -88,7 +88,7 @@ func (k *pulumiserviceProvider) Configure(_ context.Context, req *pulumirpc.Conf
 	sc := PulumiServiceConfig{}
 	sc.Config = make(map[string]string)
 	for key, val := range req.GetVariables() {
-		sc.Config[strings.TrimPrefix(key, "pulumi-service:config:")] = val
+		sc.Config[strings.TrimPrefix(key, "pulumiservice:config:")] = val
 	}
 
 	// if len(k.AccessToken) > 0 {

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -71,7 +71,7 @@ func (t *PulumiServiceTeamResource) ToPulumiServiceTeamInput(inputMap resource.P
 }
 
 func (t *PulumiServiceTeamResource) Name() string {
-	return "pulumi-service:index:Team"
+	return "pulumiservice:index:Team"
 }
 
 func (t *PulumiServiceTeamResource) Configure(config PulumiServiceConfig) {

--- a/provider/pkg/provider/unknown.go
+++ b/provider/pkg/provider/unknown.go
@@ -12,7 +12,7 @@ type PulumiServiceUnknownResource struct{}
 type PulumiServiceUnknownFunction struct{}
 
 func (c PulumiServiceUnknownResource) Name() string {
-	return "pulumi-service:index:Unknown"
+	return "pulumiservice:index:Unknown"
 }
 
 func (u *PulumiServiceUnknownResource) Configure(config PulumiServiceConfig) {
@@ -52,7 +52,7 @@ func (f *PulumiServiceUnknownResource) Invoke(s *pulumiserviceProvider, req *pul
 }
 
 func (f *PulumiServiceUnknownFunction) Name() string {
-	return "pulumi-service:index:Unknown"
+	return "pulumiservice:index:Unknown"
 }
 
 func (f *PulumiServiceUnknownFunction) Configure(config PulumiServiceConfig) {

--- a/provider/pkg/provider/webhook.go
+++ b/provider/pkg/provider/webhook.go
@@ -62,7 +62,7 @@ func (wh *PulumiServiceWebhookResource) ToPulumiServiceWebhookInput(inputMap res
 }
 
 func (wh *PulumiServiceWebhookResource) Name() string {
-	return "pulumi-service:index:Webhook"
+	return "pulumiservice:index:Webhook"
 }
 
 func (wh *PulumiServiceWebhookResource) Configure(config PulumiServiceConfig) {


### PR DESCRIPTION
We settled on the `pulumi-pulumiservice` name after internal discussions.

**Codegen PRs to follow**