### PR TITLE
fix release workflow publish-binary --> publish_binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ env:
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
   TRAVIS_OS_NAME: linux
 jobs:
-  publish-binary:
+  publish_binary:
     name: publish
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
On line `67`, we have `needs: publish_binary` so I'm renaming that step to `publish_binary`.

Doing that instead of changing it to `needs: publish-binary` because we use snake case `example_step` naming conventions.

@jkisk we may want to update the boilerplate template to fix this