### PR TITLE
build provider binary before attempting to generate sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{matrix.pythonversion}}
-      - name: Build provider binary
-        run: make provider
+      - name: Build gen and provider binary
+        run: make gen provider
       - name: Generate SDK
         run: make ${{ matrix.language }}_sdk
       - name: Check worktree clean


### PR DESCRIPTION
Attempted to run `make ${{ matrix.language }}_sdk however provider binary is not found. Therefore, create it in the step before generating the sdk. I could reuse the binary built in pubish_binary but its such a quick build I think its . [Action Run](https://github.com/pulumi/pulumi-pulumiservice/runs/6278751513?check_suite_focus=true)


```
Run make python_sdk
rm -rf sdk/python
/home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice/bin/pulumi-gen-pulumiservice -version=0.0.1 python provider/cmd/pulumi-resource-pulumiservice/schema.json /home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice
make: /home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice/bin/pulumi-gen-pulumiservice: Command not found
make: *** [Makefile:65: python_sdk] Error 127
Error: Process completed with exit code 2.
```