### PR TITLE
remove references to tfgen binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Download provider + tfgen binaries
+    - name: Download provider binaries
       uses: actions/download-artifact@v2
       with:
         name: ${{ env.PROVIDER }}-provider.tar.gz
@@ -120,12 +120,11 @@ jobs:
       uses: jaxxstorm/action-install-gh-release@v1.2.0
       with:
         repo: mikhailshilkov/schema-tools
-    - name: Build tfgen & provider binaries
+    - name: Build provider binaries
       run: make provider
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
-        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-tfgen-${{ env.PROVIDER
-        }}
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
@@ -293,7 +292,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.pythonversion}}
-    - name: Download provider + tfgen binaries
+    - name: Download provider binaries
       uses: actions/download-artifact@v2
       with:
         name: ${{ env.PROVIDER }}-provider.tar.gz


### PR DESCRIPTION
Fix copy paste error in main.yml. Rename workflow steps to not mention tfgen at all, since we're not using it.

Fixes: https://github.com/pulumi/pulumi-pulumiservice/issues/47

### Testing
1. (from project root dir) `make provider`
2. `tar -zcf ./bin/provider.tar.gz -C ./bin/ pulumi-resource-pulumiservice` (replaced all the `${{ github.workspace }}` stuff from the step)