### PR TITLE
Remove `install_plugins` step 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,6 @@ jobs:
       run: |-
         tar -zxf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace}}/bin
         find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
-    - name: Install plugins
-      run: make install_plugins
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Build SDK


### PR DESCRIPTION
Removes `make install_plugins` step. This is another dangling step from other repo.

We don't rely on any plugins for our tests besides our provider, so we don't need to have a make target for it. At least yet