### PR TITLE
Fix Build SDK step. use `make {language}_sdk` instead of `build_{lang…`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Build SDK
-      run: make build_${{ matrix.language }}
+      run: make ${{ matrix.language }}_sdk
     - name: Check worktree clean
       run: ./ci-scripts/ci/check-worktree-is-clean
     - name: Compress SDK folder


### PR DESCRIPTION
Our `make` target is called `make go_sdk`, etc, not `make build_go`, so fix that step.