### PR TITLE
tar up provider gen binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
       run: make provider
     - name: Tar provider binaries
       run: tar -zcf ${{ github.workspace }}/bin/provider.tar.gz -C ${{ github.workspace
-        }}/bin/ pulumi-resource-${{ env.PROVIDER }}
+        }}/bin/ pulumi-resource-${{ env.PROVIDER }} pulumi-gen-${{ env.PROVIDER }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
Add `pulumi-gen-pulumiservice` to our tarball. We had a  `command not found` error because we aren't including it in our artifact.

https://github.com/pulumi/pulumi-pulumiservice/runs/6378678642?check_suite_focus=true
```
/home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice/bin/pulumi-gen-pulumiservice -version=v0.0.7-alpha.1652220817+cf3be892 nodejs provider/cmd/pulumi-resource-pulumiservice/schema.json /home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice
make: /home/runner/work/pulumi-pulumiservice/pulumi-pulumiservice/bin/pulumi-gen-pulumiservice: Command not found
```