### PR TITLE
Add new issue triage workflow

### DIFF
--- a/.github/workflows/new-issues-to-triage.yml
+++ b/.github/workflows/new-issues-to-triage.yml
@@ -1,0 +1,52 @@
+name: New Issues to Triage
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    new-issue-to-triage:
+        runs-on: ubuntu-latest
+        name: New Issue to Triage
+        # Based on https://docs.github.com/en/issues/trying-out-the-new-projects-experience/automating-projects#example-workflow-authenticating-with-a-personal-access-token
+        steps:
+            - name: Get project data
+              env:
+                  GITHUB_TOKEN: ${{ secrets.TRIAGE_WORKFLOW_TOKEN }}
+                  ORGANIZATION: pulumi
+                  PROJECT_NUMBER: 33
+              run: |
+                  gh api graphql -f query='
+                    query($org: String!, $number: Int!) {
+                      organization(login: $org){
+                        projectNext(number: $number) {
+                          id
+                          fields(first:20) {
+                            nodes {
+                              id
+                              name
+                              settings
+                            }
+                          }
+                        }
+                      }
+                    }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+                  echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+                  echo 'DATE_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Date posted") | .id' project_data.json) >> $GITHUB_ENV
+                  echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+                  echo 'TODO_OPTION_ID='$(jq '.data.organization.projectNext.fields.nodes[] | select(.name== "Status") |.settings | fromjson.options[] | select(.name=="Todo") |.id' project_data.json) >> $GITHUB_ENV
+            - name: Add issue to project
+              env:
+                  GITHUB_TOKEN: ${{ secrets.TRIAGE_WORKFLOW_TOKEN }}
+                  ISSUE_ID: ${{ github.event.issue.node_id }}
+              run: |
+                  item_id="$( gh api graphql -f query='
+                    mutation($project:ID!, $pr:ID!) {
+                      addProjectNextItem(input: {projectId: $project, contentId: $pr}) {
+                        projectNextItem {
+                          id
+                        }
+                      }
+                    }' -f project=$PROJECT_ID -f pr=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"
+
+                  echo 'ITEM_ID='$item_id >> $GITHUB_ENV


### PR DESCRIPTION
New issues for this repo are going to /dev/null. I have added all the open issues to triage manually but copying over the triage workflow so that they end up on our project board automatically going forward.