### PR TITLE
add YAML support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,11 +332,13 @@ jobs:
         find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
     - run: dotnet nuget add source ${{ github.workspace }}/nuget
     - name: Download SDK
+      if: ${{ matrix.language != 'yaml' }}
       uses: actions/download-artifact@v2
       with:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress SDK folder
+      if: ${{ matrix.language != 'yaml' }}
       run: tar -zxf ${{ github.workspace }}/sdk/${{ matrix.language }}.tar.gz -C ${{
         github.workspace }}/sdk/${{ matrix.language }}
     - name: Update path
@@ -346,6 +348,7 @@ jobs:
         pip3 install virtualenv==20.0.23
         pip3 install pipenv
     - name: Install dependencies
+      if: ${{ matrix.language != 'yaml' }}
       run: make install_${{ matrix.language}}_sdk
       env:
         # Right now we pin this, we should add a way to automatically upgrade
@@ -356,13 +359,14 @@ jobs:
       # Necessary because go test reports an error if no tests match build tag
       # We could also use continue-on-error but this way we get to visually see that we've
       # skipped this step.
-      if: ${{ matrix.language == 'nodejs' || matrix.language == 'java' }}
+      if: ${{ matrix.language == 'nodejs' || matrix.language == 'java' || matrix.language == 'yaml' }}
     strategy:
       fail-fast: true
       matrix:
+        language: [nodejs, java, python, dotnet, go, yaml]
+
         dotnetversion: [3.1.301]
         goversion: [1.17.x]
-        language: [nodejs, java, python, dotnet, go]
         nodeversion: [14.x]
         pythonversion: ["3.7"]
         javaversion: ["11"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,7 @@ jobs:
           - dotnet
           - go
           - java
+          # yaml doesn't need an sdk :)
         nodeversion:
           - 14.x
         pythonversion:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -207,7 +207,6 @@ jobs:
           path: ${{ github.workspace}}/sdk
       - name: Uncompress SDK folder
         if: ${{ matrix.language != 'yaml' }}
-        uses: actions/download-artifact@v2
         run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{ github.workspace}}/sdk/${{ matrix.language}}
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -151,9 +151,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        language: [nodejs, java, yaml]
+
         dotnetversion: [3.1.301]
         goversion: [1.17.x]
-        language: [nodejs, java]
         nodeversion: [14.x]
         pythonversion: [3.7]
         javaversion: [11]
@@ -199,11 +200,14 @@ jobs:
         run: find ${{ github.workspace }} -name "pulumi-*-${{ env.PROVIDER }}" -print
           -exec chmod +x {} \;
       - name: Download SDK
+        if: ${{ matrix.language != 'yaml' }}
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.language  }}-sdk.tar.gz
           path: ${{ github.workspace}}/sdk
       - name: Uncompress SDK folder
+        if: ${{ matrix.language != 'yaml' }}
+        uses: actions/download-artifact@v2
         run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{ github.workspace}}/sdk/${{ matrix.language}}
       - name: Update path
         run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
@@ -215,6 +219,7 @@ jobs:
           pip3 install virtualenv==20.0.23
           pip3 install pipenv
       - name: Install dependencies
+        if: ${{ matrix.language != 'yaml' }}
         run: make install_${{ matrix.language}}_sdk
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v2

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,0 +1,20 @@
+//go:build yaml
+
+package examples
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+)
+
+func TestYamlTeamsExample(t *testing.T) {
+	cwd, _ := os.Getwd()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Quick:       true,
+		SkipRefresh: true,
+		Dir:         path.Join(cwd, ".", "yaml-teams"),
+	})
+}

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,4 +1,4 @@
-// go:build yaml
+//go:build yaml
 
 package examples
 

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -1,4 +1,4 @@
-//go:build yaml
+// go:build yaml
 
 package examples
 
@@ -7,6 +7,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
 )
 
@@ -16,5 +17,9 @@ func TestYamlTeamsExample(t *testing.T) {
 		Quick:       true,
 		SkipRefresh: true,
 		Dir:         path.Join(cwd, ".", "yaml-teams"),
+		// don't prepare project at all, not required for yaml
+		PrepareProject: func(_ *engine.Projinfo) error {
+			return nil
+		},
 	})
 }

--- a/examples/yaml-teams/Pulumi.yaml
+++ b/examples/yaml-teams/Pulumi.yaml
@@ -1,0 +1,20 @@
+name: pulumi-service-teams-example-yaml
+runtime: yaml
+description: An example of using python to create a team
+resources:
+  rand:
+    type: random:RandomString
+    properties:
+      length: 5
+      # team names may only contain alphanumeric, hyphens, underscores, or periods
+      special: false
+  team:
+    type: pulumiservice:index:Team
+    properties:
+      name: brand-new-yaml-team-${rand.result}
+      organizationName: service-provider-test-org
+      displayName: PulumiUP Team
+      teamType: pulumi
+      members:
+        - pulumi-bot
+        - service-provider-example-user

--- a/provider/cmd/pulumi-resource-pulumiservice/main.go
+++ b/provider/cmd/pulumi-resource-pulumiservice/main.go
@@ -15,12 +15,19 @@
 package main
 
 import (
+	_ "embed"
+
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/provider"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/version"
 )
 
 var providerName = "pulumiservice"
 
+// embed schema.json directly into resource binary so that we can properly serve the schema
+// directly from the resource provider
+//go:embed schema.json
+var schema string
+
 func main() {
-	provider.Serve(providerName, version.Version)
+	provider.Serve(providerName, version.Version, schema)
 }

--- a/provider/pkg/provider/serve.go
+++ b/provider/pkg/provider/serve.go
@@ -21,10 +21,10 @@ import (
 )
 
 // Serve launches the gRPC server for the resource provider.
-func Serve(providerName, version string) {
+func Serve(providerName, version string, schema string) {
 	// Start gRPC service.
 	err := provider.Main(providerName, func(host *provider.HostClient) (rpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
+		return makeProvider(host, providerName, version, schema)
 	})
 	if err != nil {
 		cmdutil.ExitError(err.Error())


### PR DESCRIPTION
## Details
Adds YAML support for the Pulumi Service Provider. Originally was under the impression that YAML would work out of the box, however YAML requires the `GetSchema` GRPC call to return the actual schema, since otherwise YAML has no way of determining the schema. The other languages worked just fine because they have SDKs which already know the schema.

Fixes: https://github.com/pulumi/pulumi-pulumiservice/issues/58

## Testing
1. `$ cd examples/yaml-teams`
2. `$ pulumi up`

Additionally, added test runner for yaml-teams examples and github actions config as part of this PR.