### PR TITLE
WIP Stack permissions for teams

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -91,6 +91,24 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "stackPermissions": {
+          "description": "A list of stacks to give the team access to",
+          "type": "array",
+          "items": {
+            "type":"object",
+            "properties": {
+              "projectName": {
+                "type": "string"
+              },
+              "stackName": {
+                "type": "string"
+              },
+              "permission": {
+                "type": "number"
+              }
+            }
+          }
         }
       },
       "inputProperties": {
@@ -120,6 +138,24 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "stackPermissions": {
+          "description": "A list of stacks to give the team access to",
+          "type": "array",
+          "items": {
+            "type":"object",
+            "properties": {
+              "projectName": {
+                "type": "string"
+              },
+              "stackName": {
+                "type": "string"
+              },
+              "permission": {
+                "type": "number"
+              }
+            }
+          }
         }
       },
       "requiredInputs": [

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -241,6 +241,7 @@ func (c *Client) DeleteMemberFromTeam(ctx context.Context, orgName, teamName, us
 	}
 }
 
+// todo, delete stack access
 func (c *Client) UpdateStackAccessToTeam(ctx context.Context, orgName, teamName, projectName, stackName string, permission int) error {
 	if len(orgName) == 0 {
 		return errors.New("orgname must not be empty")
@@ -263,26 +264,3 @@ func (c *Client) UpdateStackAccessToTeam(ctx context.Context, orgName, teamName,
 	}
 	return nil
 }
-
-// func (c *Client) AddMemberToTeam(ctx context.Context, orgName, teamName, userName string) error {
-// 	err := c.updateTeamMembership(ctx, orgName, teamName, userName, "add")
-// 	if err != nil {
-// 		var errResp *errorResponse
-// 		if errors.As(err, &errResp) && errResp.StatusCode == http.StatusConflict {
-// 			// ignore 409 since that means the team member is already added
-// 			return nil
-// 		}
-// 		return err
-// 	} else {
-// 		return nil
-// 	}
-// }
-
-// func (c *Client) DeleteMemberFromTeam(ctx context.Context, orgName, teamName, userName string) error {
-// 	err := c.updateTeamMembership(ctx, orgName, teamName, userName, "remove")
-// 	if err != nil {
-// 		return err
-// 	} else {
-// 		return nil
-// 	}
-// }

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -58,6 +58,16 @@ type updateTeamMembershipRequest struct {
 	Member       string `json:"member"`
 }
 
+type AddStackPermission struct {
+	ProjectName string `json:"projectName"`
+	StackName   string `json:"stackName"`
+	Permission  int    `json:"permission"`
+}
+
+type addStackPermissionRequest struct {
+	AddStackPermission AddStackPermission `json:"addStackPermission"`
+}
+
 func (c *Client) ListTeams(ctx context.Context, orgName string) ([]Team, error) {
 	if len(orgName) == 0 {
 		return nil, errors.New("empty orgName")
@@ -230,3 +240,49 @@ func (c *Client) DeleteMemberFromTeam(ctx context.Context, orgName, teamName, us
 		return nil
 	}
 }
+
+func (c *Client) UpdateStackAccessToTeam(ctx context.Context, orgName, teamName, projectName, stackName string, permission int) error {
+	if len(orgName) == 0 {
+		return errors.New("orgname must not be empty")
+	}
+
+	if len(teamName) == 0 {
+		return errors.New("teamname must not be empty")
+	}
+
+	apiPath := path.Join("orgs", orgName, "teams", teamName)
+
+	addStackPermissionRequest := addStackPermissionRequest{
+		AddStackPermission: AddStackPermission{ProjectName: projectName, StackName: stackName, Permission: permission},
+	}
+
+	_, err := c.do(ctx, http.MethodPatch, apiPath, addStackPermissionRequest, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to update stack permission for team: %w", err)
+	}
+	return nil
+}
+
+// func (c *Client) AddMemberToTeam(ctx context.Context, orgName, teamName, userName string) error {
+// 	err := c.updateTeamMembership(ctx, orgName, teamName, userName, "add")
+// 	if err != nil {
+// 		var errResp *errorResponse
+// 		if errors.As(err, &errResp) && errResp.StatusCode == http.StatusConflict {
+// 			// ignore 409 since that means the team member is already added
+// 			return nil
+// 		}
+// 		return err
+// 	} else {
+// 		return nil
+// 	}
+// }
+
+// func (c *Client) DeleteMemberFromTeam(ctx context.Context, orgName, teamName, userName string) error {
+// 	err := c.updateTeamMembership(ctx, orgName, teamName, userName, "remove")
+// 	if err != nil {
+// 		return err
+// 	} else {
+// 		return nil
+// 	}
+// }

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -199,18 +199,7 @@ func (tr *PulumiServiceTeamResource) Update(req *pulumirpc.UpdateRequest) (*pulu
 	}
 
 	if !EqualStackPermissions(teamOld.StackPermissions, teamNew.StackPermissions) {
-		// inputsChanged.Members = teamNew.Members
-		// for _, usernameToDelete := range teamOld.Members {
-		// 	if !InSlice(usernameToDelete, teamNew.Members) {
-		// 		tr.deleteFromTeam(ctx, teamOld.OrganizationName, teamOld.Name, usernameToDelete)
-		// 	}
-		// }
-
-		// for _, usernameToAdd := range teamNew.Members {
-		// 	if !InSlice(usernameToAdd, teamOld.Members) {
-		// 		tr.addToTeam(ctx, teamOld.OrganizationName, teamOld.Name, usernameToAdd)
-		// 	}
-		// }
+		// todo
 	}
 
 	outputStore := resource.PropertyMap{}

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -18,7 +18,8 @@ class TeamArgs:
                  team_type: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
-                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 stack_permissions: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None):
         """
         The set of arguments for constructing a Team resource.
         :param pulumi.Input[str] name: The team name.
@@ -27,6 +28,7 @@ class TeamArgs:
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
+        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] stack_permissions: A list of stacks to give the team access to
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
@@ -37,6 +39,8 @@ class TeamArgs:
             pulumi.set(__self__, "display_name", display_name)
         if members is not None:
             pulumi.set(__self__, "members", members)
+        if stack_permissions is not None:
+            pulumi.set(__self__, "stack_permissions", stack_permissions)
 
     @property
     @pulumi.getter
@@ -110,6 +114,18 @@ class TeamArgs:
     def members(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "members", value)
 
+    @property
+    @pulumi.getter(name="stackPermissions")
+    def stack_permissions(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+        """
+        A list of stacks to give the team access to
+        """
+        return pulumi.get(self, "stack_permissions")
+
+    @stack_permissions.setter
+    def stack_permissions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+        pulumi.set(self, "stack_permissions", value)
+
 
 class Team(pulumi.CustomResource):
     @overload
@@ -121,6 +137,7 @@ class Team(pulumi.CustomResource):
                  members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
+                 stack_permissions: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
                  team_type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -133,6 +150,7 @@ class Team(pulumi.CustomResource):
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
         :param pulumi.Input[str] name: The team name.
         :param pulumi.Input[str] organization_name: The organization's name.
+        :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] stack_permissions: A list of stacks to give the team access to
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         """
         ...
@@ -164,6 +182,7 @@ class Team(pulumi.CustomResource):
                  members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
+                 stack_permissions: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
                  team_type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         if opts is None:
@@ -186,6 +205,7 @@ class Team(pulumi.CustomResource):
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")
             __props__.__dict__["organization_name"] = organization_name
+            __props__.__dict__["stack_permissions"] = stack_permissions
             if team_type is None and not opts.urn:
                 raise TypeError("Missing required property 'team_type'")
             __props__.__dict__["team_type"] = team_type
@@ -216,6 +236,7 @@ class Team(pulumi.CustomResource):
         __props__.__dict__["members"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
+        __props__.__dict__["stack_permissions"] = None
         __props__.__dict__["team_type"] = None
         return Team(resource_name, opts=opts, __props__=__props__)
 
@@ -258,6 +279,14 @@ class Team(pulumi.CustomResource):
         The organization's name.
         """
         return pulumi.get(self, "organization_name")
+
+    @property
+    @pulumi.getter(name="stackPermissions")
+    def stack_permissions(self) -> pulumi.Output[Optional[Sequence[Mapping[str, str]]]]:
+        """
+        A list of stacks to give the team access to
+        """
+        return pulumi.get(self, "stack_permissions")
 
     @property
     @pulumi.getter(name="teamType")


### PR DESCRIPTION
Howdy, it's been probably a year since I last touched golang/a go Pulumi provider

We need https://github.com/pulumi/pulumi-pulumiservice/issues/51 because managing perms with the Pulumi service is not great, so I've started working on adding support for it. I don't handle deleting permissions, validating that the permission selected is valid (103, 102, 101), comparing permissions to see if its changed between old/new, and I don't think the schema looks great for it. 

Posting this to start getting comments on it and see if Pulumi would like to take it over. 