### PR TITLE
Implement Update and Fix Missing Property Bug

### DIFF
--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+	"gopkg.in/yaml.v2"
 )
 
 func TestYamlTeamsExample(t *testing.T) {
@@ -20,6 +21,43 @@ func TestYamlTeamsExample(t *testing.T) {
 		// don't prepare project at all, not required for yaml
 		PrepareProject: func(_ *engine.Projinfo) error {
 			return nil
+		},
+	})
+}
+
+func TestYamlStackTagsExample(t *testing.T) {
+
+	// Set up tmpdir with a Pulumi.yml with no resources
+	// mimicking the deletion of resource
+	tmpdir := t.TempDir()
+	newProgram := map[string]string{
+		"name":        "yaml-stack-tags-example",
+		"runtime":     "yaml",
+		"description": "A minimal Pulumi YAML program",
+	}
+
+	b, err := yaml.Marshal(newProgram)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(path.Join(tmpdir, "Pulumi.yml"), b, 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cwd, _ := os.Getwd()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Quick:       true,
+		SkipRefresh: true,
+		Dir:         path.Join(cwd, ".", "yaml-stack-tags"),
+		StackName:   "test-stack",
+		PrepareProject: func(_ *engine.Projinfo) error {
+			return nil
+		},
+		EditDirs: []integration.EditDir{
+			{
+				Dir: tmpdir,
+			},
 		},
 	})
 }

--- a/examples/yaml-stack-tags/Pulumi.yaml
+++ b/examples/yaml-stack-tags/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: yaml-stack-tags-example
+runtime: yaml
+description: A minimal Pulumi YAML program
+resources:
+  testing-tag:
+    type: pulumiservice:StackTag
+    properties:
+      organization: pulumi-bot
+      project: yaml-stack-tags-example
+      stack: test-stack
+      name: testing-tag
+      value: bar

--- a/provider/pkg/internal/serde/property_map_test.go
+++ b/provider/pkg/internal/serde/property_map_test.go
@@ -45,29 +45,46 @@ func TestFromPropertyMap(t *testing.T) {
 		FloatPtrField *float64 `pulumi:"floatptr_field"`
 		IntPtrField   *int64   `pulumi:"intptr_field"`
 	}
-	intValue := int64(1)
-	floatValue := 2.5
-	a := A{
-		IntField:      int(intValue),
-		FloatField:    floatValue,
-		StringField:   "example",
-		FloatPtrField: &floatValue,
-		IntPtrField:   &intValue,
-	}
-	propertyMap := resource.PropertyMap{}
-	expected := map[string]interface{}{
-		// NewPropertyValue() auto converts ints to float64
-		"int_field":      float64(1),
-		"float_field":    float64(2.5),
-		"string_field":   "example",
-		"floatptr_field": &floatValue,
-		"intptr_field":   &intValue,
-	}
-	for key, value := range expected {
-		propertyMap[resource.PropertyKey(key)] = resource.NewPropertyValue(value)
-	}
-	actual := A{}
-	FromPropertyMap(propertyMap, "pulumi", &actual)
-	assert.Equal(t, a, actual)
+	t.Run("Unmarshals Props Properly", func(t *testing.T) {
+		intValue := int64(1)
+		floatValue := 2.5
+		want := A{
+			IntField:      int(intValue),
+			FloatField:    floatValue,
+			StringField:   "example",
+			FloatPtrField: &floatValue,
+			IntPtrField:   &intValue,
+		}
+		propertyMap := resource.PropertyMap{}
+		expected := map[string]interface{}{
+			// NewPropertyValue() auto converts ints to float64
+			"int_field":      float64(1),
+			"float_field":    float64(2.5),
+			"string_field":   "example",
+			"floatptr_field": &floatValue,
+			"intptr_field":   &intValue,
+		}
+		for key, value := range expected {
+			propertyMap[resource.PropertyKey(key)] = resource.NewPropertyValue(value)
+		}
+		got := A{}
+		err := FromPropertyMap(propertyMap, "pulumi", &got)
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("Skips Missing Keys", func(t *testing.T) {
+		propertyMap := resource.PropertyMap{}
+		// property map is empty, no fields should be set
+		want := A{}
+
+		got := A{}
+		err := FromPropertyMap(propertyMap, "pulumi", &got)
+
+		// no error should be returned, even though struct has pulumi tags
+		// that aren't present in propertyMap
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
 
 }

--- a/provider/pkg/provider/stack_tags.go
+++ b/provider/pkg/provider/stack_tags.go
@@ -104,6 +104,29 @@ func (st *PulumiServiceStackTagResource) Check(req *pulumirpc.CheckRequest) (*pu
 }
 
 func (st *PulumiServiceStackTagResource) Update(req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
+	ctx := context.Background()
+	var inputs PulumiServiceStackTagInput
+	err := serde.FromProperties(req.GetNews(), structTagKey, &inputs)
+	if err != nil {
+		return nil, err
+	}
+	stackName := pulumiapi.StackName{
+		OrgName:     inputs.Organization,
+		ProjectName: inputs.Project,
+		StackName:   inputs.Stack,
+	}
+	stackTag := pulumiapi.StackTag{
+		Name:  inputs.Name,
+		Value: inputs.Value,
+	}
+	err = st.client.DeleteStackTag(ctx, stackName, stackTag.Name)
+	if err != nil {
+		return nil, err
+	}
+	err = st.client.CreateTag(ctx, stackName, stackTag)
+	if err != nil {
+		return nil, err
+	}
 	return &pulumirpc.UpdateResponse{}, nil
 }
 

--- a/provider/pkg/provider/stack_tags_test.go
+++ b/provider/pkg/provider/stack_tags_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/internal/pulumiapi"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/internal/serde"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackTagsUpdate(t *testing.T) {
+	t.Run("Calls Delete then Create on Resource", func(t *testing.T) {
+		var gotMethods []string
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethods = append(gotMethods, r.Method)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		st := &PulumiServiceStackTagResource{
+			client: apiClient,
+		}
+
+		input := PulumiServiceStackTagInput{
+			Organization: "org",
+			Project:      "project",
+			Stack:        "stack",
+			Name:         "tag",
+			Value:        "tag_value",
+		}
+
+		properties, err := serde.ToProperties(input, "pulumi")
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		upReq := pulumirpc.UpdateRequest{
+			Olds: properties,
+			News: properties,
+		}
+
+		_, err = st.Update(&upReq)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// expect DELETE first, then POST
+		wantMethods := []string{http.MethodDelete, http.MethodPost}
+		assert.Equal(t, wantMethods, gotMethods)
+
+	})
+
+}


### PR DESCRIPTION
### Description of Change

This PR fixes https://github.com/pulumi/pulumi-pulumiservice/issues/75.

There were two issues that needed to be fixed to get the issue resolved.

1. Implementing update in stack tags resource
2. Fix bug where deleting resources causes the following error: `error: field type "string" does not match property "invalid"`. This was caused by our `serde` package assuming that the PropertyMap included all entries.