### PR TITLE
Fetch credentials from disk if not specified via env or config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,28 +56,16 @@ To use from .NET, install using `dotnet add package`:
 
 ## Setup
 
-To provision resources with the Pulumi Service provider, you need to have Pulumi Service credentials. Pulumi Service maintains documentation on how to create access tokens [here](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens). 
-
-While you can use this provider to provision access tokens, you'll still need to have an access token available to generate an access token with the provider.
-
-### Set environment variables
-
-Once you have an access token, its easy to set the environment variables. The Pulumi Service Provider uses the same environment variables as Pulumi does.
-
-```bash
-$ export PULUMI_ACCESS_TOKEN=<PULUMI_ACCESS_TOKEN>
-
-$ export PULUMI_BACKEND_URL=<PULUMI_BACKEND_URL> # For self hosted customers. defaults to https://api.pulumi.com
-```
+Ensure that you have ran `pulumi login`. Run `pulumi whoami` to verify that you are logged in.
 
 ### Configuration Options
 
 Use `pulumi config set pulumiservice:<option>` or pass options to the [constructor of `new pulumiservice.Provider`](https://pulumi.com/registry/packages/pulumiservice/api-docs/provider).
 
-| Option | Required/Optional | Description |
-|-----|------|----|
-| `accessToken`| Required | [Pulumi Service Access Tokens](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens) |
-| `apiUrl`| Optional | Allows overriding default [Pulumi Service API URL](https://www.pulumi.com/docs/reference/service-rest-api) for [self hosted customers](https://www.pulumi.com/docs/guides/self-hosted/).
+| Option | Environment Variable Name | Required/Optional | Description |
+|-----|------|----|----|
+| `accessToken`| `PULUMI_ACCESS_TOKEN` |Optional | Overrides [Pulumi Service Access Tokens](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens) |
+| `apiUrl`| `PULUMI_BACKEND_URL` | Optional | Allows overriding default [Pulumi Service API URL](https://www.pulumi.com/docs/reference/service-rest-api) for [self hosted customers](https://www.pulumi.com/docs/guides/self-hosted/).
 
 
 ## Examples

--- a/examples/yaml-access-tokens/Pulumi.yaml
+++ b/examples/yaml-access-tokens/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: yaml-access-tokens
+runtime: yaml
+description: A minimal example of provisioning access token via Pulumi YAML
+
+resources:
+  access-token:
+    type: pulumiservice:index:AccessToken
+    properties:
+      description: example token
+
+outputs:
+  # export the value of the access token
+  token: ${access-token.value}

--- a/provider/pkg/provider/config.go
+++ b/provider/pkg/provider/config.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )

--- a/provider/pkg/provider/config.go
+++ b/provider/pkg/provider/config.go
@@ -20,7 +20,7 @@ type PulumiServiceConfig struct {
 }
 
 func (pc *PulumiServiceConfig) getConfig(configName, envName string) string {
-	if val, ok := pc.Config[strings.ToLower(configName)]; ok {
+	if val, ok := pc.Config[configName]; ok {
 		return val
 	}
 

--- a/provider/pkg/provider/config_test.go
+++ b/provider/pkg/provider/config_test.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	EnvVarPulumiHome = "PULUMI_HOME"
+)
+
+func TestGetPulumiAccessToken(t *testing.T) {
+	wantToken := "pul-1234abcd"
+
+	// setEnv sets environment variable and returns a function to reset
+	// environment variable back to previous value
+	setEnv := func(envVar, val string) func() {
+		oldVal := os.Getenv(envVar)
+		os.Setenv(envVar, val)
+		return func() {
+			os.Setenv(envVar, oldVal)
+		}
+	}
+
+	t.Run("Uses Config Variable", func(t *testing.T) {
+		defer setEnv(EnvVarPulumiAccessToken, "")()
+		c := PulumiServiceConfig{
+			Config: map[string]string{
+				"accessToken": wantToken,
+			},
+		}
+		gotToken, err := c.getPulumiAccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, wantToken, *gotToken)
+
+	})
+
+	t.Run("Uses Environment Variable", func(t *testing.T) {
+
+		c := PulumiServiceConfig{}
+		defer setEnv(EnvVarPulumiAccessToken, wantToken)()
+
+		gotToken, err := c.getPulumiAccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, wantToken, *gotToken)
+	})
+
+	t.Run("Uses Saved Credential", func(t *testing.T) {
+		c := PulumiServiceConfig{}
+		// ensure env var isn't set
+		defer setEnv(EnvVarPulumiAccessToken, "")()
+
+		dir := t.TempDir()
+		// set home directory so that workspace writes to temp dir
+		defer setEnv(EnvVarPulumiHome, dir)()
+
+		account := "https://api.pulumi.com"
+
+		err := workspace.StoreCredentials(workspace.Credentials{
+			Current: account,
+			AccessTokens: map[string]string{
+				account: wantToken,
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to store test credentials: %v", err)
+		}
+		gotToken, err := c.getPulumiAccessToken()
+		assert.NoError(t, err)
+		assert.Equal(t, wantToken, *gotToken)
+	})
+
+	t.Run("Returns Error", func(t *testing.T) {
+		c := PulumiServiceConfig{}
+
+		// point PULUMI_HOME to empty dir so there's no credentials available
+		dir := t.TempDir()
+		defer setEnv(EnvVarPulumiHome, dir)()
+		// explicitly unset access token variable
+		defer setEnv(EnvVarPulumiAccessToken, "")()
+
+		gotToken, err := c.getPulumiAccessToken()
+
+		assert.Nil(t, gotToken)
+		assert.Equal(t, ErrAccessTokenNotFound, err)
+	})
+}

--- a/provider/pkg/provider/config_test.go
+++ b/provider/pkg/provider/config_test.go
@@ -39,7 +39,6 @@ func TestGetPulumiAccessToken(t *testing.T) {
 	})
 
 	t.Run("Uses Environment Variable", func(t *testing.T) {
-
 		c := PulumiServiceConfig{}
 		defer setEnv(EnvVarPulumiAccessToken, wantToken)()
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -56,28 +56,16 @@ To use from .NET, install using `dotnet add package`:
 
 ## Setup
 
-To provision resources with the Pulumi Service provider, you need to have Pulumi Service credentials. Pulumi Service maintains documentation on how to create access tokens [here](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens). 
-
-While you can use this provider to provision access tokens, you'll still need to have an access token available to generate an access token with the provider.
-
-### Set environment variables
-
-Once you have an access token, its easy to set the environment variables. The Pulumi Service Provider uses the same environment variables as Pulumi does.
-
-```bash
-$ export PULUMI_ACCESS_TOKEN=<PULUMI_ACCESS_TOKEN>
-
-$ export PULUMI_BACKEND_URL=<PULUMI_BACKEND_URL> # For self hosted customers. defaults to https://api.pulumi.com
-```
+Ensure that you have ran `pulumi login`. Run `pulumi whoami` to verify that you are logged in.
 
 ### Configuration Options
 
 Use `pulumi config set pulumiservice:<option>` or pass options to the [constructor of `new pulumiservice.Provider`](https://pulumi.com/registry/packages/pulumiservice/api-docs/provider).
 
-| Option | Required/Optional | Description |
-|-----|------|----|
-| `accessToken`| Required | [Pulumi Service Access Tokens](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens) |
-| `apiUrl`| Optional | Allows overriding default [Pulumi Service API URL](https://www.pulumi.com/docs/reference/service-rest-api) for [self hosted customers](https://www.pulumi.com/docs/guides/self-hosted/).
+| Option | Environment Variable Name | Required/Optional | Description |
+|-----|------|----|----|
+| `accessToken`| `PULUMI_ACCESS_TOKEN` |Optional | Overrides [Pulumi Service Access Tokens](https://www.pulumi.com/docs/intro/pulumi-service/accounts/#access-tokens) |
+| `apiUrl`| `PULUMI_BACKEND_URL` | Optional | Allows overriding default [Pulumi Service API URL](https://www.pulumi.com/docs/reference/service-rest-api) for [self hosted customers](https://www.pulumi.com/docs/guides/self-hosted/).
 
 
 ## Examples


### PR DESCRIPTION
## Description

Adds support for fetching pulumi service credentials from disk, instead of requiring it to be set via a config variable or environment variable.

This simplifies the setup and usage of the pulumi service provider. Now, all you need to do is `pulumi login`, like you would normally, and the provider will use those credentials. I've updated the README to reflect this.

Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/63

## Testing
New unit tests, plus manual verification.