### PR TITLE
Set test owner to our test organization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ env:
   PULUMI_BACKEND_URL: https://api.pulumi-staging.io
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
 
+  PULUMI_TEST_OWNER: service-provider-test-org
+
   PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYPI_USERNAME: pulumi
   PUBLISH_PYPI: true


### PR DESCRIPTION
https://github.com/pulumi/pulumi-pulumiservice/pull/88 introduced a change that modified the expected organization for a few tests. I forgot to update `main.yml` as well with that change, so this should fix the build.

Example failing run: https://github.com/pulumi/pulumi-pulumiservice/runs/7907754936?check_suite_focus=true