### PR TITLE
Add Team/Org access token values and mark as secret

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -156,6 +156,11 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "value": {
+          "description": "The token's value.",
+          "type": "string",
+          "secret": true
         }
       },
       "inputProperties": {
@@ -192,6 +197,11 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "value": {
+          "description": "The token's value.",
+          "type": "string",
+          "secret": true
         }
       },
       "inputProperties": {

--- a/sdk/dotnet/OrgAccessToken.cs
+++ b/sdk/dotnet/OrgAccessToken.cs
@@ -33,6 +33,12 @@ namespace Pulumi.PulumiService
         [Output("organizationName")]
         public Output<string?> OrganizationName { get; private set; } = null!;
 
+        /// <summary>
+        /// The token's value.
+        /// </summary>
+        [Output("value")]
+        public Output<string?> Value { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a OrgAccessToken resource with the given unique name, arguments, and options.
@@ -56,6 +62,10 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                AdditionalSecretOutputs =
+                {
+                    "value",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/TeamAccessToken.cs
+++ b/sdk/dotnet/TeamAccessToken.cs
@@ -39,6 +39,12 @@ namespace Pulumi.PulumiService
         [Output("teamName")]
         public Output<string?> TeamName { get; private set; } = null!;
 
+        /// <summary>
+        /// The token's value.
+        /// </summary>
+        [Output("value")]
+        public Output<string?> Value { get; private set; } = null!;
+
 
         /// <summary>
         /// Create a TeamAccessToken resource with the given unique name, arguments, and options.
@@ -62,6 +68,10 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                AdditionalSecretOutputs =
+                {
+                    "value",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/pulumiservice/orgAccessToken.go
+++ b/sdk/go/pulumiservice/orgAccessToken.go
@@ -21,6 +21,8 @@ type OrgAccessToken struct {
 	Name pulumi.StringPtrOutput `pulumi:"name"`
 	// The organization's name.
 	OrganizationName pulumi.StringPtrOutput `pulumi:"organizationName"`
+	// The token's value.
+	Value pulumi.StringPtrOutput `pulumi:"value"`
 }
 
 // NewOrgAccessToken registers a new resource with the given unique name, arguments, and options.
@@ -36,6 +38,10 @@ func NewOrgAccessToken(ctx *pulumi.Context,
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
 	}
+	secrets := pulumi.AdditionalSecretOutputs([]string{
+		"value",
+	})
+	opts = append(opts, secrets)
 	var resource OrgAccessToken
 	err := ctx.RegisterResource("pulumiservice:index:OrgAccessToken", name, args, &resource, opts...)
 	if err != nil {
@@ -186,6 +192,11 @@ func (o OrgAccessTokenOutput) Name() pulumi.StringPtrOutput {
 // The organization's name.
 func (o OrgAccessTokenOutput) OrganizationName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *OrgAccessToken) pulumi.StringPtrOutput { return v.OrganizationName }).(pulumi.StringPtrOutput)
+}
+
+// The token's value.
+func (o OrgAccessTokenOutput) Value() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *OrgAccessToken) pulumi.StringPtrOutput { return v.Value }).(pulumi.StringPtrOutput)
 }
 
 type OrgAccessTokenArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumiservice/teamAccessToken.go
+++ b/sdk/go/pulumiservice/teamAccessToken.go
@@ -23,6 +23,8 @@ type TeamAccessToken struct {
 	OrganizationName pulumi.StringPtrOutput `pulumi:"organizationName"`
 	// The team name.
 	TeamName pulumi.StringPtrOutput `pulumi:"teamName"`
+	// The token's value.
+	Value pulumi.StringPtrOutput `pulumi:"value"`
 }
 
 // NewTeamAccessToken registers a new resource with the given unique name, arguments, and options.
@@ -41,6 +43,10 @@ func NewTeamAccessToken(ctx *pulumi.Context,
 	if args.TeamName == nil {
 		return nil, errors.New("invalid value for required argument 'TeamName'")
 	}
+	secrets := pulumi.AdditionalSecretOutputs([]string{
+		"value",
+	})
+	opts = append(opts, secrets)
 	var resource TeamAccessToken
 	err := ctx.RegisterResource("pulumiservice:index:TeamAccessToken", name, args, &resource, opts...)
 	if err != nil {
@@ -200,6 +206,11 @@ func (o TeamAccessTokenOutput) OrganizationName() pulumi.StringPtrOutput {
 // The team name.
 func (o TeamAccessTokenOutput) TeamName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *TeamAccessToken) pulumi.StringPtrOutput { return v.TeamName }).(pulumi.StringPtrOutput)
+}
+
+// The token's value.
+func (o TeamAccessTokenOutput) Value() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TeamAccessToken) pulumi.StringPtrOutput { return v.Value }).(pulumi.StringPtrOutput)
 }
 
 type TeamAccessTokenArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.pulumiservice.OrgAccessTokenArgs;
 import com.pulumi.pulumiservice.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -61,6 +62,20 @@ public class OrgAccessToken extends com.pulumi.resources.CustomResource {
     public Output<Optional<String>> organizationName() {
         return Codegen.optional(this.organizationName);
     }
+    /**
+     * The token&#39;s value.
+     * 
+     */
+    @Export(name="value", type=String.class, parameters={})
+    private Output</* @Nullable */ String> value;
+
+    /**
+     * @return The token&#39;s value.
+     * 
+     */
+    public Output<Optional<String>> value() {
+        return Codegen.optional(this.value);
+    }
 
     /**
      *
@@ -94,6 +109,9 @@ public class OrgAccessToken extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .additionalSecretOutputs(List.of(
+                "value"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessToken.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.pulumiservice.TeamAccessTokenArgs;
 import com.pulumi.pulumiservice.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -75,6 +76,20 @@ public class TeamAccessToken extends com.pulumi.resources.CustomResource {
     public Output<Optional<String>> teamName() {
         return Codegen.optional(this.teamName);
     }
+    /**
+     * The token&#39;s value.
+     * 
+     */
+    @Export(name="value", type=String.class, parameters={})
+    private Output</* @Nullable */ String> value;
+
+    /**
+     * @return The token&#39;s value.
+     * 
+     */
+    public Output<Optional<String>> value() {
+        return Codegen.optional(this.value);
+    }
 
     /**
      *
@@ -108,6 +123,9 @@ public class TeamAccessToken extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .additionalSecretOutputs(List.of(
+                "value"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/orgAccessToken.ts
+++ b/sdk/nodejs/orgAccessToken.ts
@@ -46,6 +46,10 @@ export class OrgAccessToken extends pulumi.CustomResource {
      * The organization's name.
      */
     public readonly organizationName!: pulumi.Output<string | undefined>;
+    /**
+     * The token's value.
+     */
+    public /*out*/ readonly value!: pulumi.Output<string | undefined>;
 
     /**
      * Create a OrgAccessToken resource with the given unique name, arguments, and options.
@@ -67,12 +71,16 @@ export class OrgAccessToken extends pulumi.CustomResource {
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
+            resourceInputs["value"] = undefined /*out*/;
         } else {
             resourceInputs["description"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
+            resourceInputs["value"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const secretOpts = { additionalSecretOutputs: ["value"] };
+        opts = pulumi.mergeOptions(opts, secretOpts);
         super(OrgAccessToken.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/teamAccessToken.ts
+++ b/sdk/nodejs/teamAccessToken.ts
@@ -50,6 +50,10 @@ export class TeamAccessToken extends pulumi.CustomResource {
      * The team name.
      */
     public readonly teamName!: pulumi.Output<string | undefined>;
+    /**
+     * The token's value.
+     */
+    public /*out*/ readonly value!: pulumi.Output<string | undefined>;
 
     /**
      * Create a TeamAccessToken resource with the given unique name, arguments, and options.
@@ -75,13 +79,17 @@ export class TeamAccessToken extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["teamName"] = args ? args.teamName : undefined;
+            resourceInputs["value"] = undefined /*out*/;
         } else {
             resourceInputs["description"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
             resourceInputs["teamName"] = undefined /*out*/;
+            resourceInputs["value"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const secretOpts = { additionalSecretOutputs: ["value"] };
+        opts = pulumi.mergeOptions(opts, secretOpts);
         super(TeamAccessToken.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_pulumiservice/org_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/org_access_token.py
@@ -126,6 +126,9 @@ class OrgAccessToken(pulumi.CustomResource):
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")
             __props__.__dict__["organization_name"] = organization_name
+            __props__.__dict__["value"] = None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
+        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(OrgAccessToken, __self__).__init__(
             'pulumiservice:index:OrgAccessToken',
             resource_name,
@@ -151,6 +154,7 @@ class OrgAccessToken(pulumi.CustomResource):
         __props__.__dict__["description"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
+        __props__.__dict__["value"] = None
         return OrgAccessToken(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -176,4 +180,12 @@ class OrgAccessToken(pulumi.CustomResource):
         The organization's name.
         """
         return pulumi.get(self, "organization_name")
+
+    @property
+    @pulumi.getter
+    def value(self) -> pulumi.Output[Optional[str]]:
+        """
+        The token's value.
+        """
+        return pulumi.get(self, "value")
 

--- a/sdk/python/pulumi_pulumiservice/team_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/team_access_token.py
@@ -147,6 +147,9 @@ class TeamAccessToken(pulumi.CustomResource):
             if team_name is None and not opts.urn:
                 raise TypeError("Missing required property 'team_name'")
             __props__.__dict__["team_name"] = team_name
+            __props__.__dict__["value"] = None
+        secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
+        opts = pulumi.ResourceOptions.merge(opts, secret_opts)
         super(TeamAccessToken, __self__).__init__(
             'pulumiservice:index:TeamAccessToken',
             resource_name,
@@ -173,6 +176,7 @@ class TeamAccessToken(pulumi.CustomResource):
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
         __props__.__dict__["team_name"] = None
+        __props__.__dict__["value"] = None
         return TeamAccessToken(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -206,4 +210,12 @@ class TeamAccessToken(pulumi.CustomResource):
         The team name.
         """
         return pulumi.get(self, "team_name")
+
+    @property
+    @pulumi.getter
+    def value(self) -> pulumi.Output[Optional[str]]:
+        """
+        The token's value.
+        """
+        return pulumi.get(self, "value")
 


### PR DESCRIPTION
The current implementation of TeamAccessTokens & OrgAccessTokens have no way to access the value through Pulumi, and the output is also not marked as a secret. 

The raw token is stored in the resource output, which it shouldn't be.

This PR adds the following field to both Team/Org access tokens schema:
```
        "value": {
          "description": "The token's value.",
          "type": "string",
          "secret": true
        }
```

This is to mirror the schema for the standard `pulumiservice:index:AccessToken`

The diffs for everything other than `provider/cmd/pulumi-resource-pulumiservice/schema.json` were generated from `make build`

