### PR TITLE
Fix Panic from marshalling `deployPullRequests` instead of `previewPullRequests`

### DIFF
--- a/provider/pkg/provider/deployment_settings.go
+++ b/provider/pkg/provider/deployment_settings.go
@@ -224,7 +224,7 @@ func toGitHubConfig(inputMap resource.PropertyMap) *pulumiapi.GitHubConfiguratio
 		github.DeployCommits = githubInput["deployCommits"].BoolValue()
 	}
 	if githubInput["previewPullRequests"].HasValue() && githubInput["previewPullRequests"].IsBool() {
-		github.PreviewPullRequests = githubInput["deployPullRequests"].BoolValue()
+		github.PreviewPullRequests = githubInput["previewPullRequests"].BoolValue()
 	}
 	if githubInput["paths"].HasValue() && githubInput["paths"].IsArray() {
 		pathsInput := githubInput["paths"].ArrayValue()


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-pulumiservice/issues/124

Should we add an examples test that covers github integration?