### PR TITLE
Support stack webhooks

### DIFF
--- a/examples/ts-webhooks/index.ts
+++ b/examples/ts-webhooks/index.ts
@@ -1,12 +1,25 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as service from "@pulumi/pulumiservice";
 
+const serviceOrg = "service-provider-test-org";
+
 const webhook = new service.Webhook("wh", {
   active: true,
   displayName: "webhook-from-provider",
-  organizationName: "service-provider-test-org",
+  organizationName: serviceOrg,
   payloadUrl: "https://google.com",
 });
 
-export const orgname = webhook.organizationName;
+const stackWebhook = new service.Webhook("stack-webhook", {
+  active: true,
+  displayName: "stack-webhook",
+  organizationName: serviceOrg,
+  projectName: pulumi.getProject(),
+  stackName: pulumi.getStack(),
+  payloadUrl: "https://example.com",
+})
+
+export const orgName = webhook.organizationName;
 export const name = webhook.name;
+export const stackWebhookName = stackWebhook.name;
+export const stackWebhookProjectName = stackWebhook.projectName;

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -519,6 +519,14 @@
         "organizationName": {
           "description": "Name of the organization.",
           "type": "string"
+        },
+        "projectName": {
+            "description": "Name of the project. Only specified if this is a stack webhook.",
+            "type": "string"
+        },
+        "stackName": {
+            "description": "Name of the stack. Only specified if this is a stack webhook.",
+            "type": "string"
         }
       },
       "inputProperties": {
@@ -541,6 +549,14 @@
         },
         "organizationName": {
           "description": "Name of the organization.",
+          "type": "string"
+        },
+        "projectName": {
+          "description": "Name of the project. Only needed if this is a stack webhook.",
+          "type": "string"
+        },
+        "stackName": {
+          "description": "Name of the stack. Only needed if this is a stack webhook.",
           "type": "string"
         }
       },

--- a/provider/pkg/internal/pulumiapi/testutils_test.go
+++ b/provider/pkg/internal/pulumiapi/testutils_test.go
@@ -2,7 +2,7 @@ package pulumiapi
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,7 +38,7 @@ func startTestServer(t *testing.T, config testServerConfig) (client *Client, cle
 		// if we expected a request body, unmarshal the body and
 		if config.ExpectedReqBody != nil {
 			expectedBody, _ := json.Marshal(config.ExpectedReqBody)
-			actualBody, _ := ioutil.ReadAll(r.Body)
+			actualBody, _ := io.ReadAll(r.Body)
 			assert.JSONEq(t, string(expectedBody), string(actualBody))
 		}
 		w.WriteHeader(config.ResponseCode)

--- a/provider/pkg/internal/pulumiapi/webhooks.go
+++ b/provider/pkg/internal/pulumiapi/webhooks.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,62 +29,70 @@ type Webhook struct {
 	Name        string
 }
 
-type createWebhookRequest struct {
-	OrganizationName string `json:"organizationName"`
-	DisplayName      string `json:"displayName"`
-	PayloadURL       string `json:"payloadUrl"`
+type CreateWebhookRequest struct {
+	OrganizationName string  `json:"organizationName"`
+	ProjectName      *string `json:"projectName,omitempty"`
+	StackName        *string `json:"stackName,omitempty"`
+	DisplayName      string  `json:"displayName"`
+	PayloadURL       string  `json:"payloadUrl"`
 	Secret           *string `json:"secret,omitempty"`
-	Active           bool   `json:"active"`
+	Active           bool    `json:"active"`
 }
 
-type updateWebhookRequest struct {
-	Name             string `json:"name"`
-	OrganizationName string `json:"organizationName"`
-	DisplayName      string `json:"displayName"`
-	PayloadURL       string `json:"payloadUrl"`
+type UpdateWebhookRequest struct {
+	Name             string  `json:"name"`
+	OrganizationName string  `json:"organizationName"`
+	ProjectName      *string `json:"projectName,omitempty"`
+	StackName        *string `json:"stackName,omitempty"`
+	DisplayName      string  `json:"displayName"`
+	PayloadURL       string  `json:"payloadUrl"`
 	Secret           *string `json:"secret,omitempty"`
-	Active           bool   `json:"active"`
+	Active           bool    `json:"active"`
 }
 
-func (c *Client) CreateWebhook(ctx context.Context, orgName, displayName, payloadURL string, secret *string, active bool) (*Webhook, error) {
+func (c *Client) CreateWebhook(ctx context.Context, req CreateWebhookRequest) (*Webhook, error) {
+	orgName := req.OrganizationName
+	projectName := req.ProjectName
+	stackName := req.StackName
 
 	if len(orgName) == 0 {
 		return nil, errors.New("orgname must not be empty")
 	}
 
-	if len(displayName) == 0 {
+	if len(req.DisplayName) == 0 {
 		return nil, errors.New("displayname must not be empty")
 	}
 
-	if len(payloadURL) == 0 {
+	if len(req.PayloadURL) == 0 {
 		return nil, errors.New("payloadurl must not be empty")
 	}
 
-	apiPath := path.Join("orgs", orgName, "hooks")
-
-	createWebhookReq := createWebhookRequest{
-		OrganizationName: orgName,
-		DisplayName:      displayName,
-		PayloadURL:       payloadURL,
-		Secret:           secret,
-		Active:           active,
+	var apiPath string
+	if projectName != nil && stackName != nil {
+		apiPath = path.Join("stacks", orgName, *projectName, *stackName, "hooks")
+	} else {
+		apiPath = path.Join("orgs", orgName, "hooks")
 	}
 
 	var webhook Webhook
-	_, err := c.do(ctx, http.MethodPost, apiPath, createWebhookReq, &webhook)
+	_, err := c.do(ctx, http.MethodPost, apiPath, req, &webhook)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create webhook: %w", err)
 	}
 	return &webhook, nil
-
 }
 
-func (c *Client) ListWebhooks(ctx context.Context, orgName string) ([]Webhook, error) {
+func (c *Client) ListWebhooks(ctx context.Context, orgName string, projectName, stackName *string) ([]Webhook, error) {
 	if len(orgName) == 0 {
 		return nil, errors.New("orgName must not be empty")
 	}
 
-	apiPath := path.Join("orgs", orgName, "hooks")
+	var apiPath string
+	if projectName != nil && stackName != nil {
+		path.Join("stacks", orgName, *projectName, *stackName, "hooks")
+	} else {
+		apiPath = path.Join("orgs", orgName, "hooks")
+	}
 
 	var webhooks []Webhook
 	_, err := c.do(ctx, http.MethodGet, apiPath, nil, &webhooks)
@@ -95,7 +103,8 @@ func (c *Client) ListWebhooks(ctx context.Context, orgName string) ([]Webhook, e
 	return webhooks, nil
 }
 
-func (c *Client) GetWebhook(ctx context.Context, orgName, webhookName string) (*Webhook, error) {
+func (c *Client) GetWebhook(ctx context.Context,
+	orgName string, projectName, stackName *string, webhookName string) (*Webhook, error) {
 	if len(orgName) == 0 {
 		return nil, errors.New("orgname must not be empty")
 	}
@@ -104,7 +113,12 @@ func (c *Client) GetWebhook(ctx context.Context, orgName, webhookName string) (*
 		return nil, errors.New("webhookname must not be empty")
 	}
 
-	apiPath := path.Join("orgs", orgName, "hooks", webhookName)
+	var apiPath string
+	if projectName != nil && stackName != nil {
+		apiPath = path.Join("stacks", orgName, *projectName, *stackName, "hooks", webhookName)
+	} else {
+		apiPath = path.Join("orgs", orgName, "hooks", webhookName)
+	}
 
 	var webhook Webhook
 	_, err := c.do(ctx, http.MethodGet, apiPath, nil, &webhook)
@@ -114,39 +128,40 @@ func (c *Client) GetWebhook(ctx context.Context, orgName, webhookName string) (*
 	return &webhook, nil
 }
 
-func (c *Client) UpdateWebhook(ctx context.Context, name, orgName, displayName, payloadUrl string, secret *string, active bool) error {
+func (c *Client) UpdateWebhook(ctx context.Context, req UpdateWebhookRequest) error {
+	orgName := req.OrganizationName
+	projectName := req.ProjectName
+	stackName := req.StackName
+	name := req.Name
+
 	if len(name) == 0 {
 		return errors.New("name must not be empty")
 	}
 	if len(orgName) == 0 {
 		return errors.New("orgname must not be empty")
 	}
-	if len(displayName) == 0 {
+	if len(req.DisplayName) == 0 {
 		return errors.New("displayname must not be empty")
 	}
-	if len(payloadUrl) == 0 {
+	if len(req.PayloadURL) == 0 {
 		return errors.New("payloadurl must not be empty")
 	}
 
-	apiPath := path.Join("orgs", orgName, "hooks", name)
-
-	updateWebhookReq := updateWebhookRequest{
-		OrganizationName: orgName,
-		Name:             name,
-		DisplayName:      displayName,
-		PayloadURL:       payloadUrl,
-		Secret:           secret,
-		Active:           active,
+	var apiPath string
+	if projectName != nil && stackName != nil {
+		apiPath = path.Join("stacks", orgName, *projectName, *stackName, "hooks", name)
+	} else {
+		apiPath = path.Join("orgs", orgName, "hooks", name)
 	}
 
-	_, err := c.do(ctx, http.MethodPatch, apiPath, updateWebhookReq, nil)
+	_, err := c.do(ctx, http.MethodPatch, apiPath, req, nil)
 	if err != nil {
 		return fmt.Errorf("failed to update webhook: %w", err)
 	}
 	return nil
 }
 
-func (c *Client) DeleteWebhook(ctx context.Context, orgName, name string) error {
+func (c *Client) DeleteWebhook(ctx context.Context, orgName string, projectName, stackName *string, name string) error {
 	if len(name) == 0 {
 		return errors.New("name must not be empty")
 	}
@@ -154,7 +169,12 @@ func (c *Client) DeleteWebhook(ctx context.Context, orgName, name string) error 
 		return errors.New("orgname must not be empty")
 	}
 
-	apiPath := path.Join("orgs", orgName, "hooks", name)
+	var apiPath string
+	if projectName != nil && stackName != nil {
+		apiPath = path.Join("stacks", orgName, *projectName, *stackName, "hooks", name)
+	} else {
+		apiPath = path.Join("orgs", orgName, "hooks", name)
+	}
 
 	_, err := c.do(ctx, http.MethodDelete, apiPath, nil, nil)
 	if err != nil {

--- a/provider/pkg/internal/pulumiapi/webhooks_test.go
+++ b/provider/pkg/internal/pulumiapi/webhooks_test.go
@@ -13,30 +13,30 @@ func TestCreateWebhook(t *testing.T) {
 	displayName := "A Webhook"
 	payloadURL := "https://example.com/webhook"
 	secret := "{...}"
-	active := true
 	webhook := Webhook{
 		Name:        webhookName,
 		DisplayName: displayName,
 		PayloadUrl:  payloadURL,
 		Secret:      &secret,
-		Active:      active,
+		Active:      true,
+	}
+	createReq := CreateWebhookRequest{
+		OrganizationName: orgName,
+		DisplayName:      displayName,
+		PayloadURL:       payloadURL,
+		Secret:           &secret,
+		Active:           true,
 	}
 	t.Run("Happy Path", func(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
 			ExpectedReqMethod: http.MethodPost,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks",
-			ExpectedReqBody: createWebhookRequest{
-				OrganizationName: orgName,
-				DisplayName:      displayName,
-				PayloadURL:       payloadURL,
-				Secret:           &secret,
-				Active:           active,
-			},
-			ResponseCode: 201,
-			ResponseBody: webhook,
+			ExpectedReqBody:   createReq,
+			ResponseCode:      201,
+			ResponseBody:      webhook,
 		})
 		defer cleanup()
-		actualWebhook, err := c.CreateWebhook(ctx, orgName, displayName, payloadURL, &secret, active)
+		actualWebhook, err := c.CreateWebhook(ctx, createReq)
 		assert.NoError(t, err)
 		assert.Equal(t, webhook, *actualWebhook)
 	})
@@ -45,20 +45,14 @@ func TestCreateWebhook(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
 			ExpectedReqMethod: http.MethodPost,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks",
-			ExpectedReqBody: createWebhookRequest{
-				OrganizationName: orgName,
-				DisplayName:      displayName,
-				PayloadURL:       payloadURL,
-				Secret:           &secret,
-				Active:           active,
-			},
-			ResponseCode: 401,
+			ExpectedReqBody:   createReq,
+			ResponseCode:      401,
 			ResponseBody: errorResponse{
 				Message: "unauthorized",
 			},
 		})
 		defer cleanup()
-		actualWebhook, err := c.CreateWebhook(ctx, orgName, displayName, payloadURL, &secret, active)
+		actualWebhook, err := c.CreateWebhook(ctx, createReq)
 		assert.Nil(t, actualWebhook, "webhook should be nil since error was returned")
 		assert.EqualError(t, err, "failed to create webhook: 401 API error: unauthorized")
 	})
@@ -70,13 +64,12 @@ func TestListWebhooks(t *testing.T) {
 	displayName := "A Webhook"
 	payloadURL := "https://example.com/webhook"
 	secret := "{...}"
-	active := true
 	webhook := Webhook{
 		Name:        webhookName,
 		DisplayName: displayName,
 		PayloadUrl:  payloadURL,
 		Secret:      &secret,
-		Active:      active,
+		Active:      true,
 	}
 	webhooks := []Webhook{webhook}
 	t.Run("Happy Path", func(t *testing.T) {
@@ -87,7 +80,7 @@ func TestListWebhooks(t *testing.T) {
 			ResponseBody:      webhooks,
 		})
 		defer cleanup()
-		actualWebhooks, err := c.ListWebhooks(ctx, orgName)
+		actualWebhooks, err := c.ListWebhooks(ctx, orgName, nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, webhooks, actualWebhooks)
 	})
@@ -102,7 +95,7 @@ func TestListWebhooks(t *testing.T) {
 			},
 		})
 		defer cleanup()
-		actualWebhooks, err := c.ListWebhooks(ctx, orgName)
+		actualWebhooks, err := c.ListWebhooks(ctx, orgName, nil, nil)
 		assert.Nil(t, actualWebhooks, "webhooks should be nil since error was returned")
 		assert.EqualError(t, err, "failed to list webhooks: 401 API error: unauthorized")
 	})
@@ -114,13 +107,12 @@ func TestGetWebhook(t *testing.T) {
 	displayName := "A Webhook"
 	payloadURL := "https://example.com/webhook"
 	secret := "{...}"
-	active := true
 	webhook := Webhook{
 		Name:        webhookName,
 		DisplayName: displayName,
 		PayloadUrl:  payloadURL,
 		Secret:      &secret,
-		Active:      active,
+		Active:      true,
 	}
 	t.Run("Happy Path", func(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
@@ -130,7 +122,7 @@ func TestGetWebhook(t *testing.T) {
 			ResponseBody:      webhook,
 		})
 		defer cleanup()
-		actualWebhook, err := c.GetWebhook(ctx, orgName, webhookName)
+		actualWebhook, err := c.GetWebhook(ctx, orgName, nil, nil, webhookName)
 		assert.NoError(t, err)
 		assert.Equal(t, webhook, *actualWebhook)
 	})
@@ -145,7 +137,7 @@ func TestGetWebhook(t *testing.T) {
 			},
 		})
 		defer cleanup()
-		actualWebhook, err := c.GetWebhook(ctx, orgName, webhookName)
+		actualWebhook, err := c.GetWebhook(ctx, orgName, nil, nil, webhookName)
 		assert.Nil(t, actualWebhook, "webhooks should be nil since error was returned")
 		assert.EqualError(t, err, "failed to get webhook: 401 API error: unauthorized")
 	})
@@ -157,31 +149,31 @@ func TestUpdateWebhook(t *testing.T) {
 	displayName := "A Webhook"
 	payloadURL := "https://example.com/webhook"
 	secret := "{...}"
-	active := true
 	webhook := Webhook{
 		Name:        webhookName,
 		DisplayName: displayName,
 		PayloadUrl:  payloadURL,
 		Secret:      &secret,
-		Active:      active,
+		Active:      true,
+	}
+	updateReq := UpdateWebhookRequest{
+		Name:             webhookName,
+		OrganizationName: orgName,
+		DisplayName:      displayName,
+		PayloadURL:       payloadURL,
+		Secret:           &secret,
+		Active:           true,
 	}
 	t.Run("Happy Path", func(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
 			ExpectedReqMethod: http.MethodPatch,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
-			ExpectedReqBody: updateWebhookRequest{
-				Name:             webhookName,
-				OrganizationName: orgName,
-				DisplayName:      displayName,
-				PayloadURL:       payloadURL,
-				Secret:           &secret,
-				Active:           active,
-			},
-			ResponseCode: 201,
-			ResponseBody: webhook,
+			ExpectedReqBody:   updateReq,
+			ResponseCode:      201,
+			ResponseBody:      webhook,
 		})
 		defer cleanup()
-		err := c.UpdateWebhook(ctx, webhookName, orgName, displayName, payloadURL, &secret, active)
+		err := c.UpdateWebhook(ctx, updateReq)
 		assert.NoError(t, err)
 	})
 
@@ -189,21 +181,14 @@ func TestUpdateWebhook(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
 			ExpectedReqMethod: http.MethodPatch,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
-			ExpectedReqBody: updateWebhookRequest{
-				Name:             webhookName,
-				OrganizationName: orgName,
-				DisplayName:      displayName,
-				PayloadURL:       payloadURL,
-				Secret:           &secret,
-				Active:           active,
-			},
-			ResponseCode: 401,
+			ExpectedReqBody:   updateReq,
+			ResponseCode:      401,
 			ResponseBody: errorResponse{
 				Message: "unauthorized",
 			},
 		})
 		defer cleanup()
-		err := c.UpdateWebhook(ctx, webhookName, orgName, displayName, payloadURL, &secret, active)
+		err := c.UpdateWebhook(ctx, updateReq)
 		assert.EqualError(t, err, "failed to update webhook: 401 API error: unauthorized")
 	})
 }
@@ -218,7 +203,7 @@ func TestDeleteWebhook(t *testing.T) {
 			ResponseCode:      201,
 		})
 		defer cleanup()
-		err := c.DeleteWebhook(ctx, orgName, webhookName)
+		err := c.DeleteWebhook(ctx, orgName, nil, nil, webhookName)
 		assert.NoError(t, err)
 	})
 
@@ -232,7 +217,7 @@ func TestDeleteWebhook(t *testing.T) {
 			},
 		})
 		defer cleanup()
-		err := c.DeleteWebhook(ctx, orgName, webhookName)
+		err := c.DeleteWebhook(ctx, orgName, nil, nil, webhookName)
 		assert.EqualError(t, err, "failed to delete webhook: 401 API error: unauthorized")
 	})
 }

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/internal/pulumiapi"
@@ -307,4 +308,13 @@ func partialError(id string, err error, state PulumiServiceTeamInput, inputs Pul
 		Inputs:     inputRpc,
 	}
 	return rpcerror.WithDetails(rpcerror.New(codes.Unknown, err.Error()), &detail)
+}
+
+func splitSingleSlashString(id string) (string, string, error) {
+	// format: organization/webhookName
+	s := strings.Split(id, "/")
+	if len(s) != 2 {
+		return "", "", fmt.Errorf("%q is invalid, must contain a single slash ('/')", id)
+	}
+	return s[0], s[1], nil
 }

--- a/provider/pkg/provider/webhook.go
+++ b/provider/pkg/provider/webhook.go
@@ -114,7 +114,7 @@ func (wh *PulumiServiceWebhookResource) Check(req *pulumirpc.CheckRequest) (*pul
 		}
 	}
 
-	stackWebhookError := "both projectName and stackName must both be specified for stack webhooks, or both unspecified for org webhooks"
+	stackWebhookError := "projectName and stackName must both be specified for stack webhooks, or both unspecified for org webhooks"
 	if !news["projectName"].HasValue() && news["stackName"].HasValue() {
 		failures = append(failures, &pulumirpc.CheckFailure{
 			Reason:   stackWebhookError,

--- a/sdk/dotnet/Webhook.cs
+++ b/sdk/dotnet/Webhook.cs
@@ -46,10 +46,22 @@ namespace Pulumi.PulumiService
         public Output<string?> PayloadUrl { get; private set; } = null!;
 
         /// <summary>
+        /// Name of the project. Only specified if this is a stack webhook.
+        /// </summary>
+        [Output("projectName")]
+        public Output<string?> ProjectName { get; private set; } = null!;
+
+        /// <summary>
         /// Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
         /// </summary>
         [Output("secret")]
         public Output<string?> Secret { get; private set; } = null!;
+
+        /// <summary>
+        /// Name of the stack. Only specified if this is a stack webhook.
+        /// </summary>
+        [Output("stackName")]
+        public Output<string?> StackName { get; private set; } = null!;
 
 
         /// <summary>
@@ -124,6 +136,12 @@ namespace Pulumi.PulumiService
         [Input("payloadUrl", required: true)]
         public Input<string> PayloadUrl { get; set; } = null!;
 
+        /// <summary>
+        /// Name of the project. Only needed if this is a stack webhook.
+        /// </summary>
+        [Input("projectName")]
+        public Input<string>? ProjectName { get; set; }
+
         [Input("secret")]
         private Input<string>? _secret;
 
@@ -139,6 +157,12 @@ namespace Pulumi.PulumiService
                 _secret = Output.Tuple<Input<string>?, int>(value, emptySecret).Apply(t => t.Item1);
             }
         }
+
+        /// <summary>
+        /// Name of the stack. Only needed if this is a stack webhook.
+        /// </summary>
+        [Input("stackName")]
+        public Input<string>? StackName { get; set; }
 
         public WebhookArgs()
         {

--- a/sdk/go/pulumiservice/webhook.go
+++ b/sdk/go/pulumiservice/webhook.go
@@ -25,8 +25,12 @@ type Webhook struct {
 	OrganizationName pulumi.StringPtrOutput `pulumi:"organizationName"`
 	// URL to send request to.
 	PayloadUrl pulumi.StringPtrOutput `pulumi:"payloadUrl"`
+	// Name of the project. Only specified if this is a stack webhook.
+	ProjectName pulumi.StringPtrOutput `pulumi:"projectName"`
 	// Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
 	Secret pulumi.StringPtrOutput `pulumi:"secret"`
+	// Name of the stack. Only specified if this is a stack webhook.
+	StackName pulumi.StringPtrOutput `pulumi:"stackName"`
 }
 
 // NewWebhook registers a new resource with the given unique name, arguments, and options.
@@ -95,8 +99,12 @@ type webhookArgs struct {
 	OrganizationName string `pulumi:"organizationName"`
 	// URL to send request to.
 	PayloadUrl string `pulumi:"payloadUrl"`
+	// Name of the project. Only needed if this is a stack webhook.
+	ProjectName *string `pulumi:"projectName"`
 	// Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
 	Secret *string `pulumi:"secret"`
+	// Name of the stack. Only needed if this is a stack webhook.
+	StackName *string `pulumi:"stackName"`
 }
 
 // The set of arguments for constructing a Webhook resource.
@@ -109,8 +117,12 @@ type WebhookArgs struct {
 	OrganizationName pulumi.StringInput
 	// URL to send request to.
 	PayloadUrl pulumi.StringInput
+	// Name of the project. Only needed if this is a stack webhook.
+	ProjectName pulumi.StringPtrInput
 	// Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
 	Secret pulumi.StringPtrInput
+	// Name of the stack. Only needed if this is a stack webhook.
+	StackName pulumi.StringPtrInput
 }
 
 func (WebhookArgs) ElementType() reflect.Type {
@@ -225,9 +237,19 @@ func (o WebhookOutput) PayloadUrl() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Webhook) pulumi.StringPtrOutput { return v.PayloadUrl }).(pulumi.StringPtrOutput)
 }
 
+// Name of the project. Only specified if this is a stack webhook.
+func (o WebhookOutput) ProjectName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Webhook) pulumi.StringPtrOutput { return v.ProjectName }).(pulumi.StringPtrOutput)
+}
+
 // Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
 func (o WebhookOutput) Secret() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Webhook) pulumi.StringPtrOutput { return v.Secret }).(pulumi.StringPtrOutput)
+}
+
+// Name of the stack. Only specified if this is a stack webhook.
+func (o WebhookOutput) StackName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *Webhook) pulumi.StringPtrOutput { return v.StackName }).(pulumi.StringPtrOutput)
 }
 
 type WebhookArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Webhook.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Webhook.java
@@ -92,6 +92,20 @@ public class Webhook extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.payloadUrl);
     }
     /**
+     * Name of the project. Only specified if this is a stack webhook.
+     * 
+     */
+    @Export(name="projectName", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> projectName;
+
+    /**
+     * @return Name of the project. Only specified if this is a stack webhook.
+     * 
+     */
+    public Output<Optional<String>> projectName() {
+        return Codegen.optional(this.projectName);
+    }
+    /**
      * Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
      * 
      */
@@ -104,6 +118,20 @@ public class Webhook extends com.pulumi.resources.CustomResource {
      */
     public Output<Optional<String>> secret() {
         return Codegen.optional(this.secret);
+    }
+    /**
+     * Name of the stack. Only specified if this is a stack webhook.
+     * 
+     */
+    @Export(name="stackName", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> stackName;
+
+    /**
+     * @return Name of the stack. Only specified if this is a stack webhook.
+     * 
+     */
+    public Output<Optional<String>> stackName() {
+        return Codegen.optional(this.stackName);
     }
 
     /**

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/WebhookArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/WebhookArgs.java
@@ -77,6 +77,21 @@ public final class WebhookArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * Name of the project. Only needed if this is a stack webhook.
+     * 
+     */
+    @Import(name="projectName")
+    private @Nullable Output<String> projectName;
+
+    /**
+     * @return Name of the project. Only needed if this is a stack webhook.
+     * 
+     */
+    public Optional<Output<String>> projectName() {
+        return Optional.ofNullable(this.projectName);
+    }
+
+    /**
      * Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
      * 
      */
@@ -91,6 +106,21 @@ public final class WebhookArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.secret);
     }
 
+    /**
+     * Name of the stack. Only needed if this is a stack webhook.
+     * 
+     */
+    @Import(name="stackName")
+    private @Nullable Output<String> stackName;
+
+    /**
+     * @return Name of the stack. Only needed if this is a stack webhook.
+     * 
+     */
+    public Optional<Output<String>> stackName() {
+        return Optional.ofNullable(this.stackName);
+    }
+
     private WebhookArgs() {}
 
     private WebhookArgs(WebhookArgs $) {
@@ -98,7 +128,9 @@ public final class WebhookArgs extends com.pulumi.resources.ResourceArgs {
         this.displayName = $.displayName;
         this.organizationName = $.organizationName;
         this.payloadUrl = $.payloadUrl;
+        this.projectName = $.projectName;
         this.secret = $.secret;
+        this.stackName = $.stackName;
     }
 
     public static Builder builder() {
@@ -204,6 +236,27 @@ public final class WebhookArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param projectName Name of the project. Only needed if this is a stack webhook.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder projectName(@Nullable Output<String> projectName) {
+            $.projectName = projectName;
+            return this;
+        }
+
+        /**
+         * @param projectName Name of the project. Only needed if this is a stack webhook.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder projectName(String projectName) {
+            return projectName(Output.of(projectName));
+        }
+
+        /**
          * @param secret Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
          * 
          * @return builder
@@ -222,6 +275,27 @@ public final class WebhookArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder secret(String secret) {
             return secret(Output.of(secret));
+        }
+
+        /**
+         * @param stackName Name of the stack. Only needed if this is a stack webhook.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder stackName(@Nullable Output<String> stackName) {
+            $.stackName = stackName;
+            return this;
+        }
+
+        /**
+         * @param stackName Name of the stack. Only needed if this is a stack webhook.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder stackName(String stackName) {
+            return stackName(Output.of(stackName));
         }
 
         public WebhookArgs build() {

--- a/sdk/nodejs/webhook.ts
+++ b/sdk/nodejs/webhook.ts
@@ -55,9 +55,17 @@ export class Webhook extends pulumi.CustomResource {
      */
     public readonly payloadUrl!: pulumi.Output<string | undefined>;
     /**
+     * Name of the project. Only specified if this is a stack webhook.
+     */
+    public readonly projectName!: pulumi.Output<string | undefined>;
+    /**
      * Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
      */
     public readonly secret!: pulumi.Output<string | undefined>;
+    /**
+     * Name of the stack. Only specified if this is a stack webhook.
+     */
+    public readonly stackName!: pulumi.Output<string | undefined>;
 
     /**
      * Create a Webhook resource with the given unique name, arguments, and options.
@@ -86,7 +94,9 @@ export class Webhook extends pulumi.CustomResource {
             resourceInputs["displayName"] = args ? args.displayName : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["payloadUrl"] = args ? args.payloadUrl : undefined;
+            resourceInputs["projectName"] = args ? args.projectName : undefined;
             resourceInputs["secret"] = args?.secret ? pulumi.secret(args.secret) : undefined;
+            resourceInputs["stackName"] = args ? args.stackName : undefined;
             resourceInputs["name"] = undefined /*out*/;
         } else {
             resourceInputs["active"] = undefined /*out*/;
@@ -94,7 +104,9 @@ export class Webhook extends pulumi.CustomResource {
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
             resourceInputs["payloadUrl"] = undefined /*out*/;
+            resourceInputs["projectName"] = undefined /*out*/;
             resourceInputs["secret"] = undefined /*out*/;
+            resourceInputs["stackName"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["secret"] };
@@ -124,7 +136,15 @@ export interface WebhookArgs {
      */
     payloadUrl: pulumi.Input<string>;
     /**
+     * Name of the project. Only needed if this is a stack webhook.
+     */
+    projectName?: pulumi.Input<string>;
+    /**
      * Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
      */
     secret?: pulumi.Input<string>;
+    /**
+     * Name of the stack. Only needed if this is a stack webhook.
+     */
+    stackName?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_pulumiservice/webhook.py
+++ b/sdk/python/pulumi_pulumiservice/webhook.py
@@ -18,21 +18,29 @@ class WebhookArgs:
                  display_name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
                  payload_url: pulumi.Input[str],
-                 secret: Optional[pulumi.Input[str]] = None):
+                 project_name: Optional[pulumi.Input[str]] = None,
+                 secret: Optional[pulumi.Input[str]] = None,
+                 stack_name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Webhook resource.
         :param pulumi.Input[bool] active: Indicates whether this webhook is enabled or not.
         :param pulumi.Input[str] display_name: The friendly name displayed in the Pulumi Service.
         :param pulumi.Input[str] organization_name: Name of the organization.
         :param pulumi.Input[str] payload_url: URL to send request to.
+        :param pulumi.Input[str] project_name: Name of the project. Only needed if this is a stack webhook.
         :param pulumi.Input[str] secret: Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
+        :param pulumi.Input[str] stack_name: Name of the stack. Only needed if this is a stack webhook.
         """
         pulumi.set(__self__, "active", active)
         pulumi.set(__self__, "display_name", display_name)
         pulumi.set(__self__, "organization_name", organization_name)
         pulumi.set(__self__, "payload_url", payload_url)
+        if project_name is not None:
+            pulumi.set(__self__, "project_name", project_name)
         if secret is not None:
             pulumi.set(__self__, "secret", secret)
+        if stack_name is not None:
+            pulumi.set(__self__, "stack_name", stack_name)
 
     @property
     @pulumi.getter
@@ -83,6 +91,18 @@ class WebhookArgs:
         pulumi.set(self, "payload_url", value)
 
     @property
+    @pulumi.getter(name="projectName")
+    def project_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the project. Only needed if this is a stack webhook.
+        """
+        return pulumi.get(self, "project_name")
+
+    @project_name.setter
+    def project_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "project_name", value)
+
+    @property
     @pulumi.getter
     def secret(self) -> Optional[pulumi.Input[str]]:
         """
@@ -94,6 +114,18 @@ class WebhookArgs:
     def secret(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "secret", value)
 
+    @property
+    @pulumi.getter(name="stackName")
+    def stack_name(self) -> Optional[pulumi.Input[str]]:
+        """
+        Name of the stack. Only needed if this is a stack webhook.
+        """
+        return pulumi.get(self, "stack_name")
+
+    @stack_name.setter
+    def stack_name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "stack_name", value)
+
 
 class Webhook(pulumi.CustomResource):
     @overload
@@ -104,7 +136,9 @@ class Webhook(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  payload_url: Optional[pulumi.Input[str]] = None,
+                 project_name: Optional[pulumi.Input[str]] = None,
                  secret: Optional[pulumi.Input[str]] = None,
+                 stack_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Pulumi Webhooks allow you to notify external services of events happening within your Pulumi organization or stack. For example, you can trigger a notification whenever a stack is updated. Whenever an event occurs, Pulumi will send an HTTP POST request to all registered webhooks. The webhook can then be used to emit some notification, start running integration tests, or even update additional stacks.
@@ -115,7 +149,9 @@ class Webhook(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: The friendly name displayed in the Pulumi Service.
         :param pulumi.Input[str] organization_name: Name of the organization.
         :param pulumi.Input[str] payload_url: URL to send request to.
+        :param pulumi.Input[str] project_name: Name of the project. Only needed if this is a stack webhook.
         :param pulumi.Input[str] secret: Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
+        :param pulumi.Input[str] stack_name: Name of the stack. Only needed if this is a stack webhook.
         """
         ...
     @overload
@@ -145,7 +181,9 @@ class Webhook(pulumi.CustomResource):
                  display_name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  payload_url: Optional[pulumi.Input[str]] = None,
+                 project_name: Optional[pulumi.Input[str]] = None,
                  secret: Optional[pulumi.Input[str]] = None,
+                 stack_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -167,7 +205,9 @@ class Webhook(pulumi.CustomResource):
             if payload_url is None and not opts.urn:
                 raise TypeError("Missing required property 'payload_url'")
             __props__.__dict__["payload_url"] = payload_url
+            __props__.__dict__["project_name"] = project_name
             __props__.__dict__["secret"] = None if secret is None else pulumi.Output.secret(secret)
+            __props__.__dict__["stack_name"] = stack_name
             __props__.__dict__["name"] = None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["secret"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
@@ -198,7 +238,9 @@ class Webhook(pulumi.CustomResource):
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
         __props__.__dict__["payload_url"] = None
+        __props__.__dict__["project_name"] = None
         __props__.__dict__["secret"] = None
+        __props__.__dict__["stack_name"] = None
         return Webhook(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -242,10 +284,26 @@ class Webhook(pulumi.CustomResource):
         return pulumi.get(self, "payload_url")
 
     @property
+    @pulumi.getter(name="projectName")
+    def project_name(self) -> pulumi.Output[Optional[str]]:
+        """
+        Name of the project. Only specified if this is a stack webhook.
+        """
+        return pulumi.get(self, "project_name")
+
+    @property
     @pulumi.getter
     def secret(self) -> pulumi.Output[Optional[str]]:
         """
         Optional. secret used as the HMAC key. See [webhook docs](https://www.pulumi.com/docs/intro/pulumi-service/webhooks/#headers) for more information.
         """
         return pulumi.get(self, "secret")
+
+    @property
+    @pulumi.getter(name="stackName")
+    def stack_name(self) -> pulumi.Output[Optional[str]]:
+        """
+        Name of the stack. Only specified if this is a stack webhook.
+        """
+        return pulumi.get(self, "stack_name")
 


### PR DESCRIPTION
Previously, our support for webhooks in the service provider only covered organization webhooks. This change adds support for stack webhooks as well. 

Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/136