### PR TITLE
Fix CI/CD collision with pulumi-command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,6 +188,12 @@ jobs:
         role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
     - name: Set PreRelease Version
       run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+    - name: Check PreRelease Version and Exit if not Alpha, Beta, or RC
+      run: |
+        if [[ ! "${GORELEASER_CURRENT_TAG}" =~ -(alpha|beta|rc) ]]; then
+          echo "Error: GORELEASER_CURRENT_TAG does not contain -alpha, -beta, or -rc"
+          exit 1
+        fi
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -12,7 +12,7 @@ blobs:
     provider: s3
     region: us-west-2
 builds:
-  - binary: pulumi-resource-command
+  - binary: pulumi-resource-pulumiservice
     dir: provider
     env:
       - CGO_ENABLED=0


### PR DESCRIPTION
When an already tagged commit is pushed to main, the `main.yml` workflow would run and `pulumictl get version` would return that tag, e.g.: 0.7.2. The goreleaser config would then publish artifacts as `pulumi-command`, resulting in pulumi/pulumi-command#200.

See logs here: https://github.com/pulumi/pulumi-pulumiservice/actions/runs/5082592752/jobs/9132840753#step:9:79

We change two things in this commmit to mitigate conflicts:

1. We change the `main.yml` workflow to exit when the version does not contain a prerelease semver tag of `-alpha`, `-beta`, or `-rc`, addressing a process issue that could result in future conflicts where the release & main workflow attempt to push to the same version.
2. We fix goreleaser prerelease config to publish artifacts as `pulumi-pulumiservice`.