### PR TITLE
Expose GitHub team ID

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -475,6 +475,10 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "githubTeamID": {
+            "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "type": "number"
         }
       },
       "inputProperties": {

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -477,7 +477,7 @@
           "type": "string"
         },
         "githubTeamId": {
-            "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.",
             "type": "number"
         }
       },
@@ -510,7 +510,7 @@
           "type": "string"
         },
         "githubTeamId": {
-            "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.",
             "type": "number"
         }
       },

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -487,7 +487,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The team name. Required for \"pulumi\" teams.",
+          "description": "The team name.",
           "type": "string"
         },
         "displayName": {
@@ -514,7 +514,7 @@
             "type": "number"
         }
       },
-      "requiredInputs": ["organizationName", "teamType"]
+      "requiredInputs": ["name", "organizationName", "teamType"]
     },
     "pulumiservice:index:TeamAccessToken": {
       "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -476,7 +476,7 @@
           "description": "The name of the Pulumi organization the team belongs to.",
           "type": "string"
         },
-        "githubTeamID": {
+        "githubTeamId": {
             "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
             "type": "number"
         }
@@ -509,7 +509,7 @@
           "description": "The name of the Pulumi organization the team belongs to.",
           "type": "string"
         },
-        "githubTeamID": {
+        "githubTeamId": {
             "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
             "type": "number"
         }

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -473,7 +473,7 @@
           }
         },
         "organizationName": {
-          "description": "The organization's name.",
+          "description": "The name of the Pulumi organization the team belongs to.",
           "type": "string"
         },
         "githubTeamID": {
@@ -487,7 +487,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The team name.",
+          "description": "The team name. Required for \"pulumi\" teams.",
           "type": "string"
         },
         "displayName": {
@@ -506,11 +506,15 @@
           }
         },
         "organizationName": {
-          "description": "The organization's name.",
+          "description": "The name of the Pulumi organization the team belongs to.",
           "type": "string"
+        },
+        "githubTeamID": {
+            "description": "The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "type": "number"
         }
       },
-      "requiredInputs": ["name", "organizationName", "teamType"]
+      "requiredInputs": ["organizationName", "teamType"]
     },
     "pulumiservice:index:TeamAccessToken": {
       "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -454,7 +454,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The team name.",
+          "description": "The team's name. Required for \"pulumi\" teams.",
           "type": "string"
         },
         "displayName": {
@@ -487,7 +487,7 @@
           "type": "string"
         },
         "name": {
-          "description": "The team name.",
+          "description": "The team's name. Required for \"pulumi\" teams.",
           "type": "string"
         },
         "displayName": {
@@ -514,7 +514,7 @@
             "type": "number"
         }
       },
-      "requiredInputs": ["name", "organizationName", "teamType"]
+      "requiredInputs": ["organizationName", "teamType"]
     },
     "pulumiservice:index:TeamAccessToken": {
       "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -477,7 +477,7 @@
           "type": "string"
         },
         "githubTeamId": {
-            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for \"github\" teams.",
             "type": "number"
         }
       },
@@ -510,7 +510,7 @@
           "type": "string"
         },
         "githubTeamId": {
-            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.",
+            "description": "The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for \"github\" teams.",
             "type": "number"
         }
       },

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,6 +46,7 @@ type createTeamRequest struct {
 	Name         string `json:"name"`
 	DisplayName  string `json:"displayName"`
 	Description  string `json:"description"`
+	GitHubTeamID int64 `json:"githubTeamID,omitempty"`
 }
 
 type updateTeamRequest struct {
@@ -86,7 +87,6 @@ func (c *Client) ListTeams(ctx context.Context, orgName string) ([]Team, error) 
 
 	var teamArray Teams
 	_, err := c.do(ctx, http.MethodGet, apiUrl, nil, &teamArray)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to list teams for %q: %w", orgName, err)
 	}
@@ -113,12 +113,12 @@ func (c *Client) GetTeam(ctx context.Context, orgName string, teamName string) (
 	return &team, nil
 }
 
-func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, displayName, description string) (*Team, error) {
+func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, displayName, description string, teamID int64) (*Team, error) {
 	if len(orgName) == 0 {
 		return nil, errors.New("orgname must not be empty")
 	}
 
-	if len(teamName) == 0 {
+	if len(teamName) == 0 && teamType != "github" {
 		return nil, errors.New("teamname must not be empty")
 	}
 
@@ -139,11 +139,11 @@ func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, di
 		Name:         teamName,
 		DisplayName:  displayName,
 		Description:  description,
+		GitHubTeamID: teamID,
 	}
 
 	var team Team
 	_, err := c.do(ctx, http.MethodPost, apiPath, createReq, &team)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to create team: %w", err)
 	}
@@ -168,7 +168,6 @@ func (c *Client) UpdateTeam(ctx context.Context, orgName, teamName, displayName,
 	}
 
 	_, err := c.do(ctx, "PATCH", apiPath, updateReq, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to update team: %w", err)
 	}
@@ -176,7 +175,6 @@ func (c *Client) UpdateTeam(ctx context.Context, orgName, teamName, displayName,
 }
 
 func (c *Client) DeleteTeam(ctx context.Context, orgName, teamName string) error {
-
 	if len(orgName) == 0 {
 		return errors.New("orgname must not be empty")
 	}
@@ -220,7 +218,6 @@ func (c *Client) updateTeamMembership(ctx context.Context, orgName, teamName, us
 	}
 
 	_, err := c.do(ctx, http.MethodPatch, apiPath, updateMembershipReq, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to update team membership: %w", err)
 	}
@@ -266,7 +263,6 @@ func (c *Client) AddStackPermission(ctx context.Context, stack StackName, teamNa
 	}
 
 	_, err := c.do(ctx, http.MethodPatch, apiPath, addStackPermissionRequest, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to add stack permission for team: %w", err)
 	}
@@ -289,7 +285,6 @@ func (c *Client) RemoveStackPermission(ctx context.Context, stack StackName, tea
 	}
 
 	_, err := c.do(ctx, http.MethodPatch, apiPath, removeStackPermissionRequest, nil)
-
 	if err != nil {
 		return fmt.Errorf("failed to remove stack permission for team: %w", err)
 	}

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -46,7 +46,7 @@ type createTeamRequest struct {
 	Name         string `json:"name"`
 	DisplayName  string `json:"displayName"`
 	Description  string `json:"description"`
-	GitHubTeamID int64  `json:"githubTeamID,omitempty"`
+	GitHubTeamID int64  `json:"githubTeamId,omitempty"`
 }
 
 type updateTeamRequest struct {
@@ -128,7 +128,7 @@ func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, di
 	}
 
 	if teamType == "github" && teamID == 0 {
-		return nil, errors.New("github teams require a githubTeamID")
+		return nil, errors.New("github teams require a githubTeamId")
 	}
 
 	apiPath := path.Join("orgs", orgName, "teams", teamType)

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -46,7 +46,7 @@ type createTeamRequest struct {
 	Name         string `json:"name"`
 	DisplayName  string `json:"displayName"`
 	Description  string `json:"description"`
-	GitHubTeamID int64 `json:"githubTeamID,omitempty"`
+	GitHubTeamID int64  `json:"githubTeamID,omitempty"`
 }
 
 type updateTeamRequest struct {
@@ -114,6 +114,11 @@ func (c *Client) GetTeam(ctx context.Context, orgName string, teamName string) (
 }
 
 func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, displayName, description string, teamID int64) (*Team, error) {
+	teamtypeList := []string{"github", "pulumi"}
+	if !contains(teamtypeList, teamType) {
+		return nil, fmt.Errorf("teamtype must be one of %v, got %q", teamtypeList, teamType)
+	}
+
 	if len(orgName) == 0 {
 		return nil, errors.New("orgname must not be empty")
 	}
@@ -122,13 +127,8 @@ func (c *Client) CreateTeam(ctx context.Context, orgName, teamName, teamType, di
 		return nil, errors.New("teamname must not be empty")
 	}
 
-	if len(teamType) == 0 {
-		return nil, errors.New("teamtype must not be empty")
-	}
-
-	teamtypeList := []string{"github", "pulumi"}
-	if !contains(teamtypeList, teamType) {
-		return nil, fmt.Errorf("teamtype must be one of %v, got %q", teamtypeList, teamType)
+	if teamType == "github" && teamID == 0 {
+		return nil, errors.New("github teams require a githubTeamID")
 	}
 
 	apiPath := path.Join("orgs", orgName, "teams", teamType)

--- a/provider/pkg/internal/pulumiapi/teams.go
+++ b/provider/pkg/internal/pulumiapi/teams.go
@@ -46,7 +46,7 @@ type createTeamRequest struct {
 	Name         string `json:"name"`
 	DisplayName  string `json:"displayName"`
 	Description  string `json:"description"`
-	GitHubTeamID int64  `json:"githubTeamId,omitempty"`
+	GitHubTeamID int64  `json:"githubTeamID,omitempty"`
 }
 
 type updateTeamRequest struct {

--- a/provider/pkg/internal/pulumiapi/teams_test.go
+++ b/provider/pkg/internal/pulumiapi/teams_test.go
@@ -122,7 +122,7 @@ func TestCreateTeam(t *testing.T) {
 			ResponseCode: 201,
 		})
 		defer cleanup()
-		actualTeam, err := c.CreateTeam(ctx, orgName, teamName, teamType, displayName, description)
+		actualTeam, err := c.CreateTeam(ctx, orgName, teamName, teamType, displayName, description, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, team, *actualTeam)
 	})
@@ -143,7 +143,7 @@ func TestCreateTeam(t *testing.T) {
 			},
 		})
 		defer cleanup()
-		team, err := c.CreateTeam(ctx, orgName, teamName, teamType, displayName, description)
+		team, err := c.CreateTeam(ctx, orgName, teamName, teamType, displayName, description, 0)
 		assert.Nil(t, team, "team should be nil since error was returned")
 		assert.EqualError(t, err, "failed to create team: 401 API error: unauthorized")
 	})

--- a/provider/pkg/internal/pulumiapi/teams_test.go
+++ b/provider/pkg/internal/pulumiapi/teams_test.go
@@ -173,7 +173,7 @@ func TestCreateTeam(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{})
 		defer cleanup()
 		_, err := c.CreateTeam(ctx, orgName, "", "github", "", "", 0)
-		assert.EqualError(t, err, "github teams require a githubTeamID")
+		assert.EqualError(t, err, "github teams require a githubTeamId")
 	})
 	t.Run("Error (invalid team type)", func(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{})

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -35,6 +35,7 @@ type PulumiServiceTeamInput struct {
 	Description      string
 	OrganizationName string
 	Members          []string
+	GitHubTeamID     int64
 }
 
 func (i *PulumiServiceTeamInput) ToPropertyMap() resource.PropertyMap {
@@ -45,6 +46,7 @@ func (i *PulumiServiceTeamInput) ToPropertyMap() resource.PropertyMap {
 	pm["description"] = resource.NewPropertyValue(i.Description)
 	pm["members"] = resource.NewPropertyValue(i.Members)
 	pm["organizationName"] = resource.NewPropertyValue(i.OrganizationName)
+	pm["githubTeamID"] = resource.NewPropertyValue(i.GitHubTeamID)
 	return pm
 }
 
@@ -83,6 +85,10 @@ func ToPulumiServiceTeamInput(inputMap resource.PropertyMap) PulumiServiceTeamIn
 
 	if inputMap["organizationName"].HasValue() && inputMap["organizationName"].IsString() {
 		input.OrganizationName = inputMap["organizationName"].StringValue()
+	}
+
+	if inputMap["githubTeamID"].HasValue() && inputMap["githubTeamID"].IsNumber() {
+		input.GitHubTeamID = int64(inputMap["githubTeamID"].NumberValue())
 	}
 
 	return input
@@ -245,7 +251,7 @@ func (t *PulumiServiceTeamResource) updateTeam(ctx context.Context, input Pulumi
 }
 
 func (t *PulumiServiceTeamResource) createTeam(ctx context.Context, input PulumiServiceTeamInput) (*string, error) {
-	_, err := t.client.CreateTeam(ctx, input.OrganizationName, input.Name, input.Type, input.DisplayName, input.Description)
+	_, err := t.client.CreateTeam(ctx, input.OrganizationName, input.Name, input.Type, input.DisplayName, input.Description, input.GitHubTeamID)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +261,6 @@ func (t *PulumiServiceTeamResource) createTeam(ctx context.Context, input Pulumi
 }
 
 func (t *PulumiServiceTeamResource) deleteFromTeam(ctx context.Context, orgName string, teamName string, userName string) error {
-
 	if len(orgName) == 0 {
 		return errors.New("orgname must not be empty")
 	}
@@ -269,7 +274,6 @@ func (t *PulumiServiceTeamResource) deleteFromTeam(ctx context.Context, orgName 
 	}
 
 	return t.client.DeleteMemberFromTeam(ctx, orgName, teamName, userName)
-
 }
 
 func (t *PulumiServiceTeamResource) addToTeam(ctx context.Context, orgName string, teamName string, userName string) error {

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -46,7 +46,7 @@ func (i *PulumiServiceTeamInput) ToPropertyMap() resource.PropertyMap {
 	pm["description"] = resource.NewPropertyValue(i.Description)
 	pm["members"] = resource.NewPropertyValue(i.Members)
 	pm["organizationName"] = resource.NewPropertyValue(i.OrganizationName)
-	pm["githubTeamID"] = resource.NewPropertyValue(i.GitHubTeamID)
+	pm["githubTeamId"] = resource.NewPropertyValue(i.GitHubTeamID)
 	return pm
 }
 
@@ -87,8 +87,8 @@ func ToPulumiServiceTeamInput(inputMap resource.PropertyMap) PulumiServiceTeamIn
 		input.OrganizationName = inputMap["organizationName"].StringValue()
 	}
 
-	if inputMap["githubTeamID"].HasValue() && inputMap["githubTeamID"].IsNumber() {
-		input.GitHubTeamID = int64(inputMap["githubTeamID"].NumberValue())
+	if inputMap["githubTeamId"].HasValue() && inputMap["githubTeamId"].IsNumber() {
+		input.GitHubTeamID = int64(inputMap["githubTeamId"].NumberValue())
 	}
 
 	return input

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -46,7 +46,7 @@ namespace Pulumi.PulumiService
         public Output<string?> Name { get; private set; } = null!;
 
         /// <summary>
-        /// The organization's name.
+        /// The name of the Pulumi organization the team belongs to.
         /// </summary>
         [Output("organizationName")]
         public Output<string?> OrganizationName { get; private set; } = null!;
@@ -114,6 +114,12 @@ namespace Pulumi.PulumiService
         [Input("displayName")]
         public Input<string>? DisplayName { get; set; }
 
+        /// <summary>
+        /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// </summary>
+        [Input("githubTeamID")]
+        public Input<double>? GithubTeamID { get; set; }
+
         [Input("members")]
         private InputList<string>? _members;
 
@@ -127,13 +133,13 @@ namespace Pulumi.PulumiService
         }
 
         /// <summary>
-        /// The team name.
+        /// The team name. Required for "pulumi" teams.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
-        /// The organization's name.
+        /// The name of the Pulumi organization the team belongs to.
         /// </summary>
         [Input("organizationName", required: true)]
         public Input<string> OrganizationName { get; set; } = null!;

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -133,10 +133,10 @@ namespace Pulumi.PulumiService
         }
 
         /// <summary>
-        /// The team name. Required for "pulumi" teams.
+        /// The team name.
         /// </summary>
-        [Input("name")]
-        public Input<string>? Name { get; set; }
+        [Input("name", required: true)]
+        public Input<string> Name { get; set; } = null!;
 
         /// <summary>
         /// The name of the Pulumi organization the team belongs to.

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -28,7 +28,7 @@ namespace Pulumi.PulumiService
         public Output<string?> DisplayName { get; private set; } = null!;
 
         /// <summary>
-        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         /// </summary>
         [Output("githubTeamId")]
         public Output<double?> GithubTeamId { get; private set; } = null!;
@@ -115,7 +115,7 @@ namespace Pulumi.PulumiService
         public Input<string>? DisplayName { get; set; }
 
         /// <summary>
-        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         /// </summary>
         [Input("githubTeamId")]
         public Input<double>? GithubTeamId { get; set; }

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -40,7 +40,7 @@ namespace Pulumi.PulumiService
         public Output<ImmutableArray<string>> Members { get; private set; } = null!;
 
         /// <summary>
-        /// The team name.
+        /// The team's name. Required for "pulumi" teams.
         /// </summary>
         [Output("name")]
         public Output<string?> Name { get; private set; } = null!;
@@ -133,10 +133,10 @@ namespace Pulumi.PulumiService
         }
 
         /// <summary>
-        /// The team name.
+        /// The team's name. Required for "pulumi" teams.
         /// </summary>
-        [Input("name", required: true)]
-        public Input<string> Name { get; set; } = null!;
+        [Input("name")]
+        public Input<string>? Name { get; set; }
 
         /// <summary>
         /// The name of the Pulumi organization the team belongs to.

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -28,7 +28,7 @@ namespace Pulumi.PulumiService
         public Output<string?> DisplayName { get; private set; } = null!;
 
         /// <summary>
-        /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         /// </summary>
         [Output("githubTeamId")]
         public Output<double?> GithubTeamId { get; private set; } = null!;
@@ -115,7 +115,7 @@ namespace Pulumi.PulumiService
         public Input<string>? DisplayName { get; set; }
 
         /// <summary>
-        /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         /// </summary>
         [Input("githubTeamId")]
         public Input<double>? GithubTeamId { get; set; }

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -28,6 +28,12 @@ namespace Pulumi.PulumiService
         public Output<string?> DisplayName { get; private set; } = null!;
 
         /// <summary>
+        /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        /// </summary>
+        [Output("githubTeamID")]
+        public Output<double?> GithubTeamID { get; private set; } = null!;
+
+        /// <summary>
         /// List of team members.
         /// </summary>
         [Output("members")]

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -30,8 +30,8 @@ namespace Pulumi.PulumiService
         /// <summary>
         /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         /// </summary>
-        [Output("githubTeamID")]
-        public Output<double?> GithubTeamID { get; private set; } = null!;
+        [Output("githubTeamId")]
+        public Output<double?> GithubTeamId { get; private set; } = null!;
 
         /// <summary>
         /// List of team members.
@@ -117,8 +117,8 @@ namespace Pulumi.PulumiService
         /// <summary>
         /// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         /// </summary>
-        [Input("githubTeamID")]
-        public Input<double>? GithubTeamID { get; set; }
+        [Input("githubTeamId")]
+        public Input<double>? GithubTeamId { get; set; }
 
         [Input("members")]
         private InputList<string>? _members;

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -19,7 +19,7 @@ type Team struct {
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrOutput `pulumi:"displayName"`
-	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
 	GithubTeamId pulumi.Float64PtrOutput `pulumi:"githubTeamId"`
 	// List of team members.
 	Members pulumi.StringArrayOutput `pulumi:"members"`
@@ -80,7 +80,7 @@ type teamArgs struct {
 	Description *string `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName *string `pulumi:"displayName"`
-	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
 	GithubTeamId *float64 `pulumi:"githubTeamId"`
 	// List of team members.
 	Members []string `pulumi:"members"`
@@ -98,7 +98,7 @@ type TeamArgs struct {
 	Description pulumi.StringPtrInput
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrInput
-	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
 	GithubTeamId pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
@@ -207,7 +207,7 @@ func (o TeamOutput) DisplayName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.DisplayName }).(pulumi.StringPtrOutput)
 }
 
-// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
 func (o TeamOutput) GithubTeamId() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.Float64PtrOutput { return v.GithubTeamId }).(pulumi.Float64PtrOutput)
 }

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -19,6 +19,8 @@ type Team struct {
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrOutput `pulumi:"displayName"`
+	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	GithubTeamID pulumi.Float64PtrOutput `pulumi:"githubTeamID"`
 	// List of team members.
 	Members pulumi.StringArrayOutput `pulumi:"members"`
 	// The team name.
@@ -202,6 +204,11 @@ func (o TeamOutput) Description() pulumi.StringPtrOutput {
 // Optional. Team display name.
 func (o TeamOutput) DisplayName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.DisplayName }).(pulumi.StringPtrOutput)
+}
+
+// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+func (o TeamOutput) GithubTeamID() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Team) pulumi.Float64PtrOutput { return v.GithubTeamID }).(pulumi.Float64PtrOutput)
 }
 
 // List of team members.

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -38,6 +38,9 @@ func NewTeam(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Name == nil {
+		return nil, errors.New("invalid value for required argument 'Name'")
+	}
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
 	}
@@ -84,8 +87,8 @@ type teamArgs struct {
 	GithubTeamId *float64 `pulumi:"githubTeamId"`
 	// List of team members.
 	Members []string `pulumi:"members"`
-	// The team name. Required for "pulumi" teams.
-	Name *string `pulumi:"name"`
+	// The team name.
+	Name string `pulumi:"name"`
 	// The name of the Pulumi organization the team belongs to.
 	OrganizationName string `pulumi:"organizationName"`
 	// The type of team. Must be either `pulumi` or `github`.
@@ -102,8 +105,8 @@ type TeamArgs struct {
 	GithubTeamId pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
-	// The team name. Required for "pulumi" teams.
-	Name pulumi.StringPtrInput
+	// The team name.
+	Name pulumi.StringInput
 	// The name of the Pulumi organization the team belongs to.
 	OrganizationName pulumi.StringInput
 	// The type of team. Must be either `pulumi` or `github`.

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -19,7 +19,7 @@ type Team struct {
 	Description pulumi.StringPtrOutput `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrOutput `pulumi:"displayName"`
-	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
 	GithubTeamId pulumi.Float64PtrOutput `pulumi:"githubTeamId"`
 	// List of team members.
 	Members pulumi.StringArrayOutput `pulumi:"members"`
@@ -80,7 +80,7 @@ type teamArgs struct {
 	Description *string `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName *string `pulumi:"displayName"`
-	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
 	GithubTeamId *float64 `pulumi:"githubTeamId"`
 	// List of team members.
 	Members []string `pulumi:"members"`
@@ -98,7 +98,7 @@ type TeamArgs struct {
 	Description pulumi.StringPtrInput
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrInput
-	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+	// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
 	GithubTeamId pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
@@ -207,7 +207,7 @@ func (o TeamOutput) DisplayName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.DisplayName }).(pulumi.StringPtrOutput)
 }
 
-// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+// The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
 func (o TeamOutput) GithubTeamId() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.Float64PtrOutput { return v.GithubTeamId }).(pulumi.Float64PtrOutput)
 }

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -20,7 +20,7 @@ type Team struct {
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrOutput `pulumi:"displayName"`
 	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
-	GithubTeamID pulumi.Float64PtrOutput `pulumi:"githubTeamID"`
+	GithubTeamId pulumi.Float64PtrOutput `pulumi:"githubTeamId"`
 	// List of team members.
 	Members pulumi.StringArrayOutput `pulumi:"members"`
 	// The team name.
@@ -81,7 +81,7 @@ type teamArgs struct {
 	// Optional. Team display name.
 	DisplayName *string `pulumi:"displayName"`
 	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
-	GithubTeamID *float64 `pulumi:"githubTeamID"`
+	GithubTeamId *float64 `pulumi:"githubTeamId"`
 	// List of team members.
 	Members []string `pulumi:"members"`
 	// The team name. Required for "pulumi" teams.
@@ -99,7 +99,7 @@ type TeamArgs struct {
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrInput
 	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
-	GithubTeamID pulumi.Float64PtrInput
+	GithubTeamId pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
 	// The team name. Required for "pulumi" teams.
@@ -208,8 +208,8 @@ func (o TeamOutput) DisplayName() pulumi.StringPtrOutput {
 }
 
 // The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
-func (o TeamOutput) GithubTeamID() pulumi.Float64PtrOutput {
-	return o.ApplyT(func(v *Team) pulumi.Float64PtrOutput { return v.GithubTeamID }).(pulumi.Float64PtrOutput)
+func (o TeamOutput) GithubTeamId() pulumi.Float64PtrOutput {
+	return o.ApplyT(func(v *Team) pulumi.Float64PtrOutput { return v.GithubTeamId }).(pulumi.Float64PtrOutput)
 }
 
 // List of team members.

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -23,7 +23,7 @@ type Team struct {
 	GithubTeamId pulumi.Float64PtrOutput `pulumi:"githubTeamId"`
 	// List of team members.
 	Members pulumi.StringArrayOutput `pulumi:"members"`
-	// The team name.
+	// The team's name. Required for "pulumi" teams.
 	Name pulumi.StringPtrOutput `pulumi:"name"`
 	// The name of the Pulumi organization the team belongs to.
 	OrganizationName pulumi.StringPtrOutput `pulumi:"organizationName"`
@@ -38,9 +38,6 @@ func NewTeam(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
 	}
@@ -87,8 +84,8 @@ type teamArgs struct {
 	GithubTeamId *float64 `pulumi:"githubTeamId"`
 	// List of team members.
 	Members []string `pulumi:"members"`
-	// The team name.
-	Name string `pulumi:"name"`
+	// The team's name. Required for "pulumi" teams.
+	Name *string `pulumi:"name"`
 	// The name of the Pulumi organization the team belongs to.
 	OrganizationName string `pulumi:"organizationName"`
 	// The type of team. Must be either `pulumi` or `github`.
@@ -105,8 +102,8 @@ type TeamArgs struct {
 	GithubTeamId pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
-	// The team name.
-	Name pulumi.StringInput
+	// The team's name. Required for "pulumi" teams.
+	Name pulumi.StringPtrInput
 	// The name of the Pulumi organization the team belongs to.
 	OrganizationName pulumi.StringInput
 	// The type of team. Must be either `pulumi` or `github`.
@@ -220,7 +217,7 @@ func (o TeamOutput) Members() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringArrayOutput { return v.Members }).(pulumi.StringArrayOutput)
 }
 
-// The team name.
+// The team's name. Required for "pulumi" teams.
 func (o TeamOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
 }

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -25,7 +25,7 @@ type Team struct {
 	Members pulumi.StringArrayOutput `pulumi:"members"`
 	// The team name.
 	Name pulumi.StringPtrOutput `pulumi:"name"`
-	// The organization's name.
+	// The name of the Pulumi organization the team belongs to.
 	OrganizationName pulumi.StringPtrOutput `pulumi:"organizationName"`
 	// The type of team. Must be either `pulumi` or `github`.
 	TeamType pulumi.StringPtrOutput `pulumi:"teamType"`
@@ -38,9 +38,6 @@ func NewTeam(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
-	if args.Name == nil {
-		return nil, errors.New("invalid value for required argument 'Name'")
-	}
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
 	}
@@ -83,11 +80,13 @@ type teamArgs struct {
 	Description *string `pulumi:"description"`
 	// Optional. Team display name.
 	DisplayName *string `pulumi:"displayName"`
+	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	GithubTeamID *float64 `pulumi:"githubTeamID"`
 	// List of team members.
 	Members []string `pulumi:"members"`
-	// The team name.
-	Name string `pulumi:"name"`
-	// The organization's name.
+	// The team name. Required for "pulumi" teams.
+	Name *string `pulumi:"name"`
+	// The name of the Pulumi organization the team belongs to.
 	OrganizationName string `pulumi:"organizationName"`
 	// The type of team. Must be either `pulumi` or `github`.
 	TeamType string `pulumi:"teamType"`
@@ -99,11 +98,13 @@ type TeamArgs struct {
 	Description pulumi.StringPtrInput
 	// Optional. Team display name.
 	DisplayName pulumi.StringPtrInput
+	// The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+	GithubTeamID pulumi.Float64PtrInput
 	// List of team members.
 	Members pulumi.StringArrayInput
-	// The team name.
-	Name pulumi.StringInput
-	// The organization's name.
+	// The team name. Required for "pulumi" teams.
+	Name pulumi.StringPtrInput
+	// The name of the Pulumi organization the team belongs to.
 	OrganizationName pulumi.StringInput
 	// The type of team. Must be either `pulumi` or `github`.
 	TeamType pulumi.StringInput
@@ -221,7 +222,7 @@ func (o TeamOutput) Name() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.Name }).(pulumi.StringPtrOutput)
 }
 
-// The organization's name.
+// The name of the Pulumi organization the team belongs to.
 func (o TeamOutput) OrganizationName() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Team) pulumi.StringPtrOutput { return v.OrganizationName }).(pulumi.StringPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -50,14 +50,14 @@ public class Team extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.displayName);
     }
     /**
-     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
      * 
      */
     @Export(name="githubTeamId", refs={Double.class}, tree="[0]")
     private Output</* @Nullable */ Double> githubTeamId;
 
     /**
-     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
      * 
      */
     public Output<Optional<Double>> githubTeamId() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -92,14 +92,14 @@ public class Team extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.name);
     }
     /**
-     * The organization&#39;s name.
+     * The name of the Pulumi organization the team belongs to.
      * 
      */
     @Export(name="organizationName", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> organizationName;
 
     /**
-     * @return The organization&#39;s name.
+     * @return The name of the Pulumi organization the team belongs to.
      * 
      */
     public Output<Optional<String>> organizationName() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -53,15 +53,15 @@ public class Team extends com.pulumi.resources.CustomResource {
      * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
-    @Export(name="githubTeamID", refs={Double.class}, tree="[0]")
-    private Output</* @Nullable */ Double> githubTeamID;
+    @Export(name="githubTeamId", refs={Double.class}, tree="[0]")
+    private Output</* @Nullable */ Double> githubTeamId;
 
     /**
      * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
-    public Output<Optional<Double>> githubTeamID() {
-        return Codegen.optional(this.githubTeamID);
+    public Output<Optional<Double>> githubTeamId() {
+        return Codegen.optional(this.githubTeamId);
     }
     /**
      * List of team members.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -50,14 +50,14 @@ public class Team extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.displayName);
     }
     /**
-     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
     @Export(name="githubTeamId", refs={Double.class}, tree="[0]")
     private Output</* @Nullable */ Double> githubTeamId;
 
     /**
-     * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
     public Output<Optional<Double>> githubTeamId() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -9,6 +9,7 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.pulumiservice.TeamArgs;
 import com.pulumi.pulumiservice.Utilities;
+import java.lang.Double;
 import java.lang.String;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,20 @@ public class Team extends com.pulumi.resources.CustomResource {
      */
     public Output<Optional<String>> displayName() {
         return Codegen.optional(this.displayName);
+    }
+    /**
+     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * 
+     */
+    @Export(name="githubTeamID", refs={Double.class}, tree="[0]")
+    private Output</* @Nullable */ Double> githubTeamID;
+
+    /**
+     * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * 
+     */
+    public Output<Optional<Double>> githubTeamID() {
+        return Codegen.optional(this.githubTeamID);
     }
     /**
      * List of team members.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -78,14 +78,14 @@ public class Team extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.members);
     }
     /**
-     * The team name.
+     * The team&#39;s name. Required for &#34;pulumi&#34; teams.
      * 
      */
     @Export(name="name", refs={String.class}, tree="[0]")
     private Output</* @Nullable */ String> name;
 
     /**
-     * @return The team name.
+     * @return The team&#39;s name. Required for &#34;pulumi&#34; teams.
      * 
      */
     public Output<Optional<String>> name() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -78,18 +78,18 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The team name.
+     * The team&#39;s name. Required for &#34;pulumi&#34; teams.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
-     * @return The team name.
+     * @return The team&#39;s name. Required for &#34;pulumi&#34; teams.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
@@ -247,18 +247,18 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param name The team name.
+         * @param name The team&#39;s name. Required for &#34;pulumi&#34; teams.
          * 
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
 
         /**
-         * @param name The team name.
+         * @param name The team&#39;s name. Required for &#34;pulumi&#34; teams.
          * 
          * @return builder
          * 
@@ -310,7 +310,6 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public TeamArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.organizationName = Objects.requireNonNull($.organizationName, "expected parameter 'organizationName' to be non-null");
             $.teamType = Objects.requireNonNull($.teamType, "expected parameter 'teamType' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -51,15 +51,15 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
      * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
-    @Import(name="githubTeamID")
-    private @Nullable Output<Double> githubTeamID;
+    @Import(name="githubTeamId")
+    private @Nullable Output<Double> githubTeamId;
 
     /**
      * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
-    public Optional<Output<Double>> githubTeamID() {
-        return Optional.ofNullable(this.githubTeamID);
+    public Optional<Output<Double>> githubTeamId() {
+        return Optional.ofNullable(this.githubTeamId);
     }
 
     /**
@@ -127,7 +127,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     private TeamArgs(TeamArgs $) {
         this.description = $.description;
         this.displayName = $.displayName;
-        this.githubTeamID = $.githubTeamID;
+        this.githubTeamId = $.githubTeamId;
         this.members = $.members;
         this.name = $.name;
         this.organizationName = $.organizationName;
@@ -195,24 +195,24 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param githubTeamID The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
          * 
          * @return builder
          * 
          */
-        public Builder githubTeamID(@Nullable Output<Double> githubTeamID) {
-            $.githubTeamID = githubTeamID;
+        public Builder githubTeamId(@Nullable Output<Double> githubTeamId) {
+            $.githubTeamId = githubTeamId;
             return this;
         }
 
         /**
-         * @param githubTeamID The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
          * 
          * @return builder
          * 
          */
-        public Builder githubTeamID(Double githubTeamID) {
-            return githubTeamID(Output.of(githubTeamID));
+        public Builder githubTeamId(Double githubTeamId) {
+            return githubTeamId(Output.of(githubTeamId));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -48,14 +48,14 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
      * 
      */
     @Import(name="githubTeamId")
     private @Nullable Output<Double> githubTeamId;
 
     /**
-     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
      * 
      */
     public Optional<Output<Double>> githubTeamId() {
@@ -195,7 +195,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
          * 
          * @return builder
          * 
@@ -206,7 +206,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for &#34;github&#34; teams.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -48,14 +48,14 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
     @Import(name="githubTeamId")
     private @Nullable Output<Double> githubTeamId;
 
     /**
-     * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * @return The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      * 
      */
     public Optional<Output<Double>> githubTeamId() {
@@ -195,7 +195,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param githubTeamId The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
          * 
          * @return builder
          * 
@@ -206,7 +206,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param githubTeamId The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * @param githubTeamId The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import java.lang.Double;
 import java.lang.String;
 import java.util.List;
 import java.util.Objects;
@@ -47,6 +48,21 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * 
+     */
+    @Import(name="githubTeamID")
+    private @Nullable Output<Double> githubTeamID;
+
+    /**
+     * @return The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * 
+     */
+    public Optional<Output<Double>> githubTeamID() {
+        return Optional.ofNullable(this.githubTeamID);
+    }
+
+    /**
      * List of team members.
      * 
      */
@@ -62,29 +78,29 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The team name.
+     * The team name. Required for &#34;pulumi&#34; teams.
      * 
      */
-    @Import(name="name", required=true)
-    private Output<String> name;
+    @Import(name="name")
+    private @Nullable Output<String> name;
 
     /**
-     * @return The team name.
+     * @return The team name. Required for &#34;pulumi&#34; teams.
      * 
      */
-    public Output<String> name() {
-        return this.name;
+    public Optional<Output<String>> name() {
+        return Optional.ofNullable(this.name);
     }
 
     /**
-     * The organization&#39;s name.
+     * The name of the Pulumi organization the team belongs to.
      * 
      */
     @Import(name="organizationName", required=true)
     private Output<String> organizationName;
 
     /**
-     * @return The organization&#39;s name.
+     * @return The name of the Pulumi organization the team belongs to.
      * 
      */
     public Output<String> organizationName() {
@@ -111,6 +127,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     private TeamArgs(TeamArgs $) {
         this.description = $.description;
         this.displayName = $.displayName;
+        this.githubTeamID = $.githubTeamID;
         this.members = $.members;
         this.name = $.name;
         this.organizationName = $.organizationName;
@@ -178,6 +195,27 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
+         * @param githubTeamID The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder githubTeamID(@Nullable Output<Double> githubTeamID) {
+            $.githubTeamID = githubTeamID;
+            return this;
+        }
+
+        /**
+         * @param githubTeamID The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder githubTeamID(Double githubTeamID) {
+            return githubTeamID(Output.of(githubTeamID));
+        }
+
+        /**
          * @param members List of team members.
          * 
          * @return builder
@@ -209,18 +247,18 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param name The team name.
+         * @param name The team name. Required for &#34;pulumi&#34; teams.
          * 
          * @return builder
          * 
          */
-        public Builder name(Output<String> name) {
+        public Builder name(@Nullable Output<String> name) {
             $.name = name;
             return this;
         }
 
         /**
-         * @param name The team name.
+         * @param name The team name. Required for &#34;pulumi&#34; teams.
          * 
          * @return builder
          * 
@@ -230,7 +268,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param organizationName The organization&#39;s name.
+         * @param organizationName The name of the Pulumi organization the team belongs to.
          * 
          * @return builder
          * 
@@ -241,7 +279,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param organizationName The organization&#39;s name.
+         * @param organizationName The name of the Pulumi organization the team belongs to.
          * 
          * @return builder
          * 
@@ -272,7 +310,6 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public TeamArgs build() {
-            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.organizationName = Objects.requireNonNull($.organizationName, "expected parameter 'organizationName' to be non-null");
             $.teamType = Objects.requireNonNull($.teamType, "expected parameter 'teamType' to be non-null");
             return $;

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamArgs.java
@@ -78,18 +78,18 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * The team name. Required for &#34;pulumi&#34; teams.
+     * The team name.
      * 
      */
-    @Import(name="name")
-    private @Nullable Output<String> name;
+    @Import(name="name", required=true)
+    private Output<String> name;
 
     /**
-     * @return The team name. Required for &#34;pulumi&#34; teams.
+     * @return The team name.
      * 
      */
-    public Optional<Output<String>> name() {
-        return Optional.ofNullable(this.name);
+    public Output<String> name() {
+        return this.name;
     }
 
     /**
@@ -247,18 +247,18 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param name The team name. Required for &#34;pulumi&#34; teams.
+         * @param name The team name.
          * 
          * @return builder
          * 
          */
-        public Builder name(@Nullable Output<String> name) {
+        public Builder name(Output<String> name) {
             $.name = name;
             return this;
         }
 
         /**
-         * @param name The team name. Required for &#34;pulumi&#34; teams.
+         * @param name The team name.
          * 
          * @return builder
          * 
@@ -310,6 +310,7 @@ public final class TeamArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public TeamArgs build() {
+            $.name = Objects.requireNonNull($.name, "expected parameter 'name' to be non-null");
             $.organizationName = Objects.requireNonNull($.organizationName, "expected parameter 'organizationName' to be non-null");
             $.teamType = Objects.requireNonNull($.teamType, "expected parameter 'teamType' to be non-null");
             return $;

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -74,6 +74,9 @@ export class Team extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.name === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'name'");
+            }
             if ((!args || args.organizationName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'organizationName'");
             }
@@ -122,9 +125,9 @@ export interface TeamArgs {
      */
     members?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The team name. Required for "pulumi" teams.
+     * The team name.
      */
-    name?: pulumi.Input<string>;
+    name: pulumi.Input<string>;
     /**
      * The name of the Pulumi organization the team belongs to.
      */

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -51,7 +51,7 @@ export class Team extends pulumi.CustomResource {
      */
     public readonly members!: pulumi.Output<string[] | undefined>;
     /**
-     * The team name.
+     * The team's name. Required for "pulumi" teams.
      */
     public readonly name!: pulumi.Output<string | undefined>;
     /**
@@ -74,9 +74,6 @@ export class Team extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.organizationName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'organizationName'");
             }
@@ -125,9 +122,9 @@ export interface TeamArgs {
      */
     members?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The team name.
+     * The team's name. Required for "pulumi" teams.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
      * The name of the Pulumi organization the team belongs to.
      */

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -43,7 +43,7 @@ export class Team extends pulumi.CustomResource {
      */
     public readonly displayName!: pulumi.Output<string | undefined>;
     /**
-     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      */
     public readonly githubTeamId!: pulumi.Output<number | undefined>;
     /**
@@ -114,7 +114,7 @@ export interface TeamArgs {
      */
     displayName?: pulumi.Input<string>;
     /**
-     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
      */
     githubTeamId?: pulumi.Input<number>;
     /**

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -45,7 +45,7 @@ export class Team extends pulumi.CustomResource {
     /**
      * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      */
-    public readonly githubTeamID!: pulumi.Output<number | undefined>;
+    public readonly githubTeamId!: pulumi.Output<number | undefined>;
     /**
      * List of team members.
      */
@@ -82,7 +82,7 @@ export class Team extends pulumi.CustomResource {
             }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["displayName"] = args ? args.displayName : undefined;
-            resourceInputs["githubTeamID"] = args ? args.githubTeamID : undefined;
+            resourceInputs["githubTeamId"] = args ? args.githubTeamId : undefined;
             resourceInputs["members"] = args ? args.members : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
@@ -90,7 +90,7 @@ export class Team extends pulumi.CustomResource {
         } else {
             resourceInputs["description"] = undefined /*out*/;
             resourceInputs["displayName"] = undefined /*out*/;
-            resourceInputs["githubTeamID"] = undefined /*out*/;
+            resourceInputs["githubTeamId"] = undefined /*out*/;
             resourceInputs["members"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
@@ -116,7 +116,7 @@ export interface TeamArgs {
     /**
      * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      */
-    githubTeamID?: pulumi.Input<number>;
+    githubTeamId?: pulumi.Input<number>;
     /**
      * List of team members.
      */

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -45,7 +45,7 @@ export class Team extends pulumi.CustomResource {
     /**
      * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
      */
-    public /*out*/ readonly githubTeamID!: pulumi.Output<number | undefined>;
+    public readonly githubTeamID!: pulumi.Output<number | undefined>;
     /**
      * List of team members.
      */
@@ -55,7 +55,7 @@ export class Team extends pulumi.CustomResource {
      */
     public readonly name!: pulumi.Output<string | undefined>;
     /**
-     * The organization's name.
+     * The name of the Pulumi organization the team belongs to.
      */
     public readonly organizationName!: pulumi.Output<string | undefined>;
     /**
@@ -74,9 +74,6 @@ export class Team extends pulumi.CustomResource {
         let resourceInputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
-            if ((!args || args.name === undefined) && !opts.urn) {
-                throw new Error("Missing required property 'name'");
-            }
             if ((!args || args.organizationName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'organizationName'");
             }
@@ -85,11 +82,11 @@ export class Team extends pulumi.CustomResource {
             }
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["displayName"] = args ? args.displayName : undefined;
+            resourceInputs["githubTeamID"] = args ? args.githubTeamID : undefined;
             resourceInputs["members"] = args ? args.members : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["teamType"] = args ? args.teamType : undefined;
-            resourceInputs["githubTeamID"] = undefined /*out*/;
         } else {
             resourceInputs["description"] = undefined /*out*/;
             resourceInputs["displayName"] = undefined /*out*/;
@@ -117,15 +114,19 @@ export interface TeamArgs {
      */
     displayName?: pulumi.Input<string>;
     /**
+     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     */
+    githubTeamID?: pulumi.Input<number>;
+    /**
      * List of team members.
      */
     members?: pulumi.Input<pulumi.Input<string>[]>;
     /**
-     * The team name.
+     * The team name. Required for "pulumi" teams.
      */
-    name: pulumi.Input<string>;
+    name?: pulumi.Input<string>;
     /**
-     * The organization's name.
+     * The name of the Pulumi organization the team belongs to.
      */
     organizationName: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -43,6 +43,10 @@ export class Team extends pulumi.CustomResource {
      */
     public readonly displayName!: pulumi.Output<string | undefined>;
     /**
+     * The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+     */
+    public /*out*/ readonly githubTeamID!: pulumi.Output<number | undefined>;
+    /**
      * List of team members.
      */
     public readonly members!: pulumi.Output<string[] | undefined>;
@@ -85,9 +89,11 @@ export class Team extends pulumi.CustomResource {
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["teamType"] = args ? args.teamType : undefined;
+            resourceInputs["githubTeamID"] = undefined /*out*/;
         } else {
             resourceInputs["description"] = undefined /*out*/;
             resourceInputs["displayName"] = undefined /*out*/;
+            resourceInputs["githubTeamID"] = undefined /*out*/;
             resourceInputs["members"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -43,7 +43,7 @@ export class Team extends pulumi.CustomResource {
      */
     public readonly displayName!: pulumi.Output<string | undefined>;
     /**
-     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
      */
     public readonly githubTeamId!: pulumi.Output<number | undefined>;
     /**
@@ -114,7 +114,7 @@ export interface TeamArgs {
      */
     displayName?: pulumi.Input<string>;
     /**
-     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+     * The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
      */
     githubTeamId?: pulumi.Input<number>;
     /**

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -27,7 +27,7 @@ class TeamArgs:
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
-        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
         :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         """
@@ -96,7 +96,7 @@ class TeamArgs:
     @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> Optional[pulumi.Input[float]]:
         """
-        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         """
         return pulumi.get(self, "github_team_id")
 
@@ -149,7 +149,7 @@ class Team(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
-        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
         :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
@@ -257,7 +257,7 @@ class Team(pulumi.CustomResource):
     @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> pulumi.Output[Optional[float]]:
         """
-        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
+        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by. Required for "github" teams.
         """
         return pulumi.get(self, "github_team_id")
 

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -27,7 +27,7 @@ class TeamArgs:
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
-        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
         :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         """
@@ -96,7 +96,7 @@ class TeamArgs:
     @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> Optional[pulumi.Input[float]]:
         """
-        The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         """
         return pulumi.get(self, "github_team_id")
 
@@ -149,7 +149,7 @@ class Team(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
-        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
         :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
@@ -257,7 +257,7 @@ class Team(pulumi.CustomResource):
     @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> pulumi.Output[Optional[float]]:
         """
-        The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        The GitHub ID of the team to mirror. Must be in the same GitHub organization that the Pulumi org is backed by.
         """
         return pulumi.get(self, "github_team_id")
 

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -14,23 +14,24 @@ __all__ = ['TeamArgs', 'Team']
 @pulumi.input_type
 class TeamArgs:
     def __init__(__self__, *,
+                 name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
                  team_type: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
                  github_team_id: Optional[pulumi.Input[float]] = None,
-                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
-                 name: Optional[pulumi.Input[str]] = None):
+                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
         The set of arguments for constructing a Team resource.
+        :param pulumi.Input[str] name: The team name.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
         :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
-        :param pulumi.Input[str] name: The team name. Required for "pulumi" teams.
         """
+        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
         pulumi.set(__self__, "team_type", team_type)
         if description is not None:
@@ -41,8 +42,18 @@ class TeamArgs:
             pulumi.set(__self__, "github_team_id", github_team_id)
         if members is not None:
             pulumi.set(__self__, "members", members)
-        if name is not None:
-            pulumi.set(__self__, "name", name)
+
+    @property
+    @pulumi.getter
+    def name(self) -> pulumi.Input[str]:
+        """
+        The team name.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: pulumi.Input[str]):
+        pulumi.set(self, "name", value)
 
     @property
     @pulumi.getter(name="organizationName")
@@ -116,18 +127,6 @@ class TeamArgs:
     def members(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "members", value)
 
-    @property
-    @pulumi.getter
-    def name(self) -> Optional[pulumi.Input[str]]:
-        """
-        The team name. Required for "pulumi" teams.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: Optional[pulumi.Input[str]]):
-        pulumi.set(self, "name", value)
-
 
 class Team(pulumi.CustomResource):
     @overload
@@ -151,7 +150,7 @@ class Team(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. Team display name.
         :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
-        :param pulumi.Input[str] name: The team name. Required for "pulumi" teams.
+        :param pulumi.Input[str] name: The team name.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         """
@@ -199,6 +198,8 @@ class Team(pulumi.CustomResource):
             __props__.__dict__["display_name"] = display_name
             __props__.__dict__["github_team_id"] = github_team_id
             __props__.__dict__["members"] = members
+            if name is None and not opts.urn:
+                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -93,7 +93,7 @@ class TeamArgs:
         pulumi.set(self, "display_name", value)
 
     @property
-    @pulumi.getter(name="githubTeamID")
+    @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> Optional[pulumi.Input[float]]:
         """
         The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
@@ -254,7 +254,7 @@ class Team(pulumi.CustomResource):
         return pulumi.get(self, "display_name")
 
     @property
-    @pulumi.getter(name="githubTeamID")
+    @pulumi.getter(name="githubTeamId")
     def github_team_id(self) -> pulumi.Output[Optional[float]]:
         """
         The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -187,6 +187,7 @@ class Team(pulumi.CustomResource):
             if team_type is None and not opts.urn:
                 raise TypeError("Missing required property 'team_type'")
             __props__.__dict__["team_type"] = team_type
+            __props__.__dict__["github_team_id"] = None
         super(Team, __self__).__init__(
             'pulumiservice:index:Team',
             resource_name,
@@ -211,6 +212,7 @@ class Team(pulumi.CustomResource):
 
         __props__.__dict__["description"] = None
         __props__.__dict__["display_name"] = None
+        __props__.__dict__["github_team_id"] = None
         __props__.__dict__["members"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
@@ -232,6 +234,14 @@ class Team(pulumi.CustomResource):
         Optional. Team display name.
         """
         return pulumi.get(self, "display_name")
+
+    @property
+    @pulumi.getter(name="githubTeamID")
+    def github_team_id(self) -> pulumi.Output[Optional[float]]:
+        """
+        The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        """
+        return pulumi.get(self, "github_team_id")
 
     @property
     @pulumi.getter

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -14,24 +14,23 @@ __all__ = ['TeamArgs', 'Team']
 @pulumi.input_type
 class TeamArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
                  team_type: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
                  github_team_id: Optional[pulumi.Input[float]] = None,
-                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Team resource.
-        :param pulumi.Input[str] name: The team name.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
         :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
+        :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
         pulumi.set(__self__, "team_type", team_type)
         if description is not None:
@@ -42,18 +41,8 @@ class TeamArgs:
             pulumi.set(__self__, "github_team_id", github_team_id)
         if members is not None:
             pulumi.set(__self__, "members", members)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The team name.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="organizationName")
@@ -127,6 +116,18 @@ class TeamArgs:
     def members(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "members", value)
 
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The team's name. Required for "pulumi" teams.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
+
 
 class Team(pulumi.CustomResource):
     @overload
@@ -150,7 +151,7 @@ class Team(pulumi.CustomResource):
         :param pulumi.Input[str] display_name: Optional. Team display name.
         :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
-        :param pulumi.Input[str] name: The team name.
+        :param pulumi.Input[str] name: The team's name. Required for "pulumi" teams.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         """
@@ -198,8 +199,6 @@ class Team(pulumi.CustomResource):
             __props__.__dict__["display_name"] = display_name
             __props__.__dict__["github_team_id"] = github_team_id
             __props__.__dict__["members"] = members
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")
@@ -274,7 +273,7 @@ class Team(pulumi.CustomResource):
     @pulumi.getter
     def name(self) -> pulumi.Output[Optional[str]]:
         """
-        The team name.
+        The team's name. Required for "pulumi" teams.
         """
         return pulumi.get(self, "name")
 

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -14,48 +14,41 @@ __all__ = ['TeamArgs', 'Team']
 @pulumi.input_type
 class TeamArgs:
     def __init__(__self__, *,
-                 name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
                  team_type: pulumi.Input[str],
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
-                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
+                 github_team_id: Optional[pulumi.Input[float]] = None,
+                 members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 name: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Team resource.
-        :param pulumi.Input[str] name: The team name.
-        :param pulumi.Input[str] organization_name: The organization's name.
+        :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
+        :param pulumi.Input[str] name: The team name. Required for "pulumi" teams.
         """
-        pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
         pulumi.set(__self__, "team_type", team_type)
         if description is not None:
             pulumi.set(__self__, "description", description)
         if display_name is not None:
             pulumi.set(__self__, "display_name", display_name)
+        if github_team_id is not None:
+            pulumi.set(__self__, "github_team_id", github_team_id)
         if members is not None:
             pulumi.set(__self__, "members", members)
-
-    @property
-    @pulumi.getter
-    def name(self) -> pulumi.Input[str]:
-        """
-        The team name.
-        """
-        return pulumi.get(self, "name")
-
-    @name.setter
-    def name(self, value: pulumi.Input[str]):
-        pulumi.set(self, "name", value)
+        if name is not None:
+            pulumi.set(__self__, "name", name)
 
     @property
     @pulumi.getter(name="organizationName")
     def organization_name(self) -> pulumi.Input[str]:
         """
-        The organization's name.
+        The name of the Pulumi organization the team belongs to.
         """
         return pulumi.get(self, "organization_name")
 
@@ -100,6 +93,18 @@ class TeamArgs:
         pulumi.set(self, "display_name", value)
 
     @property
+    @pulumi.getter(name="githubTeamID")
+    def github_team_id(self) -> Optional[pulumi.Input[float]]:
+        """
+        The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
+        """
+        return pulumi.get(self, "github_team_id")
+
+    @github_team_id.setter
+    def github_team_id(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "github_team_id", value)
+
+    @property
     @pulumi.getter
     def members(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
         """
@@ -111,6 +116,18 @@ class TeamArgs:
     def members(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "members", value)
 
+    @property
+    @pulumi.getter
+    def name(self) -> Optional[pulumi.Input[str]]:
+        """
+        The team name. Required for "pulumi" teams.
+        """
+        return pulumi.get(self, "name")
+
+    @name.setter
+    def name(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "name", value)
+
 
 class Team(pulumi.CustomResource):
     @overload
@@ -119,6 +136,7 @@ class Team(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
+                 github_team_id: Optional[pulumi.Input[float]] = None,
                  members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
@@ -131,9 +149,10 @@ class Team(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: Optional. Team description.
         :param pulumi.Input[str] display_name: Optional. Team display name.
+        :param pulumi.Input[float] github_team_id: The GitHub ID of the team to mirror. This is the only required parameter when creating a GitHub team -- all other parameters are taken from GitHub directly. Must be in the same GitHub organization that the Pulumi org is backed by.
         :param pulumi.Input[Sequence[pulumi.Input[str]]] members: List of team members.
-        :param pulumi.Input[str] name: The team name.
-        :param pulumi.Input[str] organization_name: The organization's name.
+        :param pulumi.Input[str] name: The team name. Required for "pulumi" teams.
+        :param pulumi.Input[str] organization_name: The name of the Pulumi organization the team belongs to.
         :param pulumi.Input[str] team_type: The type of team. Must be either `pulumi` or `github`.
         """
         ...
@@ -162,6 +181,7 @@ class Team(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
                  display_name: Optional[pulumi.Input[str]] = None,
+                 github_team_id: Optional[pulumi.Input[float]] = None,
                  members: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
@@ -177,9 +197,8 @@ class Team(pulumi.CustomResource):
 
             __props__.__dict__["description"] = description
             __props__.__dict__["display_name"] = display_name
+            __props__.__dict__["github_team_id"] = github_team_id
             __props__.__dict__["members"] = members
-            if name is None and not opts.urn:
-                raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")
@@ -187,7 +206,6 @@ class Team(pulumi.CustomResource):
             if team_type is None and not opts.urn:
                 raise TypeError("Missing required property 'team_type'")
             __props__.__dict__["team_type"] = team_type
-            __props__.__dict__["github_team_id"] = None
         super(Team, __self__).__init__(
             'pulumiservice:index:Team',
             resource_name,
@@ -263,7 +281,7 @@ class Team(pulumi.CustomResource):
     @pulumi.getter(name="organizationName")
     def organization_name(self) -> pulumi.Output[Optional[str]]:
         """
-        The organization's name.
+        The name of the Pulumi organization the team belongs to.
         """
         return pulumi.get(self, "organization_name")
 


### PR DESCRIPTION
The team creation API for GitHub teams only requires a `githubTeamID` parameter, which it uses to fetch all the other details like team name, description, members, etc.

I implemented `Read` while I was in here, because it was surprising to see this break `refresh` due to a not-implemented error. Also implemented `Check` because `name` and `githubTeamId` are only required for certain team types.

Tested and confirmed working by with the following program:

```typescript
import * as pulumi from "@pulumi/pulumi";
import * as service from "@pulumi/pulumiservice";

const team = new service.Team("github-team", {
  organizationName: "pulumi",
  teamType: "github",
  githubTeamId: 7475955,
});
``` 

```bash
❯ pulumi up -s pulumi/test
Previewing update (pulumi/test)

View in Browser (Ctrl+O): https://.../pulumi/pulumi-service-teams-example-ts/test/previews/3dd36e22-e7d7-4b5d-82d0-2bbd8d61f86e

     Type                         Name                                  Plan
     pulumi:pulumi:Stack          pulumi-service-teams-example-ts-test
 +   └─ pulumiservice:index:Team  github-team                           create


Resources:
    + 1 to create
    1 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:test::pulumi-service-teams-example-ts::pulumi:pulumi:Stack::pulumi-service-teams-example-ts-test]
    + pulumiservice:index:Team: (create)
        [urn=urn:pulumi:test::pulumi-service-teams-example-ts::pulumiservice:index:Team::github-team]
        [provider=urn:pulumi:test::pulumi-service-teams-example-ts::pulumi:providers:pulumiservice::default_0_9_1_alpha_1689717595_28bbd1fc_dirty::7a11ee03-f53f-4ebc-8c9f-a09cfe4ad07a]
        githubTeamId    : 7475955
        organizationName: "pulumi"
        teamType        : "github"

Do you want to perform this update? yes
Updating (pulumi/test)

View in Browser (Ctrl+O): https://.../pulumi/pulumi-service-teams-example-ts/test/updates/5

     Type                         Name                                  Status
     pulumi:pulumi:Stack          pulumi-service-teams-example-ts-test
 +   └─ pulumiservice:index:Team  github-team                           created (0.94s)


Resources:
    + 1 created
    1 unchanged

Duration: 3s
```

Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/151.