### PR TITLE
Add new source header

### DIFF
--- a/provider/pkg/internal/pulumiapi/client.go
+++ b/provider/pkg/internal/pulumiapi/client.go
@@ -70,9 +70,11 @@ func (c *Client) createRequest(ctx context.Context, method, path string, reqBody
 	}
 
 	// add default headers
+	req.Header.Add("X-Pulumi-Source", "provider")
 	req.Header.Add("Accept", "application/vnd.pulumi+8")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "token "+c.token)
+
 	return req, nil
 }
 

--- a/provider/pkg/internal/pulumiapi/deployment_setting_test.go
+++ b/provider/pkg/internal/pulumiapi/deployment_setting_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDeploymentSettings(t *testing.T) {
+func TestGetDeploymentSettings(t *testing.T) {
 
 	orgName := "an-organization"
 	projectName := "a-project"
@@ -61,5 +61,37 @@ func TestDeploymentSettings(t *testing.T) {
 
 		assert.Nil(t, ds, "deployment settings should be nil since error was returned")
 		assert.Nil(t, err, "err should be nil since error was returned")
+	})
+}
+
+func TestCreateDeploymentSettings(t *testing.T) {
+
+	orgName := "an-organization"
+	projectName := "a-project"
+	stackName := "a-stack"
+
+	t.Run("Happy Path", func(t *testing.T) {
+		dsValue := DeploymentSettings{
+			OperationContext: &OperationContext{},
+			GitHub:           &GitHubConfiguration{},
+			SourceContext:    &apitype.SourceContext{},
+			ExecutorContext:  &apitype.ExecutorContext{},
+		}
+
+		c, cleanup := startTestServer(t, testServerConfig{
+			ExpectedReqMethod: http.MethodPost,
+			ExpectedReqPath:   "/" + path.Join("api", "preview", orgName, projectName, stackName, "deployment", "settings"),
+			ResponseCode:      201,
+			ExpectedReqBody:   dsValue,
+		})
+		defer cleanup()
+
+		err := c.CreateDeploymentSettings(ctx, StackName{
+			OrgName:     orgName,
+			ProjectName: projectName,
+			StackName:   stackName,
+		}, dsValue)
+
+		assert.Nil(t, err)
 	})
 }

--- a/provider/pkg/internal/pulumiapi/testutils_test.go
+++ b/provider/pkg/internal/pulumiapi/testutils_test.go
@@ -34,6 +34,7 @@ func startTestServer(t *testing.T, config testServerConfig) (client *Client, cle
 		assert.Equal(t, "token "+token, r.Header.Get("Authorization"))
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Equal(t, "application/vnd.pulumi+8", r.Header.Get("Accept"))
+		assert.Equal(t, "provider", r.Header.Get("X-Pulumi-Source"))
 
 		// if we expected a request body, unmarshal the body and
 		if config.ExpectedReqBody != nil {


### PR DESCRIPTION
Per https://github.com/pulumi/pulumi-service/issues/13821 we want to capture deployment settings source. This PR adds the new header to be consumed by the service to identify requests made by this provider.