### PR TITLE
Adding delete after destroy into deployment settings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+- Support `deleteAfterDestroy` option for the `DeploymentSettings` resource. [#207](https://github.com/pulumi/pulumi-pulumiservice/issues/229)
+
 ### Bug Fixes
 
 ### Miscellaneous

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -329,6 +329,10 @@
         "shell": {
           "type": "string",
           "description": "The shell to use to run commands during the deployment. Defaults to 'bash'."
+        },
+        "deleteAfterDestroy": {
+          "type": "boolean",
+          "description": "Whether the stack should be deleted after it is destroyed."
         }
       }
     },

--- a/provider/pkg/internal/pulumiapi/deployment_settings.go
+++ b/provider/pkg/internal/pulumiapi/deployment_settings.go
@@ -62,6 +62,7 @@ type OperationContextOptions struct {
 	SkipInstallDependencies     bool   `json:"skipInstallDependencies,omitempty"`
 	SkipIntermediateDeployments bool   `json:"skipIntermediateDeployments,omitempty"`
 	Shell                       string `json:"shell,omitempty"`
+	DeleteAfterDestroy          bool   `json:"deleteAfterDestroy,omitempty"`
 }
 
 type GitHubConfiguration struct {

--- a/provider/pkg/provider/deployment_settings.go
+++ b/provider/pkg/provider/deployment_settings.go
@@ -100,6 +100,9 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.Propert
 			if ds.OperationContext.Options.SkipIntermediateDeployments {
 				optionsMap["skipIntermediateDeployments"] = resource.NewPropertyValue(true)
 			}
+			if ds.OperationContext.Options.DeleteAfterDestroy {
+				optionsMap["deleteAfterDestroy"] = resource.NewPropertyValue(true)
+			}
 			ocMap["options"] = resource.PropertyValue{V: optionsMap}
 		}
 		if ds.OperationContext.OIDC != nil {
@@ -383,6 +386,10 @@ func toOperationContext(inputMap resource.PropertyMap) *pulumiapi.OperationConte
 
 		if oInput["Shell"].HasValue() && oInput["Shell"].IsString() {
 			o.Shell = oInput["Shell"].StringValue()
+		}
+
+		if oInput["deleteAfterDestroy"].HasValue() && oInput["deleteAfterDestroy"].IsBool() {
+			o.DeleteAfterDestroy = oInput["deleteAfterDestroy"].BoolValue()
 		}
 
 		oc.Options = &o

--- a/sdk/dotnet/Inputs/OperationContextOptionsArgs.cs
+++ b/sdk/dotnet/Inputs/OperationContextOptionsArgs.cs
@@ -13,6 +13,12 @@ namespace Pulumi.PulumiService.Inputs
     public sealed class OperationContextOptionsArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// Whether the stack should be deleted after it is destroyed.
+        /// </summary>
+        [Input("deleteAfterDestroy")]
+        public Input<bool>? DeleteAfterDestroy { get; set; }
+
+        /// <summary>
         /// The shell to use to run commands during the deployment. Defaults to 'bash'.
         /// </summary>
         [Input("shell")]

--- a/sdk/go/pulumiservice/pulumiTypes.go
+++ b/sdk/go/pulumiservice/pulumiTypes.go
@@ -2129,6 +2129,8 @@ func (o OperationContextOIDCPtrOutput) Gcp() GCPOIDCConfigurationPtrOutput {
 }
 
 type OperationContextOptions struct {
+	// Whether the stack should be deleted after it is destroyed.
+	DeleteAfterDestroy *bool `pulumi:"deleteAfterDestroy"`
 	// The shell to use to run commands during the deployment. Defaults to 'bash'.
 	Shell *string `pulumi:"shell"`
 	// Skip the default dependency installation step - use this to customize the dependency installation (e.g. if using yarn or poetry)
@@ -2149,6 +2151,8 @@ type OperationContextOptionsInput interface {
 }
 
 type OperationContextOptionsArgs struct {
+	// Whether the stack should be deleted after it is destroyed.
+	DeleteAfterDestroy pulumi.BoolPtrInput `pulumi:"deleteAfterDestroy"`
 	// The shell to use to run commands during the deployment. Defaults to 'bash'.
 	Shell pulumi.StringPtrInput `pulumi:"shell"`
 	// Skip the default dependency installation step - use this to customize the dependency installation (e.g. if using yarn or poetry)
@@ -2234,6 +2238,11 @@ func (o OperationContextOptionsOutput) ToOperationContextOptionsPtrOutputWithCon
 	}).(OperationContextOptionsPtrOutput)
 }
 
+// Whether the stack should be deleted after it is destroyed.
+func (o OperationContextOptionsOutput) DeleteAfterDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v OperationContextOptions) *bool { return v.DeleteAfterDestroy }).(pulumi.BoolPtrOutput)
+}
+
 // The shell to use to run commands during the deployment. Defaults to 'bash'.
 func (o OperationContextOptionsOutput) Shell() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v OperationContextOptions) *string { return v.Shell }).(pulumi.StringPtrOutput)
@@ -2271,6 +2280,16 @@ func (o OperationContextOptionsPtrOutput) Elem() OperationContextOptionsOutput {
 		var ret OperationContextOptions
 		return ret
 	}).(OperationContextOptionsOutput)
+}
+
+// Whether the stack should be deleted after it is destroyed.
+func (o OperationContextOptionsPtrOutput) DeleteAfterDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *OperationContextOptions) *bool {
+		if v == nil {
+			return nil
+		}
+		return v.DeleteAfterDestroy
+	}).(pulumi.BoolPtrOutput)
 }
 
 // The shell to use to run commands during the deployment. Defaults to 'bash'.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/OperationContextOptionsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/OperationContextOptionsArgs.java
@@ -17,6 +17,21 @@ public final class OperationContextOptionsArgs extends com.pulumi.resources.Reso
     public static final OperationContextOptionsArgs Empty = new OperationContextOptionsArgs();
 
     /**
+     * Whether the stack should be deleted after it is destroyed.
+     * 
+     */
+    @Import(name="deleteAfterDestroy")
+    private @Nullable Output<Boolean> deleteAfterDestroy;
+
+    /**
+     * @return Whether the stack should be deleted after it is destroyed.
+     * 
+     */
+    public Optional<Output<Boolean>> deleteAfterDestroy() {
+        return Optional.ofNullable(this.deleteAfterDestroy);
+    }
+
+    /**
      * The shell to use to run commands during the deployment. Defaults to &#39;bash&#39;.
      * 
      */
@@ -64,6 +79,7 @@ public final class OperationContextOptionsArgs extends com.pulumi.resources.Reso
     private OperationContextOptionsArgs() {}
 
     private OperationContextOptionsArgs(OperationContextOptionsArgs $) {
+        this.deleteAfterDestroy = $.deleteAfterDestroy;
         this.shell = $.shell;
         this.skipInstallDependencies = $.skipInstallDependencies;
         this.skipIntermediateDeployments = $.skipIntermediateDeployments;
@@ -85,6 +101,27 @@ public final class OperationContextOptionsArgs extends com.pulumi.resources.Reso
 
         public Builder(OperationContextOptionsArgs defaults) {
             $ = new OperationContextOptionsArgs(Objects.requireNonNull(defaults));
+        }
+
+        /**
+         * @param deleteAfterDestroy Whether the stack should be deleted after it is destroyed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder deleteAfterDestroy(@Nullable Output<Boolean> deleteAfterDestroy) {
+            $.deleteAfterDestroy = deleteAfterDestroy;
+            return this;
+        }
+
+        /**
+         * @param deleteAfterDestroy Whether the stack should be deleted after it is destroyed.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder deleteAfterDestroy(Boolean deleteAfterDestroy) {
+            return deleteAfterDestroy(Output.of(deleteAfterDestroy));
         }
 
         /**

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -233,6 +233,10 @@ export interface OperationContextOIDCArgs {
 
 export interface OperationContextOptionsArgs {
     /**
+     * Whether the stack should be deleted after it is destroyed.
+     */
+    deleteAfterDestroy?: pulumi.Input<boolean>;
+    /**
      * The shell to use to run commands during the deployment. Defaults to 'bash'.
      */
     shell?: pulumi.Input<string>;

--- a/sdk/python/pulumi_pulumiservice/_inputs.py
+++ b/sdk/python/pulumi_pulumiservice/_inputs.py
@@ -722,20 +722,36 @@ class OperationContextOIDCArgs:
 @pulumi.input_type
 class OperationContextOptionsArgs:
     def __init__(__self__, *,
+                 delete_after_destroy: Optional[pulumi.Input[bool]] = None,
                  shell: Optional[pulumi.Input[str]] = None,
                  skip_install_dependencies: Optional[pulumi.Input[bool]] = None,
                  skip_intermediate_deployments: Optional[pulumi.Input[bool]] = None):
         """
+        :param pulumi.Input[bool] delete_after_destroy: Whether the stack should be deleted after it is destroyed.
         :param pulumi.Input[str] shell: The shell to use to run commands during the deployment. Defaults to 'bash'.
         :param pulumi.Input[bool] skip_install_dependencies: Skip the default dependency installation step - use this to customize the dependency installation (e.g. if using yarn or poetry)
         :param pulumi.Input[bool] skip_intermediate_deployments: Skip intermediate deployments (Consolidate multiple deployments of the same type into one deployment)
         """
+        if delete_after_destroy is not None:
+            pulumi.set(__self__, "delete_after_destroy", delete_after_destroy)
         if shell is not None:
             pulumi.set(__self__, "shell", shell)
         if skip_install_dependencies is not None:
             pulumi.set(__self__, "skip_install_dependencies", skip_install_dependencies)
         if skip_intermediate_deployments is not None:
             pulumi.set(__self__, "skip_intermediate_deployments", skip_intermediate_deployments)
+
+    @property
+    @pulumi.getter(name="deleteAfterDestroy")
+    def delete_after_destroy(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Whether the stack should be deleted after it is destroyed.
+        """
+        return pulumi.get(self, "delete_after_destroy")
+
+    @delete_after_destroy.setter
+    def delete_after_destroy(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "delete_after_destroy", value)
 
     @property
     @pulumi.getter


### PR DESCRIPTION
### Summary
- Added the parameter into schema, generated SDKs
- Added provider logic to use parameter from schema when calling pulumi cloud

### Testing
- imported generated .Net SDK into local project
- verified in console that `pulumi up` created DeploymentSettings with the `deleteAfterDestroy` flag as expected 