### PR TITLE
Made secret values in Deployment Settings actually work, save and refresh from source of truth

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,6 @@
 
 ### Bug Fixes
 
+- Made secret values in Deployment Settings actually work, save and refresh from source of truth. [#123](https://github.com/pulumi/pulumi-pulumiservice/issues/123)
+
 ### Miscellaneous

--- a/provider/pkg/internal/pulumiapi/deployment_settings.go
+++ b/provider/pkg/internal/pulumiapi/deployment_settings.go
@@ -86,8 +86,11 @@ func (c *Client) GetDeploymentSettings(ctx context.Context, stack StackName) (*D
 	apiPath := path.Join(
 		"stacks", stack.OrgName, stack.ProjectName, stack.StackName, "deployments", "settings",
 	)
+	queryParams := map[string]string{
+		"seeSecrets": "true",
+	}
 	var ds DeploymentSettings
-	_, err := c.do(ctx, http.MethodGet, apiPath, nil, &ds)
+	_, err := c.doWithQuery(ctx, http.MethodGet, apiPath, queryParams, &ds)
 	if err != nil {
 		statusCode := GetErrorStatusCode(err)
 		if statusCode == http.StatusNotFound {

--- a/provider/pkg/internal/pulumiapi/members.go
+++ b/provider/pkg/internal/pulumiapi/members.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -77,7 +77,7 @@ func (c *Client) ListOrgMembers(ctx context.Context, orgName string) (*Members, 
 
 	apiPath := path.Join("orgs", orgName, "members")
 
-	req, err := c.createRequest(ctx, http.MethodGet, apiPath, nil)
+	req, err := c.createRequest(ctx, http.MethodGet, apiPath, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}


### PR DESCRIPTION
### Summary
- Adding ability for client to call GET endpoints with query params (just adding to url didn't work as it got encoded and ? was turned into unicode)
- Adding logic to retrieve deployment settings with secrets on Read operation
- Adjusted logic to properly compare actual values, but only show encrypted values in console
- Other adjusted to prevent comparison of empty fields causing fake drift
- All deploymentSettings's env vars created using this provider will always be secret. I figured adding ability to pick secret or not is out of scope, I can make a followup PR, but schema will neeed to change for that.

### Issues
- [#123](https://github.com/pulumi/pulumi-pulumiservice/issues/123)

### Testing
- tested locally using devstack + DotNet SDK
```
    var settings = new DeploymentSettings(
        "My Settings",
        new DeploymentSettingsArgs{
            Organization = "IaroslavTitov",
            Project = "PulumiDotnet",
            Stack = "SdkTest4",
            SourceContext = new DeploymentSettingsSourceContextArgs{
                Git = new DeploymentSettingsGitSourceArgs{
                    RepoUrl = "https://fake-test.com",
                    Branch = "test",
                    GitAuth = new DeploymentSettingsGitSourceGitAuthArgs {
                        // BasicAuth = new DeploymentSettingsGitAuthBasicAuthArgs{
                        //     Username = "IaroTest",
                        //     Password = "IaroPass"
                        // },
                        SshAuth = new DeploymentSettingsGitAuthSSHAuthArgs{
                            SshPrivateKey = "IaroSshKey",
                            Password = "IaroSshPass"
                        }
                    }
                }
            },
            OperationContext = new DeploymentSettingsOperationContextArgs{
                EnvironmentVariables = new InputMap<string>
                {
                    { "IaroEnvVarKey", "IaroEnvVarSecret" }
                }
            }
        }
    );
```

Results in values in the resource explorer like so:
```
{
  "git": {
    "branch": "test",
    "gitAuth": {
      "sshAuth": {
        "password": {
          "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
          "ciphertext": "AAABAEsoaNBwL887is1BhzC9c/9JCiErA3v8T0K9pu/ta8Bsk93WXHkuPYGS"
        },
        "sshPrivateKey": {
          "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
          "ciphertext": "AAABALukLwq5StYjQQugxJwlS3bXLm55DSrUgVI58U0FzLpztzPDoXpPiF4="
        }
      }
    },
    "repoUrl": "https://fake-test.com"
  }
}
```

but refresh now shows no change UNLESS there was actual change.
