### PR TITLE
Fixing refresh breaking drift and ttl schedule

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,6 @@
 
 ### Bug Fixes
 
+- Fixed refresh breaking schedules bug [#257](https://github.com/pulumi/pulumi-pulumiservice/issues/257)
+
 ### Miscellaneous

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -1109,7 +1109,8 @@
         },
         "autoRemediate": {
           "description": "Whether any drift detected should be remediated after a drift run.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "scheduleId": {
           "description": "Schedule ID of the created schedule, assigned by Pulumi Cloud.",
@@ -1142,7 +1143,8 @@
         },
         "autoRemediate": {
           "description": "Whether any drift detected should be remediated after a drift run.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
       "requiredInputs": [
@@ -1173,7 +1175,8 @@
         },
         "deleteAfterDestroy": {
           "description": "True if the stack and all associated history and settings should be deleted.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "scheduleId": {
           "description": "Schedule ID of the created schedule, assigned by Pulumi Cloud.",
@@ -1206,7 +1209,8 @@
         },
         "deleteAfterDestroy": {
           "description": "True if the stack and all associated history and settings should be deleted.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
       "requiredInputs": [

--- a/provider/pkg/provider/deployment_schedules.go
+++ b/provider/pkg/provider/deployment_schedules.go
@@ -142,14 +142,18 @@ func ScheduleSharedDiff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, er
 		return nil, err
 	}
 
-	// preprocess olds to remove the `scheduleId` property since it's only an output and shouldn't cause a diff
-	if olds["scheduleId"].HasValue() {
-		delete(olds, "scheduleId")
-	}
-
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
+	}
+
+	return ScheduleSharedDiffMaps(olds, news)
+}
+
+func ScheduleSharedDiffMaps(olds resource.PropertyMap, news resource.PropertyMap) (*pulumirpc.DiffResponse, error) {
+	// preprocess olds to remove the `scheduleId` property since it's only an output and shouldn't cause a diff
+	if olds["scheduleId"].HasValue() {
+		delete(olds, "scheduleId")
 	}
 
 	diffs := olds.Diff(news)
@@ -342,7 +346,7 @@ func (st *PulumiServiceDeploymentScheduleResource) Read(req *pulumirpc.ReadReque
 	}
 
 	outputProperties, err := plugin.MarshalProperties(
-		input.ToPropertyMap(),
+		AddScheduleIdToPropertyMap(*scheduleID, input.ToPropertyMap()),
 		plugin.MarshalOptions{
 			KeepUnknowns: true,
 			SkipNulls:    true,

--- a/sdk/dotnet/DriftSchedule.cs
+++ b/sdk/dotnet/DriftSchedule.cs
@@ -128,6 +128,7 @@ namespace Pulumi.PulumiService
 
         public DriftScheduleArgs()
         {
+            AutoRemediate = false;
         }
         public static new DriftScheduleArgs Empty => new DriftScheduleArgs();
     }

--- a/sdk/dotnet/TtlSchedule.cs
+++ b/sdk/dotnet/TtlSchedule.cs
@@ -128,6 +128,7 @@ namespace Pulumi.PulumiService
 
         public TtlScheduleArgs()
         {
+            DeleteAfterDestroy = false;
         }
         public static new TtlScheduleArgs Empty => new TtlScheduleArgs();
     }

--- a/sdk/go/pulumiservice/driftSchedule.go
+++ b/sdk/go/pulumiservice/driftSchedule.go
@@ -49,6 +49,9 @@ func NewDriftSchedule(ctx *pulumi.Context,
 	if args.Stack == nil {
 		return nil, errors.New("invalid value for required argument 'Stack'")
 	}
+	if args.AutoRemediate == nil {
+		args.AutoRemediate = pulumi.BoolPtr(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource DriftSchedule
 	err := ctx.RegisterResource("pulumiservice:index:DriftSchedule", name, args, &resource, opts...)

--- a/sdk/go/pulumiservice/ttlSchedule.go
+++ b/sdk/go/pulumiservice/ttlSchedule.go
@@ -49,6 +49,9 @@ func NewTtlSchedule(ctx *pulumi.Context,
 	if args.Timestamp == nil {
 		return nil, errors.New("invalid value for required argument 'Timestamp'")
 	}
+	if args.DeleteAfterDestroy == nil {
+		args.DeleteAfterDestroy = pulumi.BoolPtr(false)
+	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource TtlSchedule
 	err := ctx.RegisterResource("pulumiservice:index:TtlSchedule", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/DriftScheduleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/DriftScheduleArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
@@ -226,6 +227,7 @@ public final class DriftScheduleArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public DriftScheduleArgs build() {
+            $.autoRemediate = Codegen.booleanProp("autoRemediate").output().arg($.autoRemediate).def(false).getNullable();
             if ($.organization == null) {
                 throw new MissingRequiredPropertyException("DriftScheduleArgs", "organization");
             }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlScheduleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlScheduleArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
@@ -226,6 +227,7 @@ public final class TtlScheduleArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public TtlScheduleArgs build() {
+            $.deleteAfterDestroy = Codegen.booleanProp("deleteAfterDestroy").output().arg($.deleteAfterDestroy).def(false).getNullable();
             if ($.organization == null) {
                 throw new MissingRequiredPropertyException("TtlScheduleArgs", "organization");
             }

--- a/sdk/nodejs/driftSchedule.ts
+++ b/sdk/nodejs/driftSchedule.ts
@@ -82,7 +82,7 @@ export class DriftSchedule extends pulumi.CustomResource {
             if ((!args || args.stack === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'stack'");
             }
-            resourceInputs["autoRemediate"] = args ? args.autoRemediate : undefined;
+            resourceInputs["autoRemediate"] = (args ? args.autoRemediate : undefined) ?? false;
             resourceInputs["organization"] = args ? args.organization : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["scheduleCron"] = args ? args.scheduleCron : undefined;

--- a/sdk/nodejs/ttlSchedule.ts
+++ b/sdk/nodejs/ttlSchedule.ts
@@ -82,7 +82,7 @@ export class TtlSchedule extends pulumi.CustomResource {
             if ((!args || args.timestamp === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'timestamp'");
             }
-            resourceInputs["deleteAfterDestroy"] = args ? args.deleteAfterDestroy : undefined;
+            resourceInputs["deleteAfterDestroy"] = (args ? args.deleteAfterDestroy : undefined) ?? false;
             resourceInputs["organization"] = args ? args.organization : undefined;
             resourceInputs["project"] = args ? args.project : undefined;
             resourceInputs["stack"] = args ? args.stack : undefined;

--- a/sdk/python/pulumi_pulumiservice/drift_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/drift_schedule.py
@@ -31,6 +31,8 @@ class DriftScheduleArgs:
         pulumi.set(__self__, "project", project)
         pulumi.set(__self__, "schedule_cron", schedule_cron)
         pulumi.set(__self__, "stack", stack)
+        if auto_remediate is None:
+            auto_remediate = False
         if auto_remediate is not None:
             pulumi.set(__self__, "auto_remediate", auto_remediate)
 
@@ -155,6 +157,8 @@ class DriftSchedule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = DriftScheduleArgs.__new__(DriftScheduleArgs)
 
+            if auto_remediate is None:
+                auto_remediate = False
             __props__.__dict__["auto_remediate"] = auto_remediate
             if organization is None and not opts.urn:
                 raise TypeError("Missing required property 'organization'")

--- a/sdk/python/pulumi_pulumiservice/ttl_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/ttl_schedule.py
@@ -31,6 +31,8 @@ class TtlScheduleArgs:
         pulumi.set(__self__, "project", project)
         pulumi.set(__self__, "stack", stack)
         pulumi.set(__self__, "timestamp", timestamp)
+        if delete_after_destroy is None:
+            delete_after_destroy = False
         if delete_after_destroy is not None:
             pulumi.set(__self__, "delete_after_destroy", delete_after_destroy)
 
@@ -155,6 +157,8 @@ class TtlSchedule(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = TtlScheduleArgs.__new__(TtlScheduleArgs)
 
+            if delete_after_destroy is None:
+                delete_after_destroy = False
             __props__.__dict__["delete_after_destroy"] = delete_after_destroy
             if organization is None and not opts.urn:
                 raise TypeError("Missing required property 'organization'")


### PR DESCRIPTION
### Summary
- Fixing 2 bugs:
- [First](https://github.com/pulumi/pulumi-pulumiservice/issues/257) is me forgetting to add scheduleId to output properties on Read
- Second one I discovered while working on the first one, when booleans are not provided, they are still saved to output state, which causes eternal diff when running pulumi update. Not sure how I missed that originally.

### Testing
- make build and install
- Tested locally using Dotnet SDK