### PR TITLE
Fixing build workflow

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -59,20 +59,24 @@ jobs:
         run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v4
+        if: ${{ matrix.language == 'go' }}
         with:
           go-version: ${{ matrix.goversion }}
           cache-dependency-path: sdk/go.sum
       - name: Setup Node
         uses: actions/setup-node@v3
+        if: ${{ matrix.language == 'nodejs' }}
         with:
           node-version: ${{matrix.nodeversion}}
           registry-url: https://registry.npmjs.org
       - name: Setup DotNet
         uses: actions/setup-dotnet@v3
+        if: ${{ matrix.language == 'dotnet' }}
         with:
           dotnet-version: ${{matrix.dotnetversion}}
       - name: Setup Python
         uses: actions/setup-python@v4
+        if: ${{ matrix.language == 'python' }}
         with:
           python-version: ${{matrix.pythonversion}}
       - name: Set up JDK 11

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ yarn.lock
 ci-scripts
 /nuget/
 **/version.txt
+.mono
+go


### PR DESCRIPTION
### Summary
- The main build and test workflow has been failing for my PRs:
 - https://github.com/pulumi/pulumi-pulumiservice/pull/259
 - https://github.com/pulumi/pulumi-pulumiservice/pull/260
- As far as I understood the issue, some dependency now leaves a folder called `go` with this in it:
```
go/pkg/mod/cache/download/github.com/pulumi/pulumi/pkg/v3/@v:
list
v3.112.0.info
v3.112.0.mod
```

I just set to ignore it in .gitignore, is there a better solution maybe? I figured it was not worth tracking down where it comes from, since this looks like some package metadata, lmk if we care to find out what leaves that behind.

Also:
- Adding '.mono` to gitignore, dotnet compilation keeps generating it
- Adding logic to not install not needed languages, which speeds up tests a little