### PR TITLE
Fixing goreleaser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate --timeout
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout
           60m0s
         version: latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 1 release --rm-dist --timeout 90m0s
+        args: -p 1 release --clean --timeout 90m0s
         version: latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
The parameter we were using got deprecated and now is called --clean, as per their [docs](https://goreleaser.com/deprecations/#__tabbed_17_2)