### PR TITLE
Fixing collision issues on environment names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,4 +4,6 @@
 
 ### Bug Fixes
 
+- Fixed environment tests breaking due to name collision [#296](https://github.com/pulumi/pulumi-pulumiservice/issues/296)
+
 ### Miscellaneous

--- a/examples/cs-environments/MyStack.cs
+++ b/examples/cs-environments/MyStack.cs
@@ -6,6 +6,7 @@ class MyStack : Stack
 {
     public MyStack()
     {
+        var config = new Pulumi.Config();
         String yaml = """
         values:
           myKey1: "myValue1"
@@ -18,7 +19,7 @@ class MyStack : Stack
             "testing-environment",
             new EnvironmentArgs {
                 Organization = "service-provider-test-org",
-                Name = "testing-environment-cs",
+                Name = "testing-environment-cs-" + config.Require("digits"),
                 Yaml = new StringAsset(yaml)
             }
         );

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -35,9 +35,13 @@ func TestDotnetSchedulesExamples(t *testing.T) {
 }
 
 func TestDotnetEnvironmentsExamples(t *testing.T) {
+	digits := generateRandomFiveDigits()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:         path.Join(getCwd(t), "cs-environments"),
 		SkipRefresh: true,
+		Config: map[string]string{
+			"digits": digits,
+		},
 		Dependencies: []string{
 			"Pulumi.PulumiService",
 		},

--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -20,10 +20,14 @@ func TestGoTeamsExample(t *testing.T) {
 }
 
 func TestGoEnvironmentsExample(t *testing.T) {
+	digits := generateRandomFiveDigits()
 	testOpts := getGoBaseOptions(t).With(integration.ProgramTestOptions{
 		Verbose:     true,
 		Dir:         filepath.Join(getCwd(t), "go-environments"),
 		SkipRefresh: true,
+		Config: map[string]string{
+			"digits": digits,
+		},
 	})
 	integration.ProgramTest(t, &testOpts)
 }

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -102,8 +102,12 @@ func TestNodejsSchedulesExample(t *testing.T) {
 
 func TestNodejsEnvironmentsExample(t *testing.T) {
 	cwd := getCwd(t)
+	digits := generateRandomFiveDigits()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: path.Join(cwd, ".", "ts-environments"),
+		Config: map[string]string{
+			"digits": digits,
+		},
 		Dependencies: []string{
 			"@pulumi/pulumiservice",
 		},

--- a/examples/examples_python_test.go
+++ b/examples/examples_python_test.go
@@ -34,9 +34,13 @@ func TestPythonDeploymentSettingsExample(t *testing.T) {
 }
 
 func TestPythonEnvironmentsExample(t *testing.T) {
+	digits := generateRandomFiveDigits()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:         path.Join(getCwd(t), "py-environments"),
 		SkipRefresh: true,
+		Config: map[string]string{
+			"digits": digits,
+		},
 		Dependencies: []string{
 			filepath.Join("..", "sdk", "python", "bin"),
 		},

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -267,8 +267,12 @@ func TestYamlSchedulesExample(t *testing.T) {
 
 func TestYamlEnvironmentsExample(t *testing.T) {
 	cwd := getCwd(t)
+	digits := generateRandomFiveDigits()
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: path.Join(cwd, ".", "yaml-environments"),
+		Config: map[string]string{
+			"digits": digits,
+		},
 		PrepareProject: func(p *engine.Projinfo) error {
 			return nil
 		},

--- a/examples/go-environments/main.go
+++ b/examples/go-environments/main.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		conf := config.New(ctx, "")
 		environment, err := pulumiservice.NewEnvironment(ctx, "testing-environment", &pulumiservice.EnvironmentArgs{
-			Name:         pulumi.String("testing-environment-go"),
+			Name:         pulumi.String("testing-environment-go-" + conf.Require("digits")),
 			Organization: pulumi.String("service-provider-test-org"),
 			Yaml: pulumi.NewStringAsset(`
             values:

--- a/examples/py-environments/__main__.py
+++ b/examples/py-environments/__main__.py
@@ -4,10 +4,12 @@ import pulumi
 from pulumi_pulumiservice import Environment, EnvironmentVersionTag
 from pulumi import ResourceOptions
 
+config = pulumi.Config()
+
 environment = Environment(
     "testing-environment",
     organization="service-provider-test-org",
-    name="testing-environment-py",
+    name="testing-environment-py-"+config.require('digits'),
     yaml=pulumi.StringAsset("""
         values:
           myKey1: "myValue1"

--- a/examples/ts-environments/index.ts
+++ b/examples/ts-environments/index.ts
@@ -1,9 +1,11 @@
 import * as service from "@pulumi/pulumiservice";
 import * as pulumi from "@pulumi/pulumi";
 
+let config = new pulumi.Config();
+
 var environment = new service.Environment("testing-environment", {
   organization: "service-provider-test-org",
-  name: "testing-environment-ts",
+  name: "testing-environment-ts-"+config.require("digits"),
   yaml: new pulumi.asset.StringAsset(
 `values:
   myKey1: "myValue1"

--- a/examples/yaml-environments/Pulumi.yaml
+++ b/examples/yaml-environments/Pulumi.yaml
@@ -6,7 +6,7 @@ resources:
     type: pulumiservice:Environment
     properties:
       organization: service-provider-test-org
-      name: testing-environment-yaml
+      name: testing-environment-yaml-${digits}
       yaml:
         fn::stringAsset: |-
           values:


### PR DESCRIPTION
### Summary
- When 2 or more workflows run at the same time, sometimes tests break due to name collisions
- This commit eliminates that issue, removing annoying ops to clean and retry the environment

### Testing
- Auto-tested by GHA 