### PR TITLE
Updating deprecated goreleaser flag in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip-validate --timeout
+        args: -p 3 -f .goreleaser.prerelease.yml --clean --skip=validate --timeout
           60m0s
         version: latest
     strategy:


### PR DESCRIPTION
Another goreleaser deprecation, source - https://goreleaser.com/deprecations/?h=skip+validate#-skip

This is needed to fix main workflow