### PR TITLE
Moving from GetOlds to GetOldInputs to avoid having to manually remove properties

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,5 @@
 - Fixed environment tests breaking due to name collision [#296](https://github.com/pulumi/pulumi-pulumiservice/issues/296)
 
 ### Miscellaneous
+
+- Migrated all Diff methods to use GetOldInputs instead of GetOlds to avoid manually removing properties [#297](https://github.com/pulumi/pulumi-pulumiservice/issues/297)

--- a/provider/pkg/internal/serde/property_map.go
+++ b/provider/pkg/internal/serde/property_map.go
@@ -64,7 +64,7 @@ func FromPropertyMap(properties resource.PropertyMap, structTagName string, out 
 
 // DiffOldsAndNews unmarshals a DiffRequest and runs a diff on them. It returns any keys changed
 func DiffOldsAndNews(req *pulumirpc.DiffRequest) ([]string, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/access_token.go
+++ b/provider/pkg/provider/access_token.go
@@ -135,7 +135,7 @@ func (at *PulumiServiceAccessTokenResource) deleteAccessToken(ctx context.Contex
 }
 
 func diffAccessTokenProperties(req *pulumirpc.DiffRequest, replaceProps []string) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/agent_pool.go
+++ b/provider/pkg/provider/agent_pool.go
@@ -54,16 +54,9 @@ func (ap *PulumiServiceAgentPoolResource) Name() string {
 }
 
 func (ap *PulumiServiceAgentPoolResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
-	}
-
-	// preprocess olds to remove the `tokenValue & agentPoolId` property since it's only an output and shouldn't cause a diff
-	for _, p := range []resource.PropertyKey{"tokenValue", "agentPoolId"} {
-		if olds[p].HasValue() {
-			delete(olds, p)
-		}
 	}
 
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
@@ -167,7 +160,7 @@ func (ap *PulumiServiceAgentPoolResource) Update(req *pulumirpc.UpdateRequest) (
 		return nil, fmt.Errorf("invalid resource id: %v", err)
 	}
 
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/deployment_schedules.go
+++ b/provider/pkg/provider/deployment_schedules.go
@@ -137,7 +137,7 @@ func ToPulumiServiceSharedScheduleOutput(properties *structpb.Struct) (*PulumiSe
 }
 
 func ScheduleSharedDiff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}
@@ -151,11 +151,6 @@ func ScheduleSharedDiff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, er
 }
 
 func ScheduleSharedDiffMaps(olds resource.PropertyMap, news resource.PropertyMap) (*pulumirpc.DiffResponse, error) {
-	// preprocess olds to remove the `scheduleId` property since it's only an output and shouldn't cause a diff
-	if olds["scheduleId"].HasValue() {
-		delete(olds, "scheduleId")
-	}
-
 	diffs := olds.Diff(news)
 	if diffs == nil {
 		return &pulumirpc.DiffResponse{

--- a/provider/pkg/provider/deployment_settings.go
+++ b/provider/pkg/provider/deployment_settings.go
@@ -488,7 +488,7 @@ func getSecretOrStringValue(prop resource.PropertyValue) string {
 }
 
 func (ds *PulumiServiceDeploymentSettingsResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/drift_schedules.go
+++ b/provider/pkg/provider/drift_schedules.go
@@ -63,7 +63,7 @@ func ToPulumiServiceDriftScheduleInput(properties *structpb.Struct) (*PulumiServ
 }
 
 func (st *PulumiServiceDriftScheduleResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/environment.go
+++ b/provider/pkg/provider/environment.go
@@ -82,7 +82,7 @@ func ToPulumiServiceEnvironmentInput(properties *structpb.Struct) (*PulumiServic
 }
 
 func (st *PulumiServiceEnvironmentResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}
@@ -90,11 +90,6 @@ func (st *PulumiServiceEnvironmentResource) Diff(req *pulumirpc.DiffRequest) (*p
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
-	}
-
-	// preprocess olds to remove the `revision` property since it's only an output and shouldn't cause a diff
-	if olds["revision"].HasValue() {
-		delete(olds, "revision")
 	}
 
 	diffs := olds.Diff(news)

--- a/provider/pkg/provider/environment_version_tags.go
+++ b/provider/pkg/provider/environment_version_tags.go
@@ -40,7 +40,7 @@ func (evt *PulumiServiceEnvironmentVersionTagResource) Name() string {
 }
 
 func (evt *PulumiServiceEnvironmentVersionTagResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/stack_tags.go
+++ b/provider/pkg/provider/stack_tags.go
@@ -43,7 +43,7 @@ func (st *PulumiServiceStackTagResource) Name() string {
 }
 
 func (st *PulumiServiceStackTagResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -161,7 +161,7 @@ func (t *PulumiServiceTeamResource) Delete(req *pulumirpc.DeleteRequest) (*pbemp
 }
 
 func (t *PulumiServiceTeamResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/ttl_schedules.go
+++ b/provider/pkg/provider/ttl_schedules.go
@@ -67,7 +67,7 @@ func ToPulumiServiceTtlScheduleInput(properties *structpb.Struct) (*PulumiServic
 }
 
 func (st *PulumiServiceTtlScheduleResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/webhook.go
+++ b/provider/pkg/provider/webhook.go
@@ -246,14 +246,9 @@ func (wh *PulumiServiceWebhookResource) createWebhook(input PulumiServiceWebhook
 }
 
 func (wh *PulumiServiceWebhookResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
+	olds, err := plugin.UnmarshalProperties(req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {
 		return nil, err
-	}
-
-	// preprocess olds to remove the `name` property since it's only an output and shouldn't cause a diff
-	if olds["name"].HasValue() {
-		delete(olds, "name")
 	}
 
 	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})


### PR DESCRIPTION
### Summary
- Moving all Diff methods to compare inputs rather than final properties
- This way we don't need to remove properties to avoid a diff, code is more straightforward

### Testing
- All the resources are checked for diff by integ tests
- Testing envrionment resource manually