### PR TITLE
Fixing Schedules import

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Fixed environment tests breaking due to name collision [#296](https://github.com/pulumi/pulumi-pulumiservice/issues/296)
+- Fixed import for Schedules [#270](https://github.com/pulumi/pulumi-pulumiservice/issues/270)
 
 ### Miscellaneous
 

--- a/provider/pkg/internal/pulumiapi/schedules_test.go
+++ b/provider/pkg/internal/pulumiapi/schedules_test.go
@@ -32,7 +32,14 @@ var createTtlScheduleReq = CreateTtlScheduleRequest{
 	DeleteAfterDestroy: true,
 }
 var testResponse = ScheduleResponse{
-	ID: testScheduleID,
+	ID:           testScheduleID,
+	ScheduleOnce: nil,
+	ScheduleCron: &cron,
+	Definition: ScheduleDefinition{
+		Request: CreateDeploymentRequest{
+			PulumiOperation: "update",
+		},
+	},
 }
 
 func TestCreateDeploymentSchedule(t *testing.T) {
@@ -78,9 +85,9 @@ func TestGetDeploymentSchedule(t *testing.T) {
 			ResponseBody:      testResponse,
 		})
 		defer cleanup()
-		expectedScheduleID, err := c.GetSchedule(ctx, testStack, testScheduleID)
+		response, err := c.GetSchedule(ctx, testStack, testScheduleID)
 		assert.NoError(t, err)
-		assert.Equal(t, testScheduleID, *expectedScheduleID)
+		assert.Equal(t, testResponse, *response)
 	})
 
 	t.Run("Error", func(t *testing.T) {


### PR DESCRIPTION
### Summary
- Reworked Read method to read using values from id, which allows import of values

### Testing
- Tested using below commands:
- `pulumi import pulumiservice:index:DriftSchedule importedthing2 IaroslavTitov/PulumiDotnet/SdkTest5/ttl/c940d27b-d563-4f07-8833-9f2d14baa32b`
- `pulumi import pulumiservice:index:TtlSchedule importedthing2 IaroslavTitov/PulumiDotnet/SdkTest5/ttl/c940d27b-d563-4f07-8833-9f2d14baa32b`
- `pulumi import pulumiservice:index:DeploymentSchedule importedthing3 IaroslavTitov/PulumiDotnet/SdkTest5/539430ce-96e9-4228-a5a2-5a3cd138d0df`

I had to grab schedule id's using browser tools, but we already have an issue to address that -  https://github.com/pulumi/pulumi-service/issues/20094