### PR TITLE
Fixing Read failure of 404 from Pulumi Service

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+- Fixed Read failure on 404 from Pulumi Service [#312](https://github.com/pulumi/pulumi-pulumiservice/issues/312)
 - Fixed environment tests breaking due to name collision [#296](https://github.com/pulumi/pulumi-pulumiservice/issues/296)
 - Fixed import for Schedules [#270](https://github.com/pulumi/pulumi-pulumiservice/issues/270)
 - Fixed noisy refresh for Team resource [#314](https://github.com/pulumi/pulumi-pulumiservice/pull/314)

--- a/provider/pkg/provider/environment_version_tags.go
+++ b/provider/pkg/provider/environment_version_tags.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
 
@@ -163,8 +164,8 @@ func (evt *PulumiServiceEnvironmentVersionTagResource) Read(req *pulumirpc.ReadR
 	}
 
 	tag, err := evt.client.GetEnvironmentRevisionTag(ctx, input.Organization, input.Environment, input.TagName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read StackTag (%q): %w", req.Id, err)
+	if err != nil && !strings.Contains(err.Error(), "404") {
+		return nil, fmt.Errorf("failed to read EnvironmentVersionTag (%q): %w", req.Id, err)
 	}
 	if tag == nil {
 		// if the tag doesn't exist, then return empty response


### PR DESCRIPTION
### Summary
- The crux of the issues turned out that ESC client lumps in 404 with other errors
- So we need to NOT throw error on 404, but instead just return empty response

###Testing
- Follow repro steps after fix, bug no longer happens