### PR TITLE
Fix noisy refresh for team resource

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,11 +1,12 @@
 ### Improvements
 
-- Added Update logic to Deplyoment Settings resourse [#299](https://github.com/pulumi/pulumi-pulumiservice/issues/299)
+- Added Update logic to Deployment Settings resource [#299](https://github.com/pulumi/pulumi-pulumiservice/issues/299)
 
 ### Bug Fixes
 
 - Fixed environment tests breaking due to name collision [#296](https://github.com/pulumi/pulumi-pulumiservice/issues/296)
 - Fixed import for Schedules [#270](https://github.com/pulumi/pulumi-pulumiservice/issues/270)
+- Fixed noisy refresh for Team resource [#314](https://github.com/pulumi/pulumi-pulumiservice/pull/314)
 
 ### Miscellaneous
 

--- a/examples/yaml-teams/Pulumi.yaml
+++ b/examples/yaml-teams/Pulumi.yaml
@@ -13,7 +13,6 @@ resources:
     properties:
       name: brand-new-yaml-team-${rand.result}
       organizationName: service-provider-test-org
-      displayName: PulumiUP Team
       teamType: pulumi
       members:
         - pulumi-bot

--- a/provider/pkg/provider/team.go
+++ b/provider/pkg/provider/team.go
@@ -291,14 +291,14 @@ func (t *PulumiServiceTeamResource) Create(req *pulumirpc.CreateRequest) (*pulum
 	}
 
 	inputsTeam := ToPulumiServiceTeamInput(inputs)
-	team, err := t.createTeam(ctx, inputsTeam)
+	teamUrn, err := t.createTeam(ctx, inputsTeam)
 	if err != nil {
-		return nil, fmt.Errorf("error creating team '%s': %s", inputsTeam.Name, err.Error())
+		return nil, fmt.Errorf("error creating teamUrn '%s': %s", inputsTeam.Name, err.Error())
 	}
 
-	// We have now created a team.  It is very important to ensure that from this point on, any other error
+	// We have now created a teamUrn.  It is very important to ensure that from this point on, any other error
 	// below returns the ID using the `pulumirpc.ErrorResourceInitFailed` error details annotation.  Otherwise,
-	// we leak a team resource. We ensure that we wrap any errors in a partial error and return that to the RPC.
+	// we leak a teamUrn resource. We ensure that we wrap any errors in a partial error and return that to the RPC.
 
 	// make copy of input so we can safely modify output without affecting input
 	inProgTeam := ToPulumiServiceTeamInput(inputsTeam.ToPropertyMap())
@@ -307,20 +307,37 @@ func (t *PulumiServiceTeamResource) Create(req *pulumirpc.CreateRequest) (*pulum
 	for _, memberToAdd := range inputsTeam.Members {
 		err := t.addToTeam(ctx, inputsTeam.OrganizationName, inputsTeam.Name, memberToAdd)
 		if err != nil {
-			return nil, partialError(*team, err, inProgTeam, inputsTeam)
+			return nil, partialError(*teamUrn, err, inProgTeam, inputsTeam)
 		}
-		// if we've successfully added member to team, save them to the state we're going to return
-		// so that a re-run can detect the left over members to add via Update
-		inProgTeam.Members = append(inProgTeam.Members, memberToAdd)
 	}
 
-	outputProperties, err := inProgTeam.ToRpc()
+	// Outputs should be the result of a GetTeam call, so we can return the full teamUrn object with fidelity
+	// including all new members that were added.
+	team, err := t.client.GetTeam(ctx, inputsTeam.OrganizationName, inputsTeam.Name)
 	if err != nil {
-		return nil, partialError(*team, err, inProgTeam, inputsTeam)
+		return nil, partialError(*teamUrn, err, inProgTeam, inputsTeam)
+	}
+	outputs := PulumiServiceTeamInput{
+		Description:      team.Description,
+		DisplayName:      team.DisplayName,
+		Name:             team.Name,
+		Type:             team.Type,
+		OrganizationName: inputsTeam.OrganizationName,
+	}
+	for _, m := range team.Members {
+		outputs.Members = append(outputs.Members, m.GithubLogin)
+	}
+
+	// Sort the members so the order is deterministic
+	slices.Sort(outputs.Members)
+
+	outputProperties, err := outputs.ToRpc()
+	if err != nil {
+		return nil, partialError(*teamUrn, err, outputs, inputsTeam)
 	}
 
 	return &pulumirpc.CreateResponse{
-		Id:         *team,
+		Id:         *teamUrn,
 		Properties: outputProperties,
 	}, nil
 }


### PR DESCRIPTION
### Testing

I updated a test. Previously, if you didn't define the team display name there would be a diff on refresh to add a new output for the display name. Now there is no diff.

Fixes #278 