### PR TITLE
Fixing Deployment Secrets - Parallel Values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+- Introduced secrets in Deployment Settings, fixed refresh and import [#123](https://github.com/pulumi/pulumi-pulumiservice/issues/123)
+
 ### Miscellaneous
 
 - Fixed integ tests [#328](https://github.com/pulumi/pulumi-pulumiservice/issues/328)

--- a/provider/pkg/internal/pulumiapi/deployment_setting_test.go
+++ b/provider/pkg/internal/pulumiapi/deployment_setting_test.go
@@ -19,7 +19,7 @@ func TestGetDeploymentSettings(t *testing.T) {
 		dsValue := DeploymentSettings{
 			OperationContext: &OperationContext{},
 			GitHub:           &GitHubConfiguration{},
-			SourceContext:    &apitype.SourceContext{},
+			SourceContext:    &SourceContext{},
 			ExecutorContext:  &apitype.ExecutorContext{},
 		}
 
@@ -74,24 +74,26 @@ func TestCreateDeploymentSettings(t *testing.T) {
 		dsValue := DeploymentSettings{
 			OperationContext: &OperationContext{},
 			GitHub:           &GitHubConfiguration{},
-			SourceContext:    &apitype.SourceContext{},
+			SourceContext:    &SourceContext{},
 			ExecutorContext:  &apitype.ExecutorContext{},
 		}
 
 		c, cleanup := startTestServer(t, testServerConfig{
-			ExpectedReqMethod: http.MethodPost,
+			ExpectedReqMethod: http.MethodPut,
 			ExpectedReqPath:   "/" + path.Join("api", "stacks", orgName, projectName, stackName, "deployments", "settings"),
 			ResponseCode:      201,
 			ExpectedReqBody:   dsValue,
+			ResponseBody:      dsValue,
 		})
 		defer cleanup()
 
-		err := c.CreateDeploymentSettings(ctx, StackName{
+		response, err := c.CreateDeploymentSettings(ctx, StackName{
 			OrgName:     orgName,
 			ProjectName: projectName,
 			StackName:   stackName,
 		}, dsValue)
 
 		assert.Nil(t, err)
+		assert.Equal(t, dsValue, *response)
 	})
 }

--- a/provider/pkg/provider/deployment_setting_test.go
+++ b/provider/pkg/provider/deployment_setting_test.go
@@ -17,11 +17,11 @@ type DeploymentSettingsClientMock struct {
 	getDeploymentSettingsFunc getDeploymentSettingsFunc
 }
 
-func (c *DeploymentSettingsClientMock) CreateDeploymentSettings(ctx context.Context, stack pulumiapi.StackName, ds pulumiapi.DeploymentSettings) error {
-	return nil
+func (c *DeploymentSettingsClientMock) CreateDeploymentSettings(ctx context.Context, stack pulumiapi.StackName, ds pulumiapi.DeploymentSettings) (*pulumiapi.DeploymentSettings, error) {
+	return nil, nil
 }
-func (c *DeploymentSettingsClientMock) UpdateDeploymentSettings(ctx context.Context, stack pulumiapi.StackName, ds pulumiapi.DeploymentSettings) error {
-	return nil
+func (c *DeploymentSettingsClientMock) UpdateDeploymentSettings(ctx context.Context, stack pulumiapi.StackName, ds pulumiapi.DeploymentSettings) (*pulumiapi.DeploymentSettings, error) {
+	return nil, nil
 }
 func (c *DeploymentSettingsClientMock) GetDeploymentSettings(ctx context.Context, stack pulumiapi.StackName) (*pulumiapi.DeploymentSettings, error) {
 	return c.getDeploymentSettingsFunc()
@@ -64,7 +64,7 @@ func TestDeploymentSettings(t *testing.T) {
 				return &pulumiapi.DeploymentSettings{
 					OperationContext: &pulumiapi.OperationContext{},
 					GitHub:           &pulumiapi.GitHubConfiguration{},
-					SourceContext:    &apitype.SourceContext{},
+					SourceContext:    &pulumiapi.SourceContext{},
 					ExecutorContext:  &apitype.ExecutorContext{},
 				}, nil
 			},

--- a/provider/pkg/provider/deployment_settings.go
+++ b/provider/pkg/provider/deployment_settings.go
@@ -14,14 +14,16 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
+// This is a value for imported secrets, to hint that value needs to be replaced
+// in generated code
+const replaceMe = "<REPLACE WITH ACTUAL SECRET VALUE>"
+
 type PulumiServiceDeploymentSettingsInput struct {
 	pulumiapi.DeploymentSettings
 	Stack pulumiapi.StackName
 }
 
-const FixMe = "<value is secret and must be replaced>"
-
-func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.PropertyMap {
+func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap(plaintextSettings *pulumiapi.DeploymentSettings, oldCipherSettings *pulumiapi.DeploymentSettings, isInput bool) resource.PropertyMap {
 	pm := resource.PropertyMap{}
 	pm["organization"] = resource.NewPropertyValue(ds.Stack.OrgName)
 	pm["project"] = resource.NewPropertyValue(ds.Stack.ProjectName)
@@ -52,10 +54,47 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.Propert
 				if ds.SourceContext.Git.GitAuth.SSHAuth != nil {
 					sshAuthPropertyMap := resource.PropertyMap{}
 					if ds.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey.Value != "" {
-						sshAuthPropertyMap["sshPrivateKey"] = resource.NewPropertyValue(FixMe)
+						if plaintextSettings == nil {
+							importSecretValue(sshAuthPropertyMap, "sshPrivateKey", ds.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey, isInput)
+						} else {
+							if oldCipherSettings == nil {
+								createSecretValue(sshAuthPropertyMap, "sshPrivateKey", ds.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey,
+									plaintextSettings.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey)
+							} else {
+								if oldCipherSettings.SourceContext != nil &&
+									oldCipherSettings.SourceContext.Git != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth.SSHAuth != nil {
+									mergeSecretValue(sshAuthPropertyMap, "sshPrivateKey", ds.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey,
+										plaintextSettings.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey,
+										oldCipherSettings.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey)
+								} else {
+									importSecretValue(sshAuthPropertyMap, "sshPrivateKey", ds.SourceContext.Git.GitAuth.SSHAuth.SSHPrivateKey, isInput)
+								}
+							}
+						}
 					}
 					if ds.SourceContext.Git.GitAuth.SSHAuth.Password.Value != "" {
-						sshAuthPropertyMap["password"] = resource.NewPropertyValue(FixMe)
+						if plaintextSettings == nil {
+							importSecretValue(sshAuthPropertyMap, "password", *ds.SourceContext.Git.GitAuth.SSHAuth.Password, isInput)
+						} else {
+							if oldCipherSettings == nil {
+								createSecretValue(sshAuthPropertyMap, "password", *ds.SourceContext.Git.GitAuth.SSHAuth.Password,
+									*plaintextSettings.SourceContext.Git.GitAuth.SSHAuth.Password)
+							} else {
+								if oldCipherSettings.SourceContext != nil &&
+									oldCipherSettings.SourceContext.Git != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth.SSHAuth != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth.SSHAuth.Password != nil {
+									mergeSecretValue(sshAuthPropertyMap, "password", *ds.SourceContext.Git.GitAuth.SSHAuth.Password,
+										*plaintextSettings.SourceContext.Git.GitAuth.SSHAuth.Password,
+										*oldCipherSettings.SourceContext.Git.GitAuth.SSHAuth.Password)
+								} else {
+									importSecretValue(sshAuthPropertyMap, "password", *ds.SourceContext.Git.GitAuth.SSHAuth.Password, isInput)
+								}
+							}
+						}
 					}
 					gitAuthPropertyMap["sshAuth"] = resource.PropertyValue{V: sshAuthPropertyMap}
 				}
@@ -65,9 +104,27 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.Propert
 						basicAuthPropertyMap["username"] = resource.NewPropertyValue(ds.SourceContext.Git.GitAuth.BasicAuth.UserName.Value)
 					}
 					if ds.SourceContext.Git.GitAuth.BasicAuth.Password.Value != "" {
-						basicAuthPropertyMap["password"] = resource.NewPropertyValue("fix me")
+						if plaintextSettings == nil {
+							importSecretValue(basicAuthPropertyMap, "password", ds.SourceContext.Git.GitAuth.BasicAuth.Password, isInput)
+						} else {
+							if oldCipherSettings == nil {
+								createSecretValue(basicAuthPropertyMap, "password", ds.SourceContext.Git.GitAuth.BasicAuth.Password,
+									plaintextSettings.SourceContext.Git.GitAuth.BasicAuth.Password)
+							} else {
+								if oldCipherSettings.SourceContext != nil &&
+									oldCipherSettings.SourceContext.Git != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth != nil &&
+									oldCipherSettings.SourceContext.Git.GitAuth.BasicAuth != nil {
+									mergeSecretValue(basicAuthPropertyMap, "password", ds.SourceContext.Git.GitAuth.BasicAuth.Password,
+										plaintextSettings.SourceContext.Git.GitAuth.BasicAuth.Password,
+										oldCipherSettings.SourceContext.Git.GitAuth.BasicAuth.Password)
+								} else {
+									importSecretValue(basicAuthPropertyMap, "password", ds.SourceContext.Git.GitAuth.BasicAuth.Password, isInput)
+								}
+							}
+						}
 					}
-					gitAuthPropertyMap["basicAuth"] = resource.NewPropertyValue(basicAuthPropertyMap)
+					gitAuthPropertyMap["basicAuth"] = resource.PropertyValue{V: basicAuthPropertyMap}
 				}
 				gitPropertyMap["gitAuth"] = resource.PropertyValue{V: gitAuthPropertyMap}
 			}
@@ -83,14 +140,49 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.Propert
 		}
 		if ds.OperationContext.EnvironmentVariables != nil {
 			evMap := resource.PropertyMap{}
+			evMapCipher := resource.PropertyMap{}
 			for k, v := range ds.OperationContext.EnvironmentVariables {
 				if v.Secret {
-					evMap[resource.PropertyKey(k)] = resource.NewPropertyValue(FixMe)
+					if plaintextSettings == nil {
+						// Import
+						if isInput {
+							evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(replaceMe))
+						} else {
+							evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(""))
+						}
+						evMapCipher[resource.PropertyKey(k)] = resource.NewPropertyValue(v.Value)
+					} else {
+						if oldCipherSettings == nil {
+							// Create
+							evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(plaintextSettings.OperationContext.EnvironmentVariables[k].Value))
+							evMapCipher[resource.PropertyKey(k)] = resource.NewPropertyValue(v.Value)
+						} else {
+							if oldCipherSettings.OperationContext != nil {
+								// Merge
+								if v.Value == oldCipherSettings.OperationContext.EnvironmentVariables[k].Value {
+									evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(plaintextSettings.OperationContext.EnvironmentVariables[k].Value))
+								} else {
+									evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(""))
+								}
+								evMapCipher[resource.PropertyKey(k)] = resource.NewPropertyValue(v.Value)
+							} else {
+								// Import
+								if isInput {
+									evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(replaceMe))
+								} else {
+									evMap[resource.PropertyKey(k)] = resource.MakeSecret(resource.NewPropertyValue(""))
+								}
+								evMapCipher[resource.PropertyKey(k)] = resource.NewPropertyValue(v.Value)
+							}
+						}
+					}
 				} else {
 					evMap[resource.PropertyKey(k)] = resource.NewPropertyValue(v.Value)
+					evMapCipher[resource.PropertyKey(k)] = resource.NewPropertyValue("")
 				}
 			}
 			ocMap["environmentVariables"] = resource.PropertyValue{V: evMap}
+			ocMap["environmentVariablesCipher"] = resource.PropertyValue{V: evMapCipher}
 		}
 		if ds.OperationContext.Options != nil {
 			optionsMap := resource.PropertyMap{}
@@ -189,11 +281,36 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap() resource.Propert
 	return pm
 }
 
+func importSecretValue(propertyMap resource.PropertyMap, propertyName string, cipherValue pulumiapi.SecretValue, isInput bool) {
+	propertyMap[resource.PropertyKey(propertyName)] = resource.MakeSecret(resource.NewPropertyValue(""))
+	propertyMap[resource.PropertyKey(propertyName+"Cipher")] = resource.NewPropertyValue(cipherValue.Value)
+
+	// Adding this for code generation
+	if isInput {
+		propertyMap[resource.PropertyKey(propertyName)] = resource.MakeSecret(resource.NewPropertyValue(replaceMe))
+	}
+}
+
+func createSecretValue(propertyMap resource.PropertyMap, propertyName string, cipherValue pulumiapi.SecretValue, plaintextValue pulumiapi.SecretValue) {
+	propertyMap[resource.PropertyKey(propertyName)] = resource.MakeSecret(resource.NewPropertyValue(plaintextValue.Value))
+	propertyMap[resource.PropertyKey(propertyName+"Cipher")] = resource.NewPropertyValue(cipherValue.Value)
+}
+
+func mergeSecretValue(propertyMap resource.PropertyMap, propertyName string, cipherValue pulumiapi.SecretValue, plaintextValue pulumiapi.SecretValue, oldCipherValue pulumiapi.SecretValue) {
+	propertyMap[resource.PropertyKey(propertyName+"Cipher")] = resource.NewPropertyValue(cipherValue.Value)
+
+	if cipherValue.Value == oldCipherValue.Value {
+		propertyMap[resource.PropertyKey(propertyName)] = resource.MakeSecret(resource.NewPropertyValue(plaintextValue.Value))
+	} else {
+		propertyMap[resource.PropertyKey(propertyName)] = resource.MakeSecret(resource.NewPropertyValue(""))
+	}
+}
+
 type PulumiServiceDeploymentSettingsResource struct {
 	client pulumiapi.DeploymentSettingsClient
 }
 
-func (ds *PulumiServiceDeploymentSettingsResource) ToPulumiServiceDeploymentSettingsInput(inputMap resource.PropertyMap) PulumiServiceDeploymentSettingsInput {
+func (ds *PulumiServiceDeploymentSettingsResource) ToPulumiServiceDeploymentSettingsInput(inputMap resource.PropertyMap, gettingPlaintext bool) PulumiServiceDeploymentSettingsInput {
 	input := PulumiServiceDeploymentSettingsInput{}
 
 	input.Stack.OrgName = getSecretOrStringValue(inputMap["organization"])
@@ -206,8 +323,8 @@ func (ds *PulumiServiceDeploymentSettingsResource) ToPulumiServiceDeploymentSett
 
 	input.ExecutorContext = toExecutorContext(inputMap)
 	input.GitHub = toGitHubConfig(inputMap)
-	input.SourceContext = toSourceContext(inputMap)
-	input.OperationContext = toOperationContext(inputMap)
+	input.SourceContext = toSourceContext(inputMap, gettingPlaintext)
+	input.OperationContext = toOperationContext(inputMap, gettingPlaintext)
 
 	return input
 }
@@ -264,17 +381,17 @@ func toGitHubConfig(inputMap resource.PropertyMap) *pulumiapi.GitHubConfiguratio
 	return &github
 }
 
-func toSourceContext(inputMap resource.PropertyMap) *apitype.SourceContext {
+func toSourceContext(inputMap resource.PropertyMap, gettingPlaintext bool) *pulumiapi.SourceContext {
 	if !inputMap["sourceContext"].HasValue() || !inputMap["sourceContext"].IsObject() {
 		return nil
 	}
 
 	scInput := inputMap["sourceContext"].ObjectValue()
-	var sc apitype.SourceContext
+	var sc pulumiapi.SourceContext
 
 	if scInput["git"].HasValue() && scInput["git"].IsObject() {
 		gitInput := scInput["git"].ObjectValue()
-		var g apitype.SourceContextGit
+		var g pulumiapi.SourceContextGit
 
 		if gitInput["repoUrl"].HasValue() {
 			g.RepoURL = getSecretOrStringValue(gitInput["repoUrl"])
@@ -288,22 +405,22 @@ func toSourceContext(inputMap resource.PropertyMap) *apitype.SourceContext {
 
 		if gitInput["gitAuth"].HasValue() && gitInput["gitAuth"].IsObject() {
 			authInput := gitInput["gitAuth"].ObjectValue()
-			var a apitype.GitAuthConfig
+			var a pulumiapi.GitAuthConfig
 
 			if authInput["sshAuth"].HasValue() && authInput["sshAuth"].IsObject() {
 				sshInput := authInput["sshAuth"].ObjectValue()
-				var s apitype.SSHAuth
+				var s pulumiapi.SSHAuth
 
-				if sshInput["sshPrivateKey"].HasValue() {
-					s.SSHPrivateKey = apitype.SecretValue{
+				if sshInput["sshPrivateKey"].HasValue() || sshInput["sshPrivateKeyCipher"].HasValue() {
+					s.SSHPrivateKey = pulumiapi.SecretValue{
 						Secret: true,
-						Value:  getSecretOrStringValue(sshInput["sshPrivateKey"]),
+						Value:  getTwinSecretValue(sshInput, "sshPrivateKey", gettingPlaintext),
 					}
 				}
-				if sshInput["password"].HasValue() {
-					s.Password = &apitype.SecretValue{
+				if sshInput["password"].HasValue() || sshInput["passwordCipher"].HasValue() {
+					s.Password = &pulumiapi.SecretValue{
 						Secret: true,
-						Value:  getSecretOrStringValue(sshInput["password"]),
+						Value:  getTwinSecretValue(sshInput, "password", gettingPlaintext),
 					}
 				}
 
@@ -312,17 +429,17 @@ func toSourceContext(inputMap resource.PropertyMap) *apitype.SourceContext {
 
 			if authInput["basicAuth"].HasValue() && authInput["basicAuth"].IsObject() {
 				basicInput := authInput["basicAuth"].ObjectValue()
-				var b apitype.BasicAuth
+				var b pulumiapi.BasicAuth
 
 				if basicInput["username"].HasValue() {
-					b.UserName = apitype.SecretValue{
+					b.UserName = pulumiapi.SecretValue{
 						Value:  getSecretOrStringValue(basicInput["username"]),
 						Secret: false,
 					}
 				}
-				if basicInput["password"].HasValue() {
-					b.Password = apitype.SecretValue{
-						Value:  getSecretOrStringValue(basicInput["password"]),
+				if basicInput["password"].HasValue() || basicInput["passwordCipher"].HasValue() {
+					b.Password = pulumiapi.SecretValue{
+						Value:  getTwinSecretValue(basicInput, "password", gettingPlaintext),
 						Secret: true,
 					}
 				}
@@ -339,7 +456,7 @@ func toSourceContext(inputMap resource.PropertyMap) *apitype.SourceContext {
 	return &sc
 }
 
-func toOperationContext(inputMap resource.PropertyMap) *pulumiapi.OperationContext {
+func toOperationContext(inputMap resource.PropertyMap, gettingPlaintext bool) *pulumiapi.OperationContext {
 	if !inputMap["operationContext"].HasValue() || !inputMap["operationContext"].IsObject() {
 		return nil
 	}
@@ -347,19 +464,30 @@ func toOperationContext(inputMap resource.PropertyMap) *pulumiapi.OperationConte
 	ocInput := inputMap["operationContext"].ObjectValue()
 	var oc pulumiapi.OperationContext
 
-	if ocInput["environmentVariables"].HasValue() && ocInput["environmentVariables"].IsObject() {
-		ev := map[string]apitype.SecretValue{}
-		evInput := ocInput["environmentVariables"].ObjectValue()
+	if gettingPlaintext {
+		if ocInput["environmentVariables"].HasValue() && ocInput["environmentVariables"].IsObject() {
+			ev := map[string]pulumiapi.SecretValue{}
+			evInput := ocInput["environmentVariables"].ObjectValue()
 
-		for k, v := range evInput {
-			if v.IsSecret() {
-				ev[string(k)] = apitype.SecretValue{Secret: true, Value: v.SecretValue().Element.StringValue()}
-			} else {
-				ev[string(k)] = apitype.SecretValue{Secret: false, Value: v.StringValue()}
+			for k, v := range evInput {
+				value := getSecretOrStringValue(v)
+				ev[string(k)] = pulumiapi.SecretValue{Secret: v.IsSecret(), Value: value}
 			}
-		}
 
-		oc.EnvironmentVariables = ev
+			oc.EnvironmentVariables = ev
+		}
+	} else {
+		if ocInput["environmentVariablesCipher"].HasValue() && ocInput["environmentVariablesCipher"].IsObject() {
+			ev := map[string]pulumiapi.SecretValue{}
+			evInput := ocInput["environmentVariablesCipher"].ObjectValue()
+
+			for k, v := range evInput {
+				value := getSecretOrStringValue(v)
+				ev[string(k)] = pulumiapi.SecretValue{Secret: v.IsSecret(), Value: value}
+			}
+
+			oc.EnvironmentVariables = ev
+		}
 	}
 
 	if ocInput["preRunCommands"].HasValue() && ocInput["preRunCommands"].IsArray() {
@@ -482,8 +610,22 @@ func getSecretOrStringValue(prop resource.PropertyValue) string {
 	switch prop.V.(type) {
 	case *resource.Secret:
 		return prop.SecretValue().Element.StringValue()
+	case nil:
+		return ""
 	default:
 		return prop.StringValue()
+	}
+}
+
+func getTwinSecretValue(propertyMap resource.PropertyMap, key string, gettingPlaintext bool) string {
+	if gettingPlaintext {
+		if propertyMap[resource.PropertyKey(key)].HasValue() {
+			return getSecretOrStringValue(propertyMap[resource.PropertyKey(key)])
+		} else {
+			return getSecretOrStringValue(propertyMap[resource.PropertyKey(key)])
+		}
+	} else {
+		return getSecretOrStringValue(propertyMap[resource.PropertyKey(key+"Cipher")])
 	}
 }
 
@@ -577,11 +719,39 @@ func (ds *PulumiServiceDeploymentSettingsResource) Read(req *pulumirpc.ReadReque
 		DeploymentSettings: *settings,
 	}
 
-	properties, err := plugin.MarshalProperties(
-		dsInput.ToPropertyMap(),
-		plugin.MarshalOptions{},
-	)
+	var plaintextSettings *pulumiapi.DeploymentSettings = nil
+	var ciphertextSettings *pulumiapi.DeploymentSettings = nil
+	inputMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
+	if err != nil {
+		return nil, err
+	}
+	if inputMap["stack"].HasValue() {
+		tempPlain := ds.ToPulumiServiceDeploymentSettingsInput(inputMap, true)
+		plaintextSettings = &tempPlain.DeploymentSettings
+		tempCipher := ds.ToPulumiServiceDeploymentSettingsInput(inputMap, false)
+		ciphertextSettings = &tempCipher.DeploymentSettings
+	}
 
+	properties, err := plugin.MarshalProperties(
+		dsInput.ToPropertyMap(plaintextSettings, ciphertextSettings, false),
+		plugin.MarshalOptions{
+			KeepUnknowns: true,
+			SkipNulls:    true,
+			KeepSecrets:  true,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	inputs, err := plugin.MarshalProperties(
+		dsInput.ToPropertyMap(plaintextSettings, ciphertextSettings, true),
+		plugin.MarshalOptions{
+			KeepUnknowns: true,
+			SkipNulls:    true,
+			KeepSecrets:  true,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -589,21 +759,18 @@ func (ds *PulumiServiceDeploymentSettingsResource) Read(req *pulumirpc.ReadReque
 	return &pulumirpc.ReadResponse{
 		Id:         req.Id,
 		Properties: properties,
-		Inputs:     properties,
+		Inputs:     inputs,
 	}, nil
 }
 
 func (ds *PulumiServiceDeploymentSettingsResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
 	ctx := context.Background()
-	inputsMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
-	if err != nil {
+	var stack pulumiapi.StackName
+	if err := stack.FromID(req.Id); err != nil {
 		return nil, err
 	}
-	inputs := ds.ToPulumiServiceDeploymentSettingsInput(inputsMap)
-	if err != nil {
-		return nil, err
-	}
-	err = ds.client.DeleteDeploymentSettings(ctx, inputs.Stack)
+
+	err := ds.client.DeleteDeploymentSettings(ctx, stack)
 	if err != nil {
 		return nil, err
 	}
@@ -617,15 +784,34 @@ func (ds *PulumiServiceDeploymentSettingsResource) Create(req *pulumirpc.CreateR
 	if err != nil {
 		return nil, err
 	}
-	inputs := ds.ToPulumiServiceDeploymentSettingsInput(inputsMap)
-	settings := inputs.DeploymentSettings
-	err = ds.client.CreateDeploymentSettings(ctx, inputs.Stack, settings)
+
+	input := ds.ToPulumiServiceDeploymentSettingsInput(inputsMap, true)
+	settings := input.DeploymentSettings
+	response, err := ds.client.CreateDeploymentSettings(ctx, input.Stack, settings)
 	if err != nil {
 		return nil, err
 	}
+
+	responseInput := PulumiServiceDeploymentSettingsInput{
+		DeploymentSettings: *response,
+		Stack:              input.Stack,
+	}
+
+	outputProperties, err := plugin.MarshalProperties(
+		responseInput.ToPropertyMap(&input.DeploymentSettings, nil, false),
+		plugin.MarshalOptions{
+			KeepUnknowns: true,
+			SkipNulls:    true,
+			KeepSecrets:  true,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &pulumirpc.CreateResponse{
-		Id:         path.Join(inputs.Stack.OrgName, inputs.Stack.ProjectName, inputs.Stack.StackName),
-		Properties: req.GetProperties(),
+		Id:         path.Join(input.Stack.OrgName, input.Stack.ProjectName, input.Stack.StackName),
+		Properties: outputProperties,
 	}, nil
 }
 
@@ -637,15 +823,32 @@ func (ds *PulumiServiceDeploymentSettingsResource) Update(req *pulumirpc.UpdateR
 		return nil, err
 	}
 
-	inputs := ds.ToPulumiServiceDeploymentSettingsInput(inputsMap)
-	settings := inputs.DeploymentSettings
-	err = ds.client.UpdateDeploymentSettings(ctx, inputs.Stack, settings)
+	input := ds.ToPulumiServiceDeploymentSettingsInput(inputsMap, true)
+	settings := input.DeploymentSettings
+	response, err := ds.client.UpdateDeploymentSettings(ctx, input.Stack, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	responseInput := PulumiServiceDeploymentSettingsInput{
+		DeploymentSettings: *response,
+		Stack:              input.Stack,
+	}
+
+	outputProperties, err := plugin.MarshalProperties(
+		responseInput.ToPropertyMap(&input.DeploymentSettings, nil, false),
+		plugin.MarshalOptions{
+			KeepUnknowns: true,
+			SkipNulls:    true,
+			KeepSecrets:  true,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
 
 	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
+		Properties: outputProperties,
 	}, nil
 }
 


### PR DESCRIPTION
Note: this is an alternative approach for PR - https://github.com/pulumi/pulumi-pulumiservice/pull/325

### Summary

- Added logic to save cipher and plaintext separately, allowing comparison on refresh of just ciphertext, fixing https://github.com/pulumi/pulumi-pulumiservice/issues/123
- Import now works as well, including code generation (with dummy values for secrets)
- Migrated to new PUT API and updated client to actually return DeploymentSettings

### Testing
- Tested pulumi up, refresh, import and up from previous version of the provider (for unchanged DS inputs, migrating to this new way of saving will require refresh and then up)

Example TS program (Sadly can't use Dotnet, due to bug with maps):
```
const settings = new service.DeploymentSettings("deployment_settings", {
  organization: "IaroslavTitov",
  project: "PulumiDotnet",
  stack: "SdkTest5",
  operationContext: {
    environmentVariables: {
      TEST_VAR: "fooa",
      SECRET_VAR: config.requireSecret("my_secret"),
    }
  },
  sourceContext: {
    git: {
        repoUrl: "https://github.com/pulumi/deploy-demos.git",
        branch: "refs/heads/main",
        repoDir: "pulumi-programs/simple-resource",
        gitAuth: {
            sshAuth: {
                sshPrivateKey: "privatekey",
                password: secret,
            }
        }
    }
}
});

Secret resource values end up split into cipher and plaintext like this:
```
        "sshPrivateKeyCipher": "AAABAJrXK3j7+jgXLJI9Q30JnAFDxek6yUyYudh3h2SU4/dQKyBl",
        "sshPrivateKey": {
          "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
          "ciphertext": "AAABAKlREY4tsjd1bbWc8JXPaABRqG6BeVxfUkhO1ob70Q=="
        }
```
twin values for each secret. Environment variables ciphers are stored in a separate variable `environmentVariablesCipher`

Passwords and sshKey are forced into twin secrets, Environment Variables are optionally twin secrets, everything else uses normal Pulumi workdlows, because they are not secret in Pulumi Service.

Import of the above code generates successfully with dummy values for secrets:
```
const ds1 = new pulumiservice.DeploymentSettings("ds1", {
    operationContext: {
        environmentVariables: {
            SECRET_VAR: pulumi.secret("<REPLACE WITH ACTUAL SECRET VALUE>"),
            TEST_VAR: "fooa",
        },
    },
    organization: "IaroslavTitov",
    project: "PulumiDotnet",
    sourceContext: {
        git: {
            branch: "refs/heads/main",
            gitAuth: {
                sshAuth: {
                    password: pulumi.secret("<REPLACE WITH ACTUAL SECRET VALUE>"),
                    sshPrivateKey: pulumi.secret("<REPLACE WITH ACTUAL SECRET VALUE>"),
                },
            },
            repoDir: "pulumi-programs/simple-resource",
            repoUrl: "https://github.com/pulumi/deploy-demos.git",
        },
    },
    stack: "SdkTest5",
}, {
    protect: true,
});
```