### PR TITLE
Pin Twine to a good version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -278,7 +278,7 @@ jobs:
         path: ${{ github.workspace }}/sdk/
     - name: uncompress java sdk
       run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
-    - run: python -m pip install pip twine
+    - run: python -m pip install pip twine==5.0.0
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       name: Publish SDKs


### PR DESCRIPTION
Python SDK publishing broke with the latest version of importlib. See https://github.com/pulumi/pulumi-pulumiservice/actions/runs/9670567679/job/26679789077#step:21:216

See https://github.com/pulumi/ci-mgmt/pull/999/files