### PR TITLE
Refactoring AccessToken Read method

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+- Fixed import by refactoring Read method of AccessToken resource + minor refactor [#311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 
 ### Miscellaneous

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -564,10 +564,6 @@
     "pulumiservice:index:AccessToken": {
       "description": "Access tokens allow a user to authenticate against the Pulumi Cloud",
       "properties": {
-        "tokenId": {
-          "description": "The token identifier.",
-          "type": "string"
-        },
         "description": {
           "description": "Description of the access token.",
           "type": "string"
@@ -579,7 +575,6 @@
         }
       },
       "required": [
-        "tokenId",
         "description",
         "value"
       ],

--- a/sdk/dotnet/AccessToken.cs
+++ b/sdk/dotnet/AccessToken.cs
@@ -22,12 +22,6 @@ namespace Pulumi.PulumiService
         public Output<string> Description { get; private set; } = null!;
 
         /// <summary>
-        /// The token identifier.
-        /// </summary>
-        [Output("tokenId")]
-        public Output<string> TokenId { get; private set; } = null!;
-
-        /// <summary>
         /// The token's value.
         /// </summary>
         [Output("value")]

--- a/sdk/go/pulumiservice/accessToken.go
+++ b/sdk/go/pulumiservice/accessToken.go
@@ -18,8 +18,6 @@ type AccessToken struct {
 
 	// Description of the access token.
 	Description pulumi.StringOutput `pulumi:"description"`
-	// The token identifier.
-	TokenId pulumi.StringOutput `pulumi:"tokenId"`
 	// The token's value.
 	Value pulumi.StringOutput `pulumi:"value"`
 }
@@ -171,11 +169,6 @@ func (o AccessTokenOutput) ToAccessTokenOutputWithContext(ctx context.Context) A
 // Description of the access token.
 func (o AccessTokenOutput) Description() pulumi.StringOutput {
 	return o.ApplyT(func(v *AccessToken) pulumi.StringOutput { return v.Description }).(pulumi.StringOutput)
-}
-
-// The token identifier.
-func (o AccessTokenOutput) TokenId() pulumi.StringOutput {
-	return o.ApplyT(func(v *AccessToken) pulumi.StringOutput { return v.TokenId }).(pulumi.StringOutput)
 }
 
 // The token's value.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
@@ -34,20 +34,6 @@ public class AccessToken extends com.pulumi.resources.CustomResource {
         return this.description;
     }
     /**
-     * The token identifier.
-     * 
-     */
-    @Export(name="tokenId", refs={String.class}, tree="[0]")
-    private Output<String> tokenId;
-
-    /**
-     * @return The token identifier.
-     * 
-     */
-    public Output<String> tokenId() {
-        return this.tokenId;
-    }
-    /**
      * The token&#39;s value.
      * 
      */

--- a/sdk/nodejs/accessToken.ts
+++ b/sdk/nodejs/accessToken.ts
@@ -39,10 +39,6 @@ export class AccessToken extends pulumi.CustomResource {
      */
     public readonly description!: pulumi.Output<string>;
     /**
-     * The token identifier.
-     */
-    public /*out*/ readonly tokenId!: pulumi.Output<string>;
-    /**
      * The token's value.
      */
     public /*out*/ readonly value!: pulumi.Output<string>;
@@ -62,11 +58,9 @@ export class AccessToken extends pulumi.CustomResource {
                 throw new Error("Missing required property 'description'");
             }
             resourceInputs["description"] = args ? args.description : undefined;
-            resourceInputs["tokenId"] = undefined /*out*/;
             resourceInputs["value"] = undefined /*out*/;
         } else {
             resourceInputs["description"] = undefined /*out*/;
-            resourceInputs["tokenId"] = undefined /*out*/;
             resourceInputs["value"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);

--- a/sdk/python/pulumi_pulumiservice/access_token.py
+++ b/sdk/python/pulumi_pulumiservice/access_token.py
@@ -85,7 +85,6 @@ class AccessToken(pulumi.CustomResource):
             if description is None and not opts.urn:
                 raise TypeError("Missing required property 'description'")
             __props__.__dict__["description"] = description
-            __props__.__dict__["token_id"] = None
             __props__.__dict__["value"] = None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
@@ -112,7 +111,6 @@ class AccessToken(pulumi.CustomResource):
         __props__ = AccessTokenArgs.__new__(AccessTokenArgs)
 
         __props__.__dict__["description"] = None
-        __props__.__dict__["token_id"] = None
         __props__.__dict__["value"] = None
         return AccessToken(resource_name, opts=opts, __props__=__props__)
 
@@ -123,14 +121,6 @@ class AccessToken(pulumi.CustomResource):
         Description of the access token.
         """
         return pulumi.get(self, "description")
-
-    @property
-    @pulumi.getter(name="tokenId")
-    def token_id(self) -> pulumi.Output[str]:
-        """
-        The token identifier.
-        """
-        return pulumi.get(self, "token_id")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
### Summary
- `tokenId` property is not used anywhere at all, lol. The output tokenId is used as the resourceId, making this one useless
- Eliminated use of req.GetProperties in AccessToken, which fixed import

### Testing 
- pulumi import pulumiservice:index:AccessToken hui a7a15253-0108-4e39-89ff-3cd8859adba5