### PR TITLE
Adding Changedlog_Pending to ignore list of main GHA workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -392,6 +392,7 @@ name: main
     - main
     paths-ignore:
     - CHANGELOG.md
+    - CHANGELOG_PENDING.md
     tags-ignore:
     - v*
     - sdk/*

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,4 @@
 - Fixed import by refactoring Read method of AgentPool resource + minor refactor [#311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 
 ### Miscellaneous
+- Added CHANGELOG_PENDING file to ignore-list of the `main` workflow [[#340](https://github.com/pulumi/pulumi-pulumiservice/issues/340)]


### PR DESCRIPTION
### Summary
- See https://github.com/pulumi/pulumi-pulumiservice/issues/340 for example - main workflow is triggered and fails on just codefreeze PRs. It doesn't really need to run at all, it only triggered because CHANGELOG_PENDING was not on the ignore list like CHANGELOG is