### PR TITLE
Fixing noisy diff in DS OIDC object

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,6 @@
 ### Bug Fixes
 - Fixed import by refactoring Read method of AccessToken resource + minor refactor [#311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 - Fixed import by refactoring Read method of AgentPool resource + minor refactor [#311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
+- Fixing noisy diff in DS OIDC object [#330](https://github.com/pulumi/pulumi-pulumiservice/issues/330)
 
 ### Miscellaneous

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -40,9 +40,8 @@ func TestDeploymentSettingsExample(t *testing.T) {
 			"my_secret": "my_secret_value",
 			"password":  "my_password",
 		},
-		Quick:       true,
-		SkipRefresh: true,
-		Dir:         path.Join(cwd, ".", "ts-deployment-settings"),
+		Quick: true,
+		Dir:   path.Join(cwd, ".", "ts-deployment-settings"),
 		Dependencies: []string{
 			"@pulumi/pulumiservice",
 		},

--- a/examples/examples_python_test.go
+++ b/examples/examples_python_test.go
@@ -21,8 +21,7 @@ func TestPythonTeamsExample(t *testing.T) {
 
 func TestPythonDeploymentSettingsExample(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:         path.Join(getCwd(t), "py-deployment-settings"),
-		SkipRefresh: true,
+		Dir: path.Join(getCwd(t), "py-deployment-settings"),
 		Config: map[string]string{
 			"my-secret": "my-secret-value",
 		},

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -186,10 +186,9 @@ func TestYamlDeploymentSettingsExample(t *testing.T) {
 	digits := generateRandomFiveDigits()
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Quick:       true,
-		SkipRefresh: true,
-		Dir:         path.Join(cwd, ".", "yaml-deployment-settings"),
-		StackName:   "test-stack-" + digits,
+		Quick:     true,
+		Dir:       path.Join(cwd, ".", "yaml-deployment-settings"),
+		StackName: "test-stack-" + digits,
 		Config: map[string]string{
 			"digits": digits,
 		},


### PR DESCRIPTION
### Summary
- Fixed diff in azure object by actually adding it to the call - it was missed accidentally
- Fixed diff in aws object's duration field by normalizing the string in Check method, the same way Pulumi Service does (conversion into time.Duration and back into string)
- Removing SkipRefresh flag, now that DeploymentSettings are fully without diff

### Testing
- Manual test using TS program
- Integ tests