### PR TITLE
Fixed Read method for OrgAccessToken

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,6 @@
 
 ### Bug Fixes
 - Fixed import by refactoring Read method of EnvironmentVersionTag resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
+- Fixed import by refactoring Read method of OrgAccessToken resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 
 ### Miscellaneous

--- a/examples/yaml-org-token/Pulumi.yaml
+++ b/examples/yaml-org-token/Pulumi.yaml
@@ -14,3 +14,4 @@ resources:
       name: test-${rand.result}
       organizationName: service-provider-test-org
       description: "example org access token"
+      admin: false

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -761,7 +761,8 @@
         },
         "admin": {
           "description": "Optional. True if this is an admin token.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         }
       },
       "requiredInputs": [

--- a/provider/pkg/internal/pulumiapi/accesstokens.go
+++ b/provider/pkg/internal/pulumiapi/accesstokens.go
@@ -23,8 +23,10 @@ import (
 
 type AccessToken struct {
 	ID          string `json:"id"`
+	Name        string `json:"name"`
 	TokenValue  string `json:"tokenValue"`
 	Description string `json:"description"`
+	Admin       bool   `json:"admin"`
 }
 
 type createTokenResponse struct {
@@ -38,8 +40,10 @@ type createTokenRequest struct {
 
 type accessTokenResponse struct {
 	ID          string `json:"id"`
+	Name        string `json:"name"`
 	Description string `json:"description"`
 	LastUsed    int    `json:"lastUsed"`
+	Admin       bool   `json:"admin"`
 }
 
 type listTokenResponse struct {

--- a/provider/pkg/internal/pulumiapi/orgtokens.go
+++ b/provider/pkg/internal/pulumiapi/orgtokens.go
@@ -103,7 +103,9 @@ func (c *Client) GetOrgAccessToken(ctx context.Context, tokenId, orgName string)
 		if token.ID == tokenId {
 			return &AccessToken{
 				ID:          token.ID,
+				Name:        token.Name,
 				Description: token.Description,
+				Admin:       token.Admin,
 			}, nil
 		}
 	}

--- a/provider/pkg/provider/org_access_token.go
+++ b/provider/pkg/provider/org_access_token.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/internal/pulumiapi"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -22,6 +23,26 @@ type PulumiServiceOrgAccessTokenInput struct {
 	Description string
 	Name        string
 	Admin       bool
+}
+
+func GenerateOrgAccessTokenProperties(input PulumiServiceOrgAccessTokenInput, orgAccessToken pulumiapi.AccessToken) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
+	inputMap := input.ToPropertyMap()
+
+	outputMap := inputMap.Copy()
+	outputMap["__inputs"] = resource.NewObjectProperty(inputMap)
+	outputMap["value"] = resource.MakeSecret(resource.NewPropertyValue(orgAccessToken.TokenValue))
+
+	inputs, err = plugin.MarshalProperties(inputMap, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	outputs, err = plugin.MarshalProperties(outputMap, plugin.MarshalOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return outputs, inputs, err
 }
 
 func (i *PulumiServiceOrgAccessTokenInput) ToPropertyMap() resource.PropertyMap {
@@ -76,39 +97,26 @@ func (ot *PulumiServiceOrgAccessTokenResource) Delete(req *pulumirpc.DeleteReque
 
 func (ot *PulumiServiceOrgAccessTokenResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
 	ctx := context.Background()
-	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	inputMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}
 
-	inputsAccessToken := ot.ToPulumiServiceOrgAccessTokenInput(inputs)
+	input := ot.ToPulumiServiceOrgAccessTokenInput(inputMap)
 
-	accessToken, err := ot.createOrgAccessToken(ctx, inputsAccessToken)
+	accessToken, err := ot.createOrgAccessToken(ctx, input)
 	if err != nil {
-		return nil, fmt.Errorf("error creating access token '%s': %s", inputsAccessToken.Name, err.Error())
+		return nil, fmt.Errorf("error creating access token '%s': %s", input.Name, err.Error())
 	}
 
-	outputStore := resource.PropertyMap{}
-	outputStore["__inputs"] = resource.NewObjectProperty(inputs)
-	outputStore["name"] = inputs["name"]
-	outputStore["organizationName"] = inputs["organizationName"]
-	outputStore["description"] = inputs["description"]
-	outputStore["admin"] = inputs["admin"]
-	outputStore["value"] = resource.NewPropertyValue(accessToken.TokenValue)
-
-	outputProperties, err := plugin.MarshalProperties(
-		outputStore,
-		plugin.MarshalOptions{},
-	)
+	outputs, _, err := GenerateOrgAccessTokenProperties(input, *accessToken)
 	if err != nil {
 		return nil, err
 	}
-
-	urn := fmt.Sprintf(inputsAccessToken.OrgName + "/" + inputsAccessToken.Name + "/" + accessToken.ID)
 
 	return &pulumirpc.CreateResponse{
-		Id:         urn,
-		Properties: outputProperties,
+		Id:         fmt.Sprintf("%s/%s/%s", input.OrgName, input.Name, accessToken.ID),
+		Properties: outputs,
 	}, nil
 
 }
@@ -127,6 +135,9 @@ func (ot *PulumiServiceOrgAccessTokenResource) Read(req *pulumirpc.ReadRequest) 
 	urn := req.GetId()
 
 	orgName, _, tokenId, err := splitOrgAccessTokenId(urn)
+	if err != nil {
+		return nil, err
+	}
 
 	// the org access token is immutable; if we get nil it got deleted, otherwise all data is the same
 	accessToken, err := ot.client.GetOrgAccessToken(ctx, tokenId, orgName)
@@ -137,9 +148,30 @@ func (ot *PulumiServiceOrgAccessTokenResource) Read(req *pulumirpc.ReadRequest) 
 		return &pulumirpc.ReadResponse{}, nil
 	}
 
+	var input = PulumiServiceOrgAccessTokenInput{
+		Name:        accessToken.Name,
+		OrgName:     orgName,
+		Description: accessToken.Description,
+		Admin:       accessToken.Admin,
+	}
+
+	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
+	if err != nil {
+		return nil, err
+	}
+	if propertyMap["value"].HasValue() {
+		accessToken.TokenValue = getSecretOrStringValue(propertyMap["value"])
+	}
+
+	outputs, inputs, err := GenerateOrgAccessTokenProperties(input, *accessToken)
+	if err != nil {
+		return nil, err
+	}
+
 	return &pulumirpc.ReadResponse{
 		Id:         req.GetId(),
-		Properties: req.GetProperties(),
+		Properties: outputs,
+		Inputs:     inputs,
 	}, nil
 }
 

--- a/sdk/dotnet/OrgAccessToken.cs
+++ b/sdk/dotnet/OrgAccessToken.cs
@@ -120,6 +120,7 @@ namespace Pulumi.PulumiService
 
         public OrgAccessTokenArgs()
         {
+            Admin = false;
         }
         public static new OrgAccessTokenArgs Empty => new OrgAccessTokenArgs();
     }

--- a/sdk/go/pulumiservice/orgAccessToken.go
+++ b/sdk/go/pulumiservice/orgAccessToken.go
@@ -41,6 +41,9 @@ func NewOrgAccessToken(ctx *pulumi.Context,
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
 	}
+	if args.Admin == nil {
+		args.Admin = pulumi.BoolPtr(false)
+	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"value",
 	})

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
@@ -189,6 +190,7 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         public OrgAccessTokenArgs build() {
+            $.admin = Codegen.booleanProp("admin").output().arg($.admin).def(false).getNullable();
             if ($.name == null) {
                 throw new MissingRequiredPropertyException("OrgAccessTokenArgs", "name");
             }

--- a/sdk/nodejs/orgAccessToken.ts
+++ b/sdk/nodejs/orgAccessToken.ts
@@ -72,7 +72,7 @@ export class OrgAccessToken extends pulumi.CustomResource {
             if ((!args || args.organizationName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'organizationName'");
             }
-            resourceInputs["admin"] = args ? args.admin : undefined;
+            resourceInputs["admin"] = (args ? args.admin : undefined) ?? false;
             resourceInputs["description"] = args ? args.description : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;

--- a/sdk/python/pulumi_pulumiservice/org_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/org_access_token.py
@@ -27,6 +27,8 @@ class OrgAccessTokenArgs:
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
+        if admin is None:
+            admin = False
         if admin is not None:
             pulumi.set(__self__, "admin", admin)
         if description is not None:
@@ -138,6 +140,8 @@ class OrgAccessToken(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = OrgAccessTokenArgs.__new__(OrgAccessTokenArgs)
 
+            if admin is None:
+                admin = False
             __props__.__dict__["admin"] = admin
             __props__.__dict__["description"] = description
             if name is None and not opts.urn:


### PR DESCRIPTION
### Summary 
- Fixed Read method to not use req.GetProperties
- Added a default value for OrgToken Admin property
- Added logic to retrieve more token values from the service
- Since actual token value is no longer retrievable after creation, so retrieving it from GetProperties on refresh still (without breaking import though)

### Testing
- Manually tested import - `pulumi import pulumiservice:index:OrgAccessToken importedToken service-provider-test-org/mytoken2/0eb9ac4a-1e2c-4055-812d-214e3954a0e8`