### PR TITLE
Fixing import for TeamAccessToken

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,6 @@
 ### Bug Fixes
 - Fixed import by refactoring Read method of EnvironmentVersionTag resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 - Fixed import by refactoring Read method of OrgAccessToken resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
+- Fixed import by refactoring Read method of TeamAccessToken resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 
 ### Miscellaneous


### PR DESCRIPTION
### Summary
- Fixed import by removing usage of req.GetProperties()

### Testing
- Tested import - `pulumi import pulumiservice:index:TeamAccessToken importedToken service-provider-test-org/tima/test-9LW51/e8bfe451-b1b9-48fe-9e0e-aeb796f26d51`