### PR TITLE
Fixed token value clearing on refresh

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,5 +4,6 @@
 - Fixed import by refactoring Read method of OrgAccessToken resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 - Fixed import by refactoring Read method of TeamAccessToken resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
 - Fixed import by refactoring Read method of StackTag resource [311](https://github.com/pulumi/pulumi-pulumiservice/issues/311)
+- Fixed token value clearing on refresh [359](https://github.com/pulumi/pulumi-pulumiservice/issues/359)
 
 ### Miscellaneous

--- a/provider/pkg/provider/org_access_token.go
+++ b/provider/pkg/provider/org_access_token.go
@@ -155,7 +155,7 @@ func (ot *PulumiServiceOrgAccessTokenResource) Read(req *pulumirpc.ReadRequest) 
 		Admin:       accessToken.Admin,
 	}
 
-	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
+	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/provider/team_access_token.go
+++ b/provider/pkg/provider/team_access_token.go
@@ -154,7 +154,7 @@ func (t *PulumiServiceTeamAccessTokenResource) Read(req *pulumirpc.ReadRequest) 
 		TeamName:    teamName,
 	}
 
-	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
+	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary
- Fixed bug with token clearing on refresh - discovered [here](https://github.com/pulumi/pulumi-pulumiservice/issues/359)

### Testing
- Verified refresh no longer breaks using below pulumi program:
```
let accessToken = new service.AccessToken("accessToken", {
    description: "coolest token",
});

let orgToken = new service.OrgAccessToken("orgToken", {
  organizationName: "service-provider-test-org",
  name: "OrgToken6442",
  admin: false,
  description: "coolest token2",
});

let teamToken = new service.TeamAccessToken("teamToken", {
  organizationName: "service-provider-test-org",
  teamName: "tima",
  name: "TeamToken",
  description: "coolest token3",
});


export const desc1 = accessToken.description;
export const value1 = accessToken.value;
export const desc2 = orgToken.description;
export const value2 = orgToken.value;
export const desc3 = teamToken.description;
export const value3 = teamToken.value;
```

And then running `pulumi stack output --show-secrets` after pulumi up, after refresh and after another up - verified the value stays consistent.
