### PR TITLE
Make the test stack name random

### DIFF
--- a/examples/ts-deployment-settings/index.ts
+++ b/examples/ts-deployment-settings/index.ts
@@ -1,13 +1,15 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as service from "@pulumi/pulumiservice";
+import * as uuid from "uuid";
 
 const config = new pulumi.Config();
+
+const id = uuid.v4();
 
 const stack = new service.Stack("my_stack", {
     organizationName: "service-provider-test-org",
     projectName: "my-new-project",
-    stackName: "my-new-stack",
-
+    stackName: id,
 })
 
 const settings = new service.DeploymentSettings("deployment_settings", {

--- a/examples/ts-deployment-settings/package.json
+++ b/examples/ts-deployment-settings/package.json
@@ -2,10 +2,12 @@
     "name": "ts-deployment-settings",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16"
+        "@types/node": "^16",
+        "@types/uuid": "^10.0.0"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/pulumiservice": "^0.4.0"
+        "@pulumi/pulumiservice": "^0.22.0",
+        "uuid": "^10.0.0"
     }
 }


### PR DESCRIPTION
We need the stack name to be random so there aren't collisions with multiple tests running.