### PR TITLE
Fix the example to use the random provider

### DIFF
--- a/examples/ts-deployment-settings/index.ts
+++ b/examples/ts-deployment-settings/index.ts
@@ -1,15 +1,15 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as service from "@pulumi/pulumiservice";
-import * as uuid from "uuid";
+import * as random from "@pulumi/random";
 
 const config = new pulumi.Config();
 
-const id = uuid.v4();
+const id = new random.RandomUuid("id");
 
 const stack = new service.Stack("my_stack", {
     organizationName: "service-provider-test-org",
     projectName: "my-new-project",
-    stackName: id,
+    stackName: id.result,
 })
 
 const settings = new service.DeploymentSettings("deployment_settings", {

--- a/examples/ts-deployment-settings/package.json
+++ b/examples/ts-deployment-settings/package.json
@@ -2,12 +2,11 @@
     "name": "ts-deployment-settings",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^16",
-        "@types/uuid": "^10.0.0"
+        "@types/node": "^16"
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/pulumiservice": "^0.22.0",
-        "uuid": "^10.0.0"
+        "@pulumi/random": "^4.16.3"
     }
 }


### PR DESCRIPTION
Using a uuid means that there is a new UUID generated every time, meaning there is a replace on every update. We should use the random provider instead.