### PR TITLE
Fixing secret leak in Deployment Settings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,5 +2,6 @@
 
 ### Bug Fixes
 - Improving error messages and input validation [#374](https://github.com/pulumi/pulumi-pulumiservice/issues/374)
+- Fixing secrets leak [#376](https://github.com/pulumi/pulumi-pulumiservice/issues/376)[#377](https://github.com/pulumi/pulumi-pulumiservice/issues/377)
 
 ### Miscellaneous

--- a/provider/pkg/provider/deployment_settings.go
+++ b/provider/pkg/provider/deployment_settings.go
@@ -650,7 +650,7 @@ func (ds *PulumiServiceDeploymentSettingsResource) Diff(req *pulumirpc.DiffReque
 }
 
 func (ds *PulumiServiceDeploymentSettingsResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
 	if err != nil {
 		return nil, err
 	}
@@ -688,7 +688,7 @@ func (ds *PulumiServiceDeploymentSettingsResource) Check(req *pulumirpc.CheckReq
 		}
 	}
 
-	checkedNews, err := plugin.MarshalProperties(news, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	checkedNews, err := plugin.MarshalProperties(news, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true, KeepSecrets: true})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Summary
- [This commit](https://github.com/pulumi/pulumi-pulumiservice/commit/7d42451815b446810fe593ef8e0591ea1e5c8192) unintentionally introduced code "unsercreting" all the inputs, which is what resulted in a leak
- Other values that are forced to be secrets (like github passwords) were not affected, which has covered up this issue during tests

### Testing
- Manually tested, verified secrets and now covered up in both Pulumi Console and in stack export json