### PR TITLE
Fix Asset handling for Environments

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,7 @@
 
 ### Bug Fixes
 
-- Fixes a bug where the `Environment` resource would print its contents on error. [#390](https://github.com/pulumi/pulumi-pulumiservice/pull/390)   
+- Fixes a bug where the `Environment` resource would print its contents on error. [#390](https://github.com/pulumi/pulumi-pulumiservice/pull/390)
+- Fixes a bug where the `Environment` resource would error if a FileAsset was used. [#391](https://github.com/pulumi/pulumi-pulumiservice/pull/391)
 
 ### Miscellaneous

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -118,3 +118,17 @@ func TestNodejsTemplateSourcesExample(t *testing.T) {
 		},
 	})
 }
+
+func TestNodejsEnvironmentsFileAssetExample(t *testing.T) {
+	cwd := getCwd(t)
+	digits := generateRandomFiveDigits()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: path.Join(cwd, ".", "ts-environments-file-asset"),
+		Config: map[string]string{
+			"digits": digits,
+		},
+		Dependencies: []string{
+			"@pulumi/pulumiservice",
+		},
+	})
+}

--- a/examples/ts-environments-file-asset/Pulumi.yaml
+++ b/examples/ts-environments-file-asset/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: environments-file-asset
+runtime: nodejs
+description: An Example Of Using Environments with a file asset

--- a/examples/ts-environments-file-asset/env.yaml
+++ b/examples/ts-environments-file-asset/env.yaml
@@ -1,0 +1,4 @@
+values:
+  hello: world
+  nested:
+    deeper: value

--- a/examples/ts-environments-file-asset/index.ts
+++ b/examples/ts-environments-file-asset/index.ts
@@ -1,0 +1,10 @@
+import * as service from "@pulumi/pulumiservice";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+
+const environment = new service.Environment("testing-environment", {
+  organization: "service-provider-test-org",
+  name: "testing-environment-ts-file-asset"+config.require("digits"),
+  yaml: new pulumi.asset.FileAsset("env.yaml")
+})

--- a/examples/ts-environments-file-asset/package.json
+++ b/examples/ts-environments-file-asset/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "stack-tags",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^5.0.0",
+        "@pulumi/awsx": "^0.40.0"
+    }
+}

--- a/examples/ts-environments-file-asset/tsconfig.json
+++ b/examples/ts-environments-file-asset/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/provider/pkg/provider/environment.go
+++ b/provider/pkg/provider/environment.go
@@ -23,7 +23,7 @@ type PulumiServiceEnvironmentResource struct {
 type PulumiServiceEnvironmentInput struct {
 	OrgName string
 	EnvName string
-	Yaml    *asset.Asset
+	Yaml    string
 }
 
 type PulumiServiceEnvironmentOutput struct {
@@ -35,7 +35,7 @@ func (i *PulumiServiceEnvironmentInput) ToPropertyMap() (resource.PropertyMap, e
 	propertyMap := resource.PropertyMap{}
 	propertyMap["organization"] = resource.NewPropertyValue(i.OrgName)
 	propertyMap["name"] = resource.NewPropertyValue(i.EnvName)
-	propertyMap["yaml"] = resource.MakeSecret(resource.NewAssetProperty(i.Yaml))
+	propertyMap["yaml"] = resource.MakeSecret(resource.NewStringProperty(i.Yaml))
 
 	return propertyMap, nil
 }
@@ -60,7 +60,7 @@ func ToPulumiServiceEnvironmentInput(properties *structpb.Struct) (*PulumiServic
 	input := PulumiServiceEnvironmentInput{}
 	input.OrgName = inputMap["organization"].StringValue()
 	input.EnvName = inputMap["name"].StringValue()
-	input.Yaml = inputMap["yaml"].AssetValue()
+	input.Yaml = inputMap["yaml"].StringValue()
 
 	return &input, nil
 }
@@ -144,24 +144,14 @@ func (st *PulumiServiceEnvironmentResource) Create(req *pulumirpc.CreateRequest)
 	}
 
 	// First check if yaml is valid
-	yamlBytes, err := getBytesFromAsset(input.Yaml)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read yaml asset: %w", err)
-	}
-	_, diagnostics, err := st.client.CheckYAMLEnvironment(context.Background(), input.OrgName, yamlBytes)
-	if err != nil {
-		return nil, err
-	}
-	if diagnostics != nil {
-		return nil, fmt.Errorf("failed to create environment, yaml code failed following checks: %+v", diagnostics)
-	}
+	_, diagnostics, err := st.client.CheckYAMLEnvironment(context.Background(), input.OrgName, []byte(input.Yaml))
 
 	// Then create environment, and update it with yaml provided. ESC API architecture doesn't let you do it in one call
 	err = st.client.CreateEnvironment(context.Background(), input.OrgName, input.EnvName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new environment due to error: %+v", err)
 	}
-	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, yamlBytes, "")
+	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, []byte(input.Yaml), "")
 	if diagnostics != nil {
 		return nil, fmt.Errorf("failed to update brand new environment with pre-checked yaml, due to failing the following checks: %+v \n"+
 			"This should never happen, if you're seeing this message there's likely a bug in ESC APIs", diagnostics)
@@ -216,13 +206,20 @@ func (st *PulumiServiceEnvironmentResource) Check(req *pulumirpc.CheckRequest) (
 		}
 	}
 
-	if !inputMap["yaml"].IsAsset() {
-		failures = append(failures, &pulumirpc.CheckFailure{
-			Reason: "property 'yaml' must be an Asset type",
-		})
+	yamlBytes, err := getBytesFromAsset(inputMap["yaml"].AssetValue())
+	if err != nil {
+		return nil, err
+	}
+	stringYaml := string(yamlBytes)
+	trimmedYaml := strings.TrimSpace(stringYaml)
+	inputMap["yaml"] = resource.MakeSecret(resource.NewStringProperty(trimmedYaml))
+
+	inputs, err := plugin.MarshalProperties(inputMap, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
 	}
 
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews(), Failures: failures}, nil
+	return &pulumirpc.CheckResponse{Inputs: inputs, Failures: failures}, nil
 }
 
 func (st *PulumiServiceEnvironmentResource) Update(req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
@@ -231,11 +228,7 @@ func (st *PulumiServiceEnvironmentResource) Update(req *pulumirpc.UpdateRequest)
 		return nil, err
 	}
 
-	yamlBytes, err := getBytesFromAsset(input.Yaml)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read yaml asset: %w", err)
-	}
-	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, yamlBytes, "")
+	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, []byte(input.Yaml), "")
 	if err != nil {
 		return nil, err
 	}
@@ -280,15 +273,13 @@ func (st *PulumiServiceEnvironmentResource) Read(req *pulumirpc.ReadRequest) (*p
 		return &pulumirpc.ReadResponse{Id: "", Properties: nil}, nil
 	}
 
-	yamlAsset, err := asset.FromText(string(retrievedYaml))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create asset from yaml: %w", err)
-	}
+	stringYaml := string(retrievedYaml)
+	trimmedYaml := strings.TrimSpace(stringYaml)
 
 	input := PulumiServiceEnvironmentInput{
 		OrgName: orgName,
 		EnvName: envName,
-		Yaml:    yamlAsset,
+		Yaml:    trimmedYaml,
 	}
 
 	result := PulumiServiceEnvironmentOutput{

--- a/provider/pkg/provider/environment.go
+++ b/provider/pkg/provider/environment.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"io"
 	"path"
 	"strings"
 
@@ -22,7 +23,7 @@ type PulumiServiceEnvironmentResource struct {
 type PulumiServiceEnvironmentInput struct {
 	OrgName string
 	EnvName string
-	Yaml    []byte
+	Yaml    *asset.Asset
 }
 
 type PulumiServiceEnvironmentOutput struct {
@@ -34,12 +35,7 @@ func (i *PulumiServiceEnvironmentInput) ToPropertyMap() (resource.PropertyMap, e
 	propertyMap := resource.PropertyMap{}
 	propertyMap["organization"] = resource.NewPropertyValue(i.OrgName)
 	propertyMap["name"] = resource.NewPropertyValue(i.EnvName)
-
-	yamlAsset, err := asset.FromText(strings.TrimSuffix(string(i.Yaml), "\n"))
-	if err != nil {
-		return nil, err
-	}
-	propertyMap["yaml"] = resource.MakeSecret(resource.NewAssetProperty(yamlAsset))
+	propertyMap["yaml"] = resource.MakeSecret(resource.NewAssetProperty(i.Yaml))
 
 	return propertyMap, nil
 }
@@ -64,9 +60,18 @@ func ToPulumiServiceEnvironmentInput(properties *structpb.Struct) (*PulumiServic
 	input := PulumiServiceEnvironmentInput{}
 	input.OrgName = inputMap["organization"].StringValue()
 	input.EnvName = inputMap["name"].StringValue()
-	input.Yaml = []byte(inputMap["yaml"].AssetValue().Text)
+	input.Yaml = inputMap["yaml"].AssetValue()
 
 	return &input, nil
+}
+
+func getBytesFromAsset(asset *asset.Asset) ([]byte, error) {
+	reader, err := asset.Read()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	return io.ReadAll(reader)
 }
 
 func (st *PulumiServiceEnvironmentResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
@@ -139,12 +144,16 @@ func (st *PulumiServiceEnvironmentResource) Create(req *pulumirpc.CreateRequest)
 	}
 
 	// First check if yaml is valid
-	_, diagnostics, err := st.client.CheckYAMLEnvironment(context.Background(), input.OrgName, input.Yaml)
-	if diagnostics != nil {
-		return nil, fmt.Errorf("failed to check environment, yaml code failed following checks: %+v", diagnostics)
-	}
+	yamlBytes, err := getBytesFromAsset(input.Yaml)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check environment due to error: %+v", err)
+		return nil, fmt.Errorf("failed to read yaml asset: %w", err)
+	}
+	_, diagnostics, err := st.client.CheckYAMLEnvironment(context.Background(), input.OrgName, yamlBytes)
+	if err != nil {
+		return nil, err
+	}
+	if diagnostics != nil {
+		return nil, fmt.Errorf("failed to create environment, yaml code failed following checks: %+v", diagnostics)
 	}
 
 	// Then create environment, and update it with yaml provided. ESC API architecture doesn't let you do it in one call
@@ -152,7 +161,7 @@ func (st *PulumiServiceEnvironmentResource) Create(req *pulumirpc.CreateRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new environment due to error: %+v", err)
 	}
-	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, input.Yaml, "")
+	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, yamlBytes, "")
 	if diagnostics != nil {
 		return nil, fmt.Errorf("failed to update brand new environment with pre-checked yaml, due to failing the following checks: %+v \n"+
 			"This should never happen, if you're seeing this message there's likely a bug in ESC APIs", diagnostics)
@@ -222,12 +231,16 @@ func (st *PulumiServiceEnvironmentResource) Update(req *pulumirpc.UpdateRequest)
 		return nil, err
 	}
 
-	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, input.Yaml, "")
+	yamlBytes, err := getBytesFromAsset(input.Yaml)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read yaml asset: %w", err)
+	}
+	diagnostics, revision, err := st.client.UpdateEnvironmentWithRevision(context.Background(), input.OrgName, input.EnvName, yamlBytes, "")
+	if err != nil {
+		return nil, err
+	}
 	if diagnostics != nil {
 		return nil, fmt.Errorf("failed to update environment, yaml code failed following checks: %+v", diagnostics)
-	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to update environment due to error: %+v", err)
 	}
 
 	output := PulumiServiceEnvironmentOutput{
@@ -267,10 +280,15 @@ func (st *PulumiServiceEnvironmentResource) Read(req *pulumirpc.ReadRequest) (*p
 		return &pulumirpc.ReadResponse{Id: "", Properties: nil}, nil
 	}
 
+	yamlAsset, err := asset.FromText(string(retrievedYaml))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create asset from yaml: %w", err)
+	}
+
 	input := PulumiServiceEnvironmentInput{
 		OrgName: orgName,
 		EnvName: envName,
-		Yaml:    retrievedYaml,
+		Yaml:    yamlAsset,
 	}
 
 	result := PulumiServiceEnvironmentOutput{

--- a/provider/pkg/provider/environment_test.go
+++ b/provider/pkg/provider/environment_test.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"testing"
 	"time"
 
@@ -136,13 +135,13 @@ func TestEnvironment(t *testing.T) {
 		provider := PulumiServiceEnvironmentResource{
 			client: mockedClient,
 		}
-		yamlAsset, err := asset.FromText("test-environment")
-		assert.NoError(t, err)
 
 		input := PulumiServiceEnvironmentInput{
 			OrgName: "org",
 			EnvName: "env",
-			Yaml:    yamlAsset,
+			Yaml: `values:
+	foo: bar
+`,
 		}
 
 		propertyMap, _ := input.ToPropertyMap()
@@ -179,13 +178,12 @@ func TestEnvironment(t *testing.T) {
 			client: mockedClient,
 		}
 
-		yamlAsset, err := asset.FromText("test-environment")
-		assert.NoError(t, err)
-
 		input := PulumiServiceEnvironmentInput{
 			OrgName: "org",
 			EnvName: "project",
-			Yaml:    yamlAsset,
+			Yaml: `values:
+	foo: bar
+`,
 		}
 
 		propertyMap, _ := input.ToPropertyMap()

--- a/provider/pkg/provider/environment_test.go
+++ b/provider/pkg/provider/environment_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"testing"
 	"time"
 
@@ -135,11 +136,13 @@ func TestEnvironment(t *testing.T) {
 		provider := PulumiServiceEnvironmentResource{
 			client: mockedClient,
 		}
+		yamlAsset, err := asset.FromText("test-environment")
+		assert.NoError(t, err)
 
 		input := PulumiServiceEnvironmentInput{
 			OrgName: "org",
 			EnvName: "env",
-			Yaml:    []byte("test-environment"),
+			Yaml:    yamlAsset,
 		}
 
 		propertyMap, _ := input.ToPropertyMap()
@@ -176,10 +179,13 @@ func TestEnvironment(t *testing.T) {
 			client: mockedClient,
 		}
 
+		yamlAsset, err := asset.FromText("test-environment")
+		assert.NoError(t, err)
+
 		input := PulumiServiceEnvironmentInput{
 			OrgName: "org",
 			EnvName: "project",
-			Yaml:    []byte("test-environment"),
+			Yaml:    yamlAsset,
 		}
 
 		propertyMap, _ := input.ToPropertyMap()


### PR DESCRIPTION
We were only handling `StringAsset`s in the previous implementation, but we need to be able to handle all Asset types.

Fixes #368 