### PR TITLE
Fix refresh on agent pools

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,5 +5,6 @@
 
 - Fixes a bug where the `Environment` resource would print its contents on error. [#390](https://github.com/pulumi/pulumi-pulumiservice/pull/390)
 - Fixes a bug where the `Environment` resource would error if a FileAsset was used. [#391](https://github.com/pulumi/pulumi-pulumiservice/pull/391)
+- Fixes a bug where the `AgentPool` resource lost some outputs on `refresh`. [#395](https://github.com/pulumi/pulumi-pulumiservice/pull/395)
 
 ### Miscellaneous

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -277,6 +277,20 @@ func TestYamlEnvironmentsExample(t *testing.T) {
 	})
 }
 
+func TestYamlAgentPoolsExample(t *testing.T) {
+	cwd := getCwd(t)
+	digits := generateRandomFiveDigits()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: path.Join(cwd, ".", "yaml-agent-pools"),
+		Config: map[string]string{
+			"digits": digits,
+		},
+		PrepareProject: func(p *engine.Projinfo) error {
+			return nil
+		},
+	})
+}
+
 func TestYamlTemplateSourcesExample(t *testing.T) {
 	cwd := getCwd(t)
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/examples/yaml-agent-pools/Pulumi.yaml
+++ b/examples/yaml-agent-pools/Pulumi.yaml
@@ -7,7 +7,7 @@ resources:
     type: pulumiservice:index:AgentPool
     properties:
       organizationName: service-provider-test-org
-      name: test-agent-pool
+      name: test-agent-pool-${digits}
       description: Test agent pool
 
 outputs:

--- a/provider/pkg/internal/pulumiapi/agent_pools.go
+++ b/provider/pkg/internal/pulumiapi/agent_pools.go
@@ -31,7 +31,7 @@ type AgentPoolClient interface {
 type AgentPool struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	TokenValue  string `json:"tokenValue"`
 }
 
@@ -42,7 +42,7 @@ type createAgentPoolResponse struct {
 
 type createUpdateAgentPoolRequest struct {
 	Name        string `json:"name"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 func (c *Client) CreateAgentPool(ctx context.Context, orgName, name, description string) (*AgentPool, error) {

--- a/provider/pkg/provider/agent_pool.go
+++ b/provider/pkg/provider/agent_pool.go
@@ -217,6 +217,14 @@ func (ap *PulumiServiceAgentPoolResource) Read(req *pulumirpc.ReadRequest) (*pul
 		return &pulumirpc.ReadResponse{}, nil
 	}
 
+	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepSecrets: true})
+	if err != nil {
+		return nil, err
+	}
+	if propertyMap["tokenValue"].HasValue() {
+		agentPool.TokenValue = getSecretOrStringValue(propertyMap["tokenValue"])
+	}
+
 	input := PulumiServiceAgentPoolInput{
 		OrgName:     orgName,
 		Description: agentPool.Description,

--- a/provider/pkg/provider/agent_pool.go
+++ b/provider/pkg/provider/agent_pool.go
@@ -27,15 +27,19 @@ type PulumiServiceAgentPoolInput struct {
 func GenerateAgentPoolProperties(input PulumiServiceAgentPoolInput, agentPool pulumiapi.AgentPool) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
 	inputMap := resource.PropertyMap{}
 	inputMap["name"] = resource.NewPropertyValue(input.Name)
-	inputMap["description"] = resource.NewPropertyValue(input.Description)
 	inputMap["organizationName"] = resource.NewPropertyValue(input.OrgName)
+	if input.Description != "" {
+		inputMap["description"] = resource.NewPropertyValue(input.Description)
+	}
 
 	outputMap := resource.PropertyMap{}
 	outputMap["agentPoolId"] = resource.NewPropertyValue(agentPool.ID)
 	outputMap["name"] = inputMap["name"]
 	outputMap["organizationName"] = inputMap["organizationName"]
-	outputMap["description"] = inputMap["description"]
 	outputMap["tokenValue"] = resource.NewPropertyValue(agentPool.TokenValue)
+	if input.Description != "" {
+		outputMap["description"] = inputMap["description"]
+	}
 
 	inputs, err = plugin.MarshalProperties(inputMap, plugin.MarshalOptions{})
 	if err != nil {


### PR DESCRIPTION
Fixes an issue where the AgentPool resource would lose the tokenValue property on refresh. Also enables an existing example for agent pools which would have highlighted the bug, but didn't because it wasn't running :/ 

Fixes #379 