### PR TITLE
Fix environment input yaml type error panic

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,6 @@
 
 ### Bug Fixes
 
+- Fixes type error panic with environments [#400](https://github.com/pulumi/pulumi-pulumiservice/issues/400)
+
 ### Miscellaneous

--- a/provider/pkg/provider/environment.go
+++ b/provider/pkg/provider/environment.go
@@ -60,7 +60,13 @@ func ToPulumiServiceEnvironmentInput(properties *structpb.Struct) (*PulumiServic
 	input := PulumiServiceEnvironmentInput{}
 	input.OrgName = inputMap["organization"].StringValue()
 	input.EnvName = inputMap["name"].StringValue()
-	input.Yaml = inputMap["yaml"].StringValue()
+
+	inputYaml := inputMap["yaml"]
+	if inputYaml.IsAsset() {
+		input.Yaml = inputYaml.AssetValue().Text
+	} else {
+		input.Yaml = inputYaml.StringValue()
+	}
 
 	return &input, nil
 }


### PR DESCRIPTION
This fixes the issue where creating esc resources with an older version of pulumi-pulumiservice and then using pulumi to do something with that resource on a newer version of pulumi-pulumiservice causes a panic due to a type error

We started loading input yamls as strings starting in https://github.com/pulumi/pulumi-pulumiservice/pull/391, but resources created before then will still be assets. This fix will check both the old and new way for backwards compatibility

Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/400

## Testing
Reproduction steps:
- use PSP from dc382f79ee477f670e3721613ba5b2c00ce8b51c or earlier
- `pulumi up` from `examples/ts-environments`
- update PSP to latest
- `pulumi destroy` from `examples/ts-environments` 

Without this change, you get an error that looks like:
```
 panic: interface conversion: interface {} is *asset.Asset, not string
    goroutine 45 [running]:
    github.com/pulumi/pulumi/sdk/v3/go/common/resource.PropertyValue.StringValue(...)
        /Users/sean/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.115.3-0.20240507143413-cffdfd1fa489/go/common/resource/properties.go:451
    github.com/pulumi/pulumi-pulumiservice/provider/pkg/provider.ToPulumiServiceEnvironmentInput(0x2?)
        /Users/sean/go/src/github.com/pulumi/pulumi-pulumiservice/provider/pkg/provider/environment.go:63 +0x1d0
```