### PR TITLE
Fix panic when environment uses computed values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,6 @@
 ### Bug Fixes
 
 - Fixes failing pulumi refresh on org tokens with a slash in its name [#388](https://github.com/pulumi/pulumi-pulumiservice/issues/388)
+- Fix panic when using computed values in environment definition [#411](https://github.com/pulumi/pulumi-pulumiservice/issues/411)
 
 ### Miscellaneous

--- a/provider/pkg/provider/environment.go
+++ b/provider/pkg/provider/environment.go
@@ -238,10 +238,14 @@ func (st *PulumiServiceEnvironmentResource) Check(req *pulumirpc.CheckRequest) (
 		}
 	}
 
-	yamlBytes, err := getBytesFromAsset(inputMap["yaml"].AssetValue())
-	if err != nil {
-		return nil, err
+	yamlBytes := []byte{}
+	if !inputMap["yaml"].IsComputed() {
+		yamlBytes, err = getBytesFromAsset(inputMap["yaml"].AssetValue())
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	stringYaml := string(yamlBytes)
 	trimmedYaml := strings.TrimSpace(stringYaml)
 	inputMap["yaml"] = resource.MakeSecret(resource.NewStringProperty(trimmedYaml))


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/411

This is related to https://github.com/pulumi/pulumi-pulumiservice/pull/399

Example repro program:
```typescript
import * as pulumi from "@pulumi/pulumi";
import * as service from "@pulumi/pulumiservice";
import * as aws from "@pulumi/aws";

const org = "big-org";
const bucket = new aws.s3.Bucket("myBucket", {
    bucket: "syeh-panic-test",
    acl: "private",
});

const envDef = pulumi.interpolate`values:
  myKey1: "${bucket.arn}"`;
const envAsset = envDef.apply(x => new pulumi.asset.StringAsset(x));

const environment = new service.Environment("panic", {
  organization: org,
  project: "abc",
  name: "panic",
  yaml: envAsset,
})
```