### PR TITLE
Allow force deleting agent pools

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+- Allow force deleting agent pools. [#435](https://github.com/pulumi/pulumi-pulumiservice/pull/435)
+
 ### Bug Fixes
 
 ### Miscellaneous

--- a/examples/ts-webhooks/index.ts
+++ b/examples/ts-webhooks/index.ts
@@ -39,7 +39,7 @@ const stackWebhook = new service.Webhook("stack-webhook", {
   organizationName: serviceOrg,
   projectName: pulumi.getProject(),
   stackName: pulumi.getStack(),
-  payloadUrl: "https://example.com",
+  payloadUrl: "https://hooks.slack.com/blahblah",
   format: WebhookFormat.Slack,
   groups: [ WebhookGroup.Stacks ],
   filters: [WebhookFilters.DeploymentStarted, WebhookFilters.DeploymentSucceeded],

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -662,6 +662,10 @@
           "description": "The agent pool's token's value.",
           "type": "string",
           "secret": true
+        },
+        "forceDestroy": {
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.",
+          "type": "boolean"
         }
       },
       "required": [
@@ -682,6 +686,10 @@
         "organizationName": {
           "description": "The organization's name.",
           "type": "string"
+        },
+        "forceDestroy": {
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.",
+          "type": "boolean"
         }
       },
       "requiredInputs": [

--- a/provider/pkg/internal/pulumiapi/accesstokens_test.go
+++ b/provider/pkg/internal/pulumiapi/accesstokens_test.go
@@ -27,7 +27,7 @@ func TestDeleteAccessToken(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/user/tokens/" + tokenId,
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "token not found",
 			},
@@ -75,7 +75,7 @@ func TestCreateAccessToken(t *testing.T) {
 				Description: desc,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},
@@ -131,7 +131,7 @@ func TestGetAccessToken(t *testing.T) {
 			ExpectedReqPath:   "/api/user/tokens",
 			ExpectedReqBody:   nil,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},

--- a/provider/pkg/internal/pulumiapi/agent_pools_test.go
+++ b/provider/pkg/internal/pulumiapi/agent_pools_test.go
@@ -18,7 +18,7 @@ func TestDeleteAgentPool(t *testing.T) {
 			ResponseCode:      204,
 		})
 		defer cleanup()
-		assert.NoError(t, c.DeleteAgentPool(teamCtx, agentPoolId, orgName))
+		assert.NoError(t, c.DeleteAgentPool(teamCtx, agentPoolId, orgName, false))
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -26,14 +26,14 @@ func TestDeleteAgentPool(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/orgs/anOrg/agent-pools/" + agentPoolId,
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "agent pool not found",
 			},
 		})
 		defer cleanup()
 		assert.EqualError(t,
-			c.DeleteAgentPool(teamCtx, agentPoolId, orgName),
+			c.DeleteAgentPool(teamCtx, agentPoolId, orgName, false),
 			`failed to delete agent pool "abcdegh": 404 API error: agent pool not found`,
 		)
 	})
@@ -80,7 +80,7 @@ func TestCreateAgentPool(t *testing.T) {
 				Name:        name,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},
@@ -129,7 +129,7 @@ func TestGetAgentPool(t *testing.T) {
 			ExpectedReqPath:   fmt.Sprintf("/api/orgs/%s/agent-pools/%s", org, id),
 			ExpectedReqBody:   nil,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},

--- a/provider/pkg/internal/pulumiapi/client.go
+++ b/provider/pkg/internal/pulumiapi/client.go
@@ -79,7 +79,7 @@ func (c *Client) createRequest(ctx context.Context, method string, url *url.URL,
 }
 
 // sendRequest executes req and unmarshals response json into resBody
-// returns attempts to unmarshal response into errorResponse if statusCode not 2XX
+// returns attempts to unmarshal response into ErrorResponse if statusCode not 2XX
 func (c *Client) sendRequest(req *http.Request, resBody interface{}) (*http.Response, error) {
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -91,9 +91,9 @@ func (c *Client) sendRequest(req *http.Request, resBody interface{}) (*http.Resp
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 	if !ok(res.StatusCode) {
-		// if we didn't get an 2XX status code, unmarshal the response as an errorResponse
+		// if we didn't get an 2XX status code, unmarshal the response as an ErrorResponse
 		// and return an error
-		var errRes errorResponse
+		var errRes ErrorResponse
 		err = json.Unmarshal(body, &errRes)
 		if err != nil {
 			return res, fmt.Errorf("failed to parse response body from url %q, status code %d: %w\n\n%s\n",

--- a/provider/pkg/internal/pulumiapi/deployment_setting_test.go
+++ b/provider/pkg/internal/pulumiapi/deployment_setting_test.go
@@ -46,7 +46,7 @@ func TestGetDeploymentSettings(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/" + path.Join("api", "stacks", orgName, projectName, stackName, "deployments", "settings"),
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "not found",
 			},

--- a/provider/pkg/internal/pulumiapi/error.go
+++ b/provider/pkg/internal/pulumiapi/error.go
@@ -18,18 +18,18 @@ import (
 	"fmt"
 )
 
-// errorResponse is returned from pulumi service api when there's been an error
-type errorResponse struct {
+// ErrorResponse is returned from pulumi service api when there's been an error
+type ErrorResponse struct {
 	StatusCode int    `json:"code"`
 	Message    string `json:"message"`
 }
 
-func (err *errorResponse) Error() string {
+func (err *ErrorResponse) Error() string {
 	return fmt.Sprintf("%d API error: %s", err.StatusCode, err.Message)
 }
 
 func GetErrorStatusCode(err error) int {
-	var errResp *errorResponse
+	var errResp *ErrorResponse
 	if errors.As(err, &errResp) {
 		return errResp.StatusCode
 	}

--- a/provider/pkg/internal/pulumiapi/members_test.go
+++ b/provider/pkg/internal/pulumiapi/members_test.go
@@ -33,7 +33,7 @@ func TestAddMemberToOrg(t *testing.T) {
 				Role: role,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -75,7 +75,7 @@ func TestListOrgMembers(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/members",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -105,7 +105,7 @@ func TestDeleteMemberFromOrg(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/orgs/an-organization/members/a-user",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/internal/pulumiapi/orgtokens_test.go
+++ b/provider/pkg/internal/pulumiapi/orgtokens_test.go
@@ -26,7 +26,7 @@ func TestDeleteOrgAccessToken(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/orgs/anOrg/tokens/" + tokenId,
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "token not found",
 			},
@@ -105,7 +105,7 @@ func TestCreateOrgAccessToken(t *testing.T) {
 				Name:        name,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},
@@ -162,7 +162,7 @@ func TestGetOrgAccessToken(t *testing.T) {
 			ExpectedReqPath:   fmt.Sprintf("/api/orgs/%s/tokens", org),
 			ExpectedReqBody:   nil,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},

--- a/provider/pkg/internal/pulumiapi/schedules_test.go
+++ b/provider/pkg/internal/pulumiapi/schedules_test.go
@@ -64,7 +64,7 @@ func TestCreateDeploymentSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/schedules",
 			ExpectedReqBody:   createDeploymentScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -95,7 +95,7 @@ func TestGetDeploymentSchedule(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/schedules/" + testScheduleID,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -110,7 +110,7 @@ func TestGetDeploymentSchedule(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/schedules/" + testScheduleID,
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "not found",
 			},
@@ -144,7 +144,7 @@ func TestUpdateDeploymentSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/schedules/" + testScheduleID,
 			ExpectedReqBody:   createDeploymentScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -172,7 +172,7 @@ func TestDeleteSchedule(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/schedules/" + testScheduleID,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -204,7 +204,7 @@ func TestCreateDriftSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/drift/schedules",
 			ExpectedReqBody:   createDriftScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -237,7 +237,7 @@ func TestUpdateDriftSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/drift/schedules/" + testScheduleID,
 			ExpectedReqBody:   createDriftScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -270,7 +270,7 @@ func TestCreateTtlSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/ttl/schedules",
 			ExpectedReqBody:   createTtlScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -303,7 +303,7 @@ func TestUpdateTtlSchedule(t *testing.T) {
 			ExpectedReqPath:   "/api/stacks/org/project/stack/deployments/ttl/schedules/" + testScheduleID,
 			ExpectedReqBody:   createTtlScheduleReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/internal/pulumiapi/stack_tags_test.go
+++ b/provider/pkg/internal/pulumiapi/stack_tags_test.go
@@ -36,7 +36,7 @@ func TestCreateStackTags(t *testing.T) {
 			ExpectedReqMethod: http.MethodPost,
 			ExpectedReqPath:   fmt.Sprintf("/api/stacks/%s/%s/%s/tags", stackName.OrgName, stackName.ProjectName, stackName.StackName),
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -68,7 +68,7 @@ func TestDeleteStackTags(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/stacks/organization/project/stack/tags/tagName",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/internal/pulumiapi/stack_test.go
+++ b/provider/pkg/internal/pulumiapi/stack_test.go
@@ -34,7 +34,7 @@ func TestCreateStack(t *testing.T) {
 			ExpectedReqMethod: http.MethodPost,
 			ExpectedReqPath:   fmt.Sprintf("/api/stacks/%s/%s", s.OrgName, s.ProjectName),
 			ResponseCode:      http.StatusUnauthorized,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -76,7 +76,7 @@ func TestDeleteStack(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/stacks/organization/project/stack",
 			ResponseCode:      http.StatusUnauthorized,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/internal/pulumiapi/teams_test.go
+++ b/provider/pkg/internal/pulumiapi/teams_test.go
@@ -42,7 +42,7 @@ func TestListTeams(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/teams",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -84,7 +84,7 @@ func TestGetTeam(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/teams/a-team",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -99,7 +99,7 @@ func TestGetTeam(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/teams/a-team",
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "not found",
 			},
@@ -176,7 +176,7 @@ func TestCreateTeam(t *testing.T) {
 				Description:  description,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -238,7 +238,7 @@ func TestAddMemberToTeam(t *testing.T) {
 				Member:       userName,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/internal/pulumiapi/teamtokens_test.go
+++ b/provider/pkg/internal/pulumiapi/teamtokens_test.go
@@ -30,7 +30,7 @@ func TestDeleteTeamAccessToken(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/orgs/anOrg/teams/aTeam/tokens/" + tokenId,
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "token not found",
 			},
@@ -83,7 +83,7 @@ func TestCreateTeamAccessToken(t *testing.T) {
 				Name:        tokenName,
 			},
 			ResponseCode: 401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},
@@ -141,7 +141,7 @@ func TestGetTeamAccessToken(t *testing.T) {
 			ExpectedReqPath:   fmt.Sprintf("/api/orgs/%s/teams/%s/tokens", org, team),
 			ExpectedReqBody:   nil,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 401,
 				Message:    "unauthorized",
 			},

--- a/provider/pkg/internal/pulumiapi/webhooks_test.go
+++ b/provider/pkg/internal/pulumiapi/webhooks_test.go
@@ -47,7 +47,7 @@ func TestCreateWebhook(t *testing.T) {
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks",
 			ExpectedReqBody:   createReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -90,7 +90,7 @@ func TestListWebhooks(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -132,7 +132,7 @@ func TestGetWebhook(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -147,7 +147,7 @@ func TestGetWebhook(t *testing.T) {
 			ExpectedReqMethod: http.MethodGet,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
 			ResponseCode:      404,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				StatusCode: 404,
 				Message:    "not found",
 			},
@@ -201,7 +201,7 @@ func TestUpdateWebhook(t *testing.T) {
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
 			ExpectedReqBody:   updateReq,
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})
@@ -230,7 +230,7 @@ func TestDeleteWebhook(t *testing.T) {
 			ExpectedReqMethod: http.MethodDelete,
 			ExpectedReqPath:   "/api/orgs/an-organization/hooks/a-webhook",
 			ResponseCode:      401,
-			ResponseBody: errorResponse{
+			ResponseBody: ErrorResponse{
 				Message: "unauthorized",
 			},
 		})

--- a/provider/pkg/provider/agent_pool.go
+++ b/provider/pkg/provider/agent_pool.go
@@ -204,6 +204,7 @@ func (ap *PulumiServiceAgentPoolResource) Update(req *pulumirpc.UpdateRequest) (
 	changedInputs := olds
 	changedInputs["name"] = news["name"]
 	changedInputs["description"] = news["description"]
+	changedInputs["forceDestroy"] = news["forceDestroy"]
 
 	inputsAgentPool := ap.ToPulumiServiceAgentPoolInput(changedInputs)
 	err = ap.updateAgentPool(ctx, agentPoolId, inputsAgentPool)

--- a/provider/pkg/provider/agent_pool.go
+++ b/provider/pkg/provider/agent_pool.go
@@ -19,9 +19,10 @@ type PulumiServiceAgentPoolResource struct {
 }
 
 type PulumiServiceAgentPoolInput struct {
-	OrgName     string
-	Description string
-	Name        string
+	OrgName      string
+	Description  string
+	Name         string
+	ForceDestroy bool
 }
 
 func GenerateAgentPoolProperties(input PulumiServiceAgentPoolInput, agentPool pulumiapi.AgentPool) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
@@ -31,6 +32,9 @@ func GenerateAgentPoolProperties(input PulumiServiceAgentPoolInput, agentPool pu
 	if input.Description != "" {
 		inputMap["description"] = resource.NewPropertyValue(input.Description)
 	}
+	if input.ForceDestroy {
+		inputMap["forceDestroy"] = resource.NewPropertyValue(input.ForceDestroy)
+	}
 
 	outputMap := resource.PropertyMap{}
 	outputMap["agentPoolId"] = resource.NewPropertyValue(agentPool.ID)
@@ -39,6 +43,9 @@ func GenerateAgentPoolProperties(input PulumiServiceAgentPoolInput, agentPool pu
 	outputMap["tokenValue"] = resource.NewPropertyValue(agentPool.TokenValue)
 	if input.Description != "" {
 		outputMap["description"] = inputMap["description"]
+	}
+	if input.ForceDestroy {
+		outputMap["forceDestroy"] = inputMap["forceDestroy"]
 	}
 
 	inputs, err = plugin.MarshalProperties(inputMap, plugin.MarshalOptions{})
@@ -67,6 +74,10 @@ func (ap *PulumiServiceAgentPoolResource) ToPulumiServiceAgentPoolInput(inputMap
 
 	if inputMap["organizationName"].HasValue() && inputMap["organizationName"].IsString() {
 		input.OrgName = inputMap["organizationName"].StringValue()
+	}
+
+	if inputMap["forceDestroy"].HasValue() && inputMap["forceDestroy"].IsBool() {
+		input.ForceDestroy = inputMap["forceDestroy"].BoolValue()
 	}
 
 	return input
@@ -123,7 +134,17 @@ func (ap *PulumiServiceAgentPoolResource) Diff(req *pulumirpc.DiffRequest) (*pul
 
 func (ap *PulumiServiceAgentPoolResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
 	ctx := context.Background()
-	err := ap.deleteAgentPool(ctx, req.Id)
+	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
+	if err != nil {
+		return nil, err
+	}
+
+	pool := ap.ToPulumiServiceAgentPoolInput(inputs)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ap.deleteAgentPool(ctx, req.Id, pool.ForceDestroy)
 
 	if err != nil {
 		return &pbempty.Empty{}, err
@@ -266,13 +287,13 @@ func (ap *PulumiServiceAgentPoolResource) updateAgentPool(ctx context.Context, a
 	return ap.client.UpdateAgentPool(ctx, agentPoolId, input.OrgName, input.Name, input.Description)
 }
 
-func (ap *PulumiServiceAgentPoolResource) deleteAgentPool(ctx context.Context, id string) error {
+func (ap *PulumiServiceAgentPoolResource) deleteAgentPool(ctx context.Context, id string, forceDestroy bool) error {
 	// we don't need the token name when we delete
 	orgName, _, agentPoolId, err := splitAgentPoolId(id)
 	if err != nil {
 		return err
 	}
-	return ap.client.DeleteAgentPool(ctx, agentPoolId, orgName)
+	return ap.client.DeleteAgentPool(ctx, agentPoolId, orgName, forceDestroy)
 
 }
 

--- a/provider/pkg/provider/agent_pool_test.go
+++ b/provider/pkg/provider/agent_pool_test.go
@@ -24,7 +24,7 @@ func (c *AgentPoolClientMock) CreateAgentPool(ctx context.Context, name, orgName
 func (c *AgentPoolClientMock) UpdateAgentPool(ctx context.Context, agentPoolId, name, orgName, description string) error {
 	return nil
 }
-func (c *AgentPoolClientMock) DeleteAgentPool(ctx context.Context, agentPoolId, orgName string) error {
+func (c *AgentPoolClientMock) DeleteAgentPool(ctx context.Context, agentPoolId, orgName string, forceDestroy bool) error {
 	return nil
 }
 

--- a/sdk/dotnet/AgentPool.cs
+++ b/sdk/dotnet/AgentPool.cs
@@ -28,6 +28,12 @@ namespace Pulumi.PulumiService
         public Output<string?> Description { get; private set; } = null!;
 
         /// <summary>
+        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        /// </summary>
+        [Output("forceDestroy")]
+        public Output<bool?> ForceDestroy { get; private set; } = null!;
+
+        /// <summary>
         /// The name of the agent pool.
         /// </summary>
         [Output("name")]
@@ -99,6 +105,12 @@ namespace Pulumi.PulumiService
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }
+
+        /// <summary>
+        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        /// </summary>
+        [Input("forceDestroy")]
+        public Input<bool>? ForceDestroy { get; set; }
 
         /// <summary>
         /// Name of the agent pool.

--- a/sdk/go/pulumiservice/agentPool.go
+++ b/sdk/go/pulumiservice/agentPool.go
@@ -20,6 +20,8 @@ type AgentPool struct {
 	AgentPoolId pulumi.StringOutput `pulumi:"agentPoolId"`
 	// Description of the agent pool.
 	Description pulumi.StringPtrOutput `pulumi:"description"`
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	ForceDestroy pulumi.BoolPtrOutput `pulumi:"forceDestroy"`
 	// The name of the agent pool.
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The organization's name.
@@ -80,6 +82,8 @@ func (AgentPoolState) ElementType() reflect.Type {
 type agentPoolArgs struct {
 	// Description of the agent pool.
 	Description *string `pulumi:"description"`
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	ForceDestroy *bool `pulumi:"forceDestroy"`
 	// Name of the agent pool.
 	Name string `pulumi:"name"`
 	// The organization's name.
@@ -90,6 +94,8 @@ type agentPoolArgs struct {
 type AgentPoolArgs struct {
 	// Description of the agent pool.
 	Description pulumi.StringPtrInput
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	ForceDestroy pulumi.BoolPtrInput
 	// Name of the agent pool.
 	Name pulumi.StringInput
 	// The organization's name.
@@ -191,6 +197,11 @@ func (o AgentPoolOutput) AgentPoolId() pulumi.StringOutput {
 // Description of the agent pool.
 func (o AgentPoolOutput) Description() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AgentPool) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
+}
+
+// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+func (o AgentPoolOutput) ForceDestroy() pulumi.BoolPtrOutput {
+	return o.ApplyT(func(v *AgentPool) pulumi.BoolPtrOutput { return v.ForceDestroy }).(pulumi.BoolPtrOutput)
 }
 
 // The name of the agent pool.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
@@ -9,6 +9,7 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.pulumiservice.AgentPoolArgs;
 import com.pulumi.pulumiservice.Utilities;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,20 @@ public class AgentPool extends com.pulumi.resources.CustomResource {
      */
     public Output<Optional<String>> description() {
         return Codegen.optional(this.description);
+    }
+    /**
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * 
+     */
+    @Export(name="forceDestroy", refs={Boolean.class}, tree="[0]")
+    private Output</* @Nullable */ Boolean> forceDestroy;
+
+    /**
+     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * 
+     */
+    public Output<Optional<Boolean>> forceDestroy() {
+        return Codegen.optional(this.forceDestroy);
     }
     /**
      * The name of the agent pool.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPoolArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPoolArgs.java
@@ -6,6 +6,7 @@ package com.pulumi.pulumiservice;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
+import java.lang.Boolean;
 import java.lang.String;
 import java.util.Objects;
 import java.util.Optional;
@@ -29,6 +30,21 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
      */
     public Optional<Output<String>> description() {
         return Optional.ofNullable(this.description);
+    }
+
+    /**
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * 
+     */
+    @Import(name="forceDestroy")
+    private @Nullable Output<Boolean> forceDestroy;
+
+    /**
+     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * 
+     */
+    public Optional<Output<Boolean>> forceDestroy() {
+        return Optional.ofNullable(this.forceDestroy);
     }
 
     /**
@@ -65,6 +81,7 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
 
     private AgentPoolArgs(AgentPoolArgs $) {
         this.description = $.description;
+        this.forceDestroy = $.forceDestroy;
         this.name = $.name;
         this.organizationName = $.organizationName;
     }
@@ -106,6 +123,27 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder description(String description) {
             return description(Output.of(description));
+        }
+
+        /**
+         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder forceDestroy(@Nullable Output<Boolean> forceDestroy) {
+            $.forceDestroy = forceDestroy;
+            return this;
+        }
+
+        /**
+         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder forceDestroy(Boolean forceDestroy) {
+            return forceDestroy(Output.of(forceDestroy));
         }
 
         /**

--- a/sdk/nodejs/agentPool.ts
+++ b/sdk/nodejs/agentPool.ts
@@ -43,6 +43,10 @@ export class AgentPool extends pulumi.CustomResource {
      */
     public readonly description!: pulumi.Output<string | undefined>;
     /**
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     */
+    public readonly forceDestroy!: pulumi.Output<boolean | undefined>;
+    /**
      * The name of the agent pool.
      */
     public readonly name!: pulumi.Output<string>;
@@ -73,6 +77,7 @@ export class AgentPool extends pulumi.CustomResource {
                 throw new Error("Missing required property 'organizationName'");
             }
             resourceInputs["description"] = args ? args.description : undefined;
+            resourceInputs["forceDestroy"] = args ? args.forceDestroy : undefined;
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["agentPoolId"] = undefined /*out*/;
@@ -80,6 +85,7 @@ export class AgentPool extends pulumi.CustomResource {
         } else {
             resourceInputs["agentPoolId"] = undefined /*out*/;
             resourceInputs["description"] = undefined /*out*/;
+            resourceInputs["forceDestroy"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
             resourceInputs["tokenValue"] = undefined /*out*/;
@@ -99,6 +105,10 @@ export interface AgentPoolArgs {
      * Description of the agent pool.
      */
     description?: pulumi.Input<string>;
+    /**
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     */
+    forceDestroy?: pulumi.Input<boolean>;
     /**
      * Name of the agent pool.
      */

--- a/sdk/python/pulumi_pulumiservice/agent_pool.py
+++ b/sdk/python/pulumi_pulumiservice/agent_pool.py
@@ -16,17 +16,21 @@ class AgentPoolArgs:
     def __init__(__self__, *,
                  name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
-                 description: Optional[pulumi.Input[str]] = None):
+                 description: Optional[pulumi.Input[str]] = None,
+                 force_destroy: Optional[pulumi.Input[bool]] = None):
         """
         The set of arguments for constructing a AgentPool resource.
         :param pulumi.Input[str] name: Name of the agent pool.
         :param pulumi.Input[str] organization_name: The organization's name.
         :param pulumi.Input[str] description: Description of the agent pool.
+        :param pulumi.Input[bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if force_destroy is not None:
+            pulumi.set(__self__, "force_destroy", force_destroy)
 
     @property
     @pulumi.getter
@@ -64,6 +68,18 @@ class AgentPoolArgs:
     def description(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "description", value)
 
+    @property
+    @pulumi.getter(name="forceDestroy")
+    def force_destroy(self) -> Optional[pulumi.Input[bool]]:
+        """
+        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        """
+        return pulumi.get(self, "force_destroy")
+
+    @force_destroy.setter
+    def force_destroy(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "force_destroy", value)
+
 
 class AgentPool(pulumi.CustomResource):
     @overload
@@ -71,6 +87,7 @@ class AgentPool(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 force_destroy: Optional[pulumi.Input[bool]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -80,6 +97,7 @@ class AgentPool(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] description: Description of the agent pool.
+        :param pulumi.Input[bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
         :param pulumi.Input[str] name: Name of the agent pool.
         :param pulumi.Input[str] organization_name: The organization's name.
         """
@@ -108,6 +126,7 @@ class AgentPool(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  description: Optional[pulumi.Input[str]] = None,
+                 force_destroy: Optional[pulumi.Input[bool]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -120,6 +139,7 @@ class AgentPool(pulumi.CustomResource):
             __props__ = AgentPoolArgs.__new__(AgentPoolArgs)
 
             __props__.__dict__["description"] = description
+            __props__.__dict__["force_destroy"] = force_destroy
             if name is None and not opts.urn:
                 raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
@@ -154,6 +174,7 @@ class AgentPool(pulumi.CustomResource):
 
         __props__.__dict__["agent_pool_id"] = None
         __props__.__dict__["description"] = None
+        __props__.__dict__["force_destroy"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
         __props__.__dict__["token_value"] = None
@@ -174,6 +195,14 @@ class AgentPool(pulumi.CustomResource):
         Description of the agent pool.
         """
         return pulumi.get(self, "description")
+
+    @property
+    @pulumi.getter(name="forceDestroy")
+    def force_destroy(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        """
+        return pulumi.get(self, "force_destroy")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
Sometimes, a user may want to force delete an agent pool, even if it is associated with existing deployment settings. This is already supported in the API, bringing the functionality to PSP.