### PR TITLE
Don't skip post-merge tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -71,6 +71,8 @@ jobs:
       isPrerelease: true
 
   test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,8 @@ jobs:
       isPrerelease: false
 
   test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -92,6 +92,8 @@ jobs:
     uses: ./.github/workflows/lint.yml
     secrets: inherit
   test:
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test.yml
     needs:
       - prerequisites

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,6 @@ env:
 
 jobs:
   test:
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     name: test
     permissions:
       contents: read


### PR DESCRIPTION
Merging isn't triggering the pre-release step because tests are getting [skipped](https://github.com/pulumi/pulumi-pulumiservice/actions/runs/12202653842).

I think this is due to the test getting a `workflow_call` event instead of a `repository_dispatch` event. This broke when I consolidated the test workflow, and moving the conditional up should fix it.