### PR TITLE
Adding cascading secrets to Deployment settings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
 - Added secret support for all fields in DeploymentSettings [#419](https://github.com/pulumi/pulumi-pulumiservice/issues/419)
+- Added cascading secrets to Deployment settings [#447](https://github.com/pulumi/pulumi-pulumiservice/issues/447)
 
 ### Bug Fixes
 


### PR DESCRIPTION
### Summary
- Fixes: https://github.com/pulumi/pulumi-pulumiservice/issues/447 (kinda)
- The reason secret was failing to create is due to this c# specific bug - https://github.com/pulumi/pulumi-dotnet/issues/22
- A secret among env vars made the whole object secret and it was skipped
- Recent change https://github.com/pulumi/pulumi-pulumiservice/pull/467 actually made the issue worse - it is creating the env vars, but NOT secret (Thankfully I never released after that PR! 😅 )
- This PR adds cascading logic to envVars and username values - they are the only ones that are optionally secret

### Testing 
- Manual test