### PR TITLE
Fixing deleted schedules Read method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 CHANGELOG
 =========
 
-## 0.28.0 (WIP)
+## 0.29.1 (WIP)
+
+### Bug Fixes
+- Fixed Schedules' Read method erroring on non-existant schedule [#500](https://github.com/pulumi/pulumi-pulumiservice/issues/500)
+
+## 0.28.0
 
 ### Improvements
 - Added OIDC Issuer resource [#349](https://github.com/pulumi/pulumi-pulumiservice/issues/349)

--- a/provider/pkg/pulumiapi/schedules.go
+++ b/provider/pkg/pulumiapi/schedules.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"strings"
 	"time"
 )
 
@@ -105,7 +104,7 @@ func (c *Client) GetSchedule(ctx context.Context, stack StackIdentifier, schedul
 	var scheduleResponse ScheduleResponse
 	_, err := c.do(ctx, http.MethodGet, apiPath, nil, &scheduleResponse)
 	if err != nil {
-		if strings.Contains(err.Error(), "404 API error") {
+		if GetErrorStatusCode(err) == http.StatusNotFound {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to get schedule with scheduleId %s : %w", scheduleID, err)

--- a/provider/pkg/pulumiapi/schedules.go
+++ b/provider/pkg/pulumiapi/schedules.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 	"time"
 )
 
@@ -104,6 +105,9 @@ func (c *Client) GetSchedule(ctx context.Context, stack StackIdentifier, schedul
 	var scheduleResponse ScheduleResponse
 	_, err := c.do(ctx, http.MethodGet, apiPath, nil, &scheduleResponse)
 	if err != nil {
+		if strings.Contains(err.Error(), "404 API error") {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("failed to get schedule with scheduleId %s : %w", scheduleID, err)
 	}
 	return &scheduleResponse, nil

--- a/provider/pkg/pulumiapi/schedules_test.go
+++ b/provider/pkg/pulumiapi/schedules_test.go
@@ -117,8 +117,8 @@ func TestGetDeploymentSchedule(t *testing.T) {
 		})
 		defer cleanup()
 		expectedScheduleID, err := c.GetSchedule(ctx, testStack, testScheduleID)
-		assert.Nil(t, expectedScheduleID, "scheduleId should be nil since error was returned")
-		assert.EqualError(t, err, "failed to get schedule with scheduleId test-schedule-id : 404 API error: not found")
+		assert.Nil(t, expectedScheduleID, "scheduleId should be nil since it was not found")
+		assert.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
### Summary
- Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/500
- On `GetSchedule` call, return nil for both error and schedule on 404
- This makes schedule resources return empty response and cause the provider to mark object as `delete` on refresh of non-existing schedule (mostly relates to TTL schedules that destroy themselves after executing)

### Testing
- Manually tested by creating a TTL schedule that executed right after, ran `pulumi refresh`