### PR TITLE
Added ability to pass in backend URL in provider constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 ### Bug Fixes
 - Fixed Schedules' Read method erroring on non-existant schedule [#500](https://github.com/pulumi/pulumi-pulumiservice/issues/500)
+- Added ability to pass in backend url in provider constructor [#514](https://github.com/pulumi/pulumi-pulumiservice/issues/514)
 
 ## 0.28.0
 

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -16,6 +16,9 @@
       "accessToken": {
         "type": "string",
         "secret": true
+      },
+      "apiUrl": {
+        "type": "string"
       }
     }
   },
@@ -26,6 +29,10 @@
         "description": "Access Token to authenticate with Pulumi Cloud.",
         "type": "string",
         "secret": true
+      },
+      "apiUrl": {
+        "description": "Optional override of Pulumi Cloud API endpoint.",
+        "type": "string"
       }
     }
   },

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -39,5 +39,12 @@ namespace Pulumi.PulumiService
             set => _accessToken.Set(value);
         }
 
+        private static readonly __Value<string?> _apiUrl = new __Value<string?>(() => __config.Get("apiUrl"));
+        public static string? ApiUrl
+        {
+            get => _apiUrl.Get();
+            set => _apiUrl.Set(value);
+        }
+
     }
 }

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -55,6 +55,12 @@ namespace Pulumi.PulumiService
             }
         }
 
+        /// <summary>
+        /// Optional override of Pulumi Cloud API endpoint.
+        /// </summary>
+        [Input("apiUrl")]
+        public Input<string>? ApiUrl { get; set; }
+
         public ProviderArgs()
         {
         }

--- a/sdk/go/pulumiservice/config/config.go
+++ b/sdk/go/pulumiservice/config/config.go
@@ -14,3 +14,6 @@ var _ = internal.GetEnvOrDefault
 func GetAccessToken(ctx *pulumi.Context) string {
 	return config.Get(ctx, "pulumiservice:accessToken")
 }
+func GetApiUrl(ctx *pulumi.Context) string {
+	return config.Get(ctx, "pulumiservice:apiUrl")
+}

--- a/sdk/go/pulumiservice/provider.go
+++ b/sdk/go/pulumiservice/provider.go
@@ -37,12 +37,16 @@ func NewProvider(ctx *pulumi.Context,
 type providerArgs struct {
 	// Access Token to authenticate with Pulumi Cloud.
 	AccessToken *string `pulumi:"accessToken"`
+	// Optional override of Pulumi Cloud API endpoint.
+	ApiUrl *string `pulumi:"apiUrl"`
 }
 
 // The set of arguments for constructing a Provider resource.
 type ProviderArgs struct {
 	// Access Token to authenticate with Pulumi Cloud.
 	AccessToken pulumi.StringPtrInput
+	// Optional override of Pulumi Cloud API endpoint.
+	ApiUrl pulumi.StringPtrInput
 }
 
 func (ProviderArgs) ElementType() reflect.Type {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Config.java
@@ -13,4 +13,7 @@ public final class Config {
     public Optional<String> accessToken() {
         return Codegen.stringProp("accessToken").config(config).get();
     }
+    public Optional<String> apiUrl() {
+        return Codegen.stringProp("apiUrl").config(config).get();
+    }
 }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/ProviderArgs.java
@@ -30,10 +30,26 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.accessToken);
     }
 
+    /**
+     * Optional override of Pulumi Cloud API endpoint.
+     * 
+     */
+    @Import(name="apiUrl")
+    private @Nullable Output<String> apiUrl;
+
+    /**
+     * @return Optional override of Pulumi Cloud API endpoint.
+     * 
+     */
+    public Optional<Output<String>> apiUrl() {
+        return Optional.ofNullable(this.apiUrl);
+    }
+
     private ProviderArgs() {}
 
     private ProviderArgs(ProviderArgs $) {
         this.accessToken = $.accessToken;
+        this.apiUrl = $.apiUrl;
     }
 
     public static Builder builder() {
@@ -73,6 +89,27 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder accessToken(String accessToken) {
             return accessToken(Output.of(accessToken));
+        }
+
+        /**
+         * @param apiUrl Optional override of Pulumi Cloud API endpoint.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder apiUrl(@Nullable Output<String> apiUrl) {
+            $.apiUrl = apiUrl;
+            return this;
+        }
+
+        /**
+         * @param apiUrl Optional override of Pulumi Cloud API endpoint.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder apiUrl(String apiUrl) {
+            return apiUrl(Output.of(apiUrl));
         }
 
         public ProviderArgs build() {

--- a/sdk/nodejs/config/vars.ts
+++ b/sdk/nodejs/config/vars.ts
@@ -15,3 +15,11 @@ Object.defineProperty(exports, "accessToken", {
     enumerable: true,
 });
 
+export declare const apiUrl: string | undefined;
+Object.defineProperty(exports, "apiUrl", {
+    get() {
+        return __config.get("apiUrl");
+    },
+    enumerable: true,
+});
+

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -32,6 +32,7 @@ export class Provider extends pulumi.ProviderResource {
         opts = opts || {};
         {
             resourceInputs["accessToken"] = args?.accessToken ? pulumi.secret(args.accessToken) : undefined;
+            resourceInputs["apiUrl"] = args ? args.apiUrl : undefined;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         super(Provider.__pulumiType, name, resourceInputs, opts);
@@ -46,4 +47,8 @@ export interface ProviderArgs {
      * Access Token to authenticate with Pulumi Cloud.
      */
     accessToken?: pulumi.Input<string>;
+    /**
+     * Optional override of Pulumi Cloud API endpoint.
+     */
+    apiUrl?: pulumi.Input<string>;
 }

--- a/sdk/python/pulumi_pulumiservice/config/__init__.pyi
+++ b/sdk/python/pulumi_pulumiservice/config/__init__.pyi
@@ -16,3 +16,5 @@ from .. import _utilities
 
 accessToken: Optional[str]
 
+apiUrl: Optional[str]
+

--- a/sdk/python/pulumi_pulumiservice/config/vars.py
+++ b/sdk/python/pulumi_pulumiservice/config/vars.py
@@ -24,3 +24,7 @@ class _ExportableConfig(types.ModuleType):
     def access_token(self) -> Optional[str]:
         return __config__.get('accessToken')
 
+    @property
+    def api_url(self) -> Optional[str]:
+        return __config__.get('apiUrl')
+

--- a/sdk/python/pulumi_pulumiservice/provider.py
+++ b/sdk/python/pulumi_pulumiservice/provider.py
@@ -19,13 +19,17 @@ __all__ = ['ProviderArgs', 'Provider']
 @pulumi.input_type
 class ProviderArgs:
     def __init__(__self__, *,
-                 access_token: Optional[pulumi.Input[str]] = None):
+                 access_token: Optional[pulumi.Input[str]] = None,
+                 api_url: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a Provider resource.
         :param pulumi.Input[str] access_token: Access Token to authenticate with Pulumi Cloud.
+        :param pulumi.Input[str] api_url: Optional override of Pulumi Cloud API endpoint.
         """
         if access_token is not None:
             pulumi.set(__self__, "access_token", access_token)
+        if api_url is not None:
+            pulumi.set(__self__, "api_url", api_url)
 
     @property
     @pulumi.getter(name="accessToken")
@@ -39,6 +43,18 @@ class ProviderArgs:
     def access_token(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "access_token", value)
 
+    @property
+    @pulumi.getter(name="apiUrl")
+    def api_url(self) -> Optional[pulumi.Input[str]]:
+        """
+        Optional override of Pulumi Cloud API endpoint.
+        """
+        return pulumi.get(self, "api_url")
+
+    @api_url.setter
+    def api_url(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "api_url", value)
+
 
 class Provider(pulumi.ProviderResource):
     @overload
@@ -46,12 +62,14 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  access_token: Optional[pulumi.Input[str]] = None,
+                 api_url: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
         Create a Pulumiservice resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] access_token: Access Token to authenticate with Pulumi Cloud.
+        :param pulumi.Input[str] api_url: Optional override of Pulumi Cloud API endpoint.
         """
         ...
     @overload
@@ -77,6 +95,7 @@ class Provider(pulumi.ProviderResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  access_token: Optional[pulumi.Input[str]] = None,
+                 api_url: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):
@@ -87,6 +106,7 @@ class Provider(pulumi.ProviderResource):
             __props__ = ProviderArgs.__new__(ProviderArgs)
 
             __props__.__dict__["access_token"] = None if access_token is None else pulumi.Output.secret(access_token)
+            __props__.__dict__["api_url"] = api_url
         super(Provider, __self__).__init__(
             'pulumiservice',
             resource_name,


### PR DESCRIPTION
### Summary
- Added ability to pass in backend URL in provider constructor

### Testing
- Verified running against prod, but creating resources in review stack:
```
const myProvider = new service.Provider("revStackProvider", {
    accessToken: "pul-123",
    apiUrl: "https://api.review-stacks.pulumi-dev.io"
})

const webhook = new service.Webhook("test-webhook", {
    active: true,
    displayName:"webhook testing2",
    organizationName: "pulumi_local",
    payloadUrl: "https://calendar.google.com/calendar/u/0/r/week",
    }, {
        provider: myProvider
    });
```

