### PR TITLE
Fix a typo in the TTL API type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 CHANGELOG
 =========
-
-## 0.29.1 (WIP)
+## 0.29.2 (WIP)
 
 ### Bug Fixes
-- Fixed Schedules' Read method erroring on non-existant schedule [#500](https://github.com/pulumi/pulumi-pulumiservice/issues/500)
-- Added ability to pass in backend url in provider constructor [#514](https://github.com/pulumi/pulumi-pulumiservice/issues/514)
+
+- Fix a bug in TTLSchedules preventing correct handling of deleteBeforeDestroy [#517](https://github.com/pulumi/pulumi-pulumiservice/pull/517)
+
+## 0.29.1
+
+### Bug Fixes
+
+- Fixed Schedules' Read method erroring on non-existent schedule [#510](https://github.com/pulumi/pulumi-pulumiservice/pull/510)
+- Added ability to pass in backend url in provider constructor [#515](https://github.com/pulumi/pulumi-pulumiservice/pull/515)
 
 ## 0.28.0
 
 ### Improvements
+
 - Added OIDC Issuer resource [#349](https://github.com/pulumi/pulumi-pulumiservice/issues/349)
 
 ## 0.27.4

--- a/provider/pkg/pulumiapi/schedules.go
+++ b/provider/pkg/pulumiapi/schedules.go
@@ -50,7 +50,7 @@ type CreateDriftScheduleRequest struct {
 
 type CreateTtlScheduleRequest struct {
 	Timestamp          time.Time `json:"timestamp,omitempty"`
-	DeleteAfterDestroy bool      `json:"deleteAfterDestroy ,omitempty"`
+	DeleteAfterDestroy bool      `json:"deleteAfterDestroy,omitempty"`
 }
 
 type ScheduleResponse struct {


### PR DESCRIPTION
The typo was preventing the API request from being marshalled correctly, causing the `deleteBeforeDestroy` property to get dropped.

Fixes https://github.com/pulumi/pulumi-pulumiservice/issues/512