### PR TITLE
teams: add support for ESC env max open duration 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.24.0
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/pgavlin/fx/v2 v2.0.9
 	github.com/pulumi/esc v0.10.0
 	github.com/pulumi/pulumi/pkg/v3 v3.138.0
 	github.com/pulumi/pulumi/sdk/v3 v3.138.0

--- a/go.sum
+++ b/go.sum
@@ -320,6 +320,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pgavlin/fx v0.1.6 h1:r9jEg69DhNoCd3Xh0+5mIbdbS3PqWrVWujkY76MFRTU=
 github.com/pgavlin/fx v0.1.6/go.mod h1:KWZJ6fqBBSh8GxHYqwYCf3rYE7Gp2p0N8tJp8xv9u9M=
+github.com/pgavlin/fx/v2 v2.0.9 h1:jOne6A8vOeYM/lHe8OvvE5Hy/krU6sRZs9naGorVO2U=
+github.com/pgavlin/fx/v2 v2.0.9/go.mod h1:Cvnwqq0BopdHUJ7CU50h1XPeKrF4ZwdFj1nJLXbAjCE=
 github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 h1:LoCV5cscNVWyK5ChN/uCoIFJz8jZD63VQiGJIRgr6uo=
 github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386/go.mod h1:MRxHTJrf9FhdfNQ8Hdeh9gmHevC9RJE/fu8M3JIGjoE=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -1683,6 +1683,10 @@
         "permission": {
           "description": "Which permission level to grant to the specified team.",
           "$ref": "#/types/pulumiservice:index:EnvironmentPermission"
+        },
+        "maxOpenDuration": {
+          "description": "The maximum duration for which members of this team may open the environment.",
+          "type": "string"
         }
       },
       "inputProperties": {
@@ -1706,6 +1710,10 @@
         "permission": {
           "description": "Which permission level to grant to the specified team.",
           "$ref": "#/types/pulumiservice:index:EnvironmentPermission"
+        },
+        "maxOpenDuration": {
+          "description": "The maximum duration for which members of this team may open the environment.",
+          "type": "string"
         }
       },
       "requiredInputs": [

--- a/provider/pkg/pulumiapi/teams_test.go
+++ b/provider/pkg/pulumiapi/teams_test.go
@@ -3,7 +3,9 @@ package pulumiapi
 import (
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/pgavlin/fx/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -310,24 +312,26 @@ func TestAddEnvironmentPermission(t *testing.T) {
 		c, cleanup := startTestServer(t, testServerConfig{
 			ExpectedReqMethod: http.MethodPatch,
 			ExpectedReqPath:   "/api/orgs/an-organization/teams/a-team",
-			ExpectedReqBody: addEnvironmentPermissionRequest{
+			ExpectedReqBody: addEnvironmentSettingsRequest{
 				AddEnvironmentPermission: AddEnvironmentPermission{
-					ProjectName: project,
-					EnvName:     environment,
-					Permission:  permission,
+					ProjectName:     project,
+					EnvName:         environment,
+					Permission:      permission,
+					MaxOpenDuration: fx.Some(Duration(15 * time.Minute)),
 				},
 			},
 			ResponseCode: 204,
 		})
 		defer cleanup()
-		assert.NoError(t, c.AddEnvironmentPermission(ctx, CreateTeamEnvironmentPermissionRequest{
-			TeamEnvironmentPermissionRequest: TeamEnvironmentPermissionRequest{
+		assert.NoError(t, c.AddEnvironmentSettings(ctx, CreateTeamEnvironmentSettingsRequest{
+			TeamEnvironmentSettingsRequest: TeamEnvironmentSettingsRequest{
 				Organization: organization,
 				Project:      project,
 				Environment:  environment,
 				Team:         teamName,
 			},
-			Permission: permission,
+			Permission:      permission,
+			MaxOpenDuration: fx.Some(Duration(15 * time.Minute)),
 		}))
 	})
 }
@@ -350,7 +354,7 @@ func TestRemoveEnvironmentPermission(t *testing.T) {
 			ResponseCode: 204,
 		})
 		defer cleanup()
-		assert.NoError(t, c.RemoveEnvironmentPermission(ctx, TeamEnvironmentPermissionRequest{
+		assert.NoError(t, c.RemoveEnvironmentSettings(ctx, TeamEnvironmentSettingsRequest{
 			Organization: organization,
 			Team:         teamName,
 			Project:      project,

--- a/provider/pkg/pulumiapi/utils.go
+++ b/provider/pkg/pulumiapi/utils.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 package pulumiapi
+
+import (
+	"encoding/json"
+	"time"
+)
 
 func contains(s []string, e string) bool {
 	for _, a := range s {
@@ -24,4 +29,24 @@ func contains(s []string, e string) bool {
 
 func ok(code int) bool {
 	return code >= 200 && code < 300
+}
+
+// A Duration is a wrapper for time.Duration that marshals into JSON as a human-readable string.
+type Duration time.Duration
+
+func (v Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Duration(v).String())
+}
+
+func (v *Duration) UnmarshalJSON(bytes []byte) error {
+	var s string
+	if err := json.Unmarshal(bytes, &s); err != nil {
+		return err
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*v = Duration(d)
+	return nil
 }

--- a/provider/pkg/resources/team_environment_perm.go
+++ b/provider/pkg/resources/team_environment_perm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
 
@@ -19,11 +20,12 @@ type PulumiServiceTeamEnvironmentPermissionResource struct {
 }
 
 type TeamEnvironmentPermissionInput struct {
-	Organization string `pulumi:"organization"`
-	Team         string `pulumi:"team"`
-	Environment  string `pulumi:"environment"`
-	Project      string `pulumi:"project"`
-	Permission   string `pulumi:"permission"`
+	Organization    string `pulumi:"organization"`
+	Team            string `pulumi:"team"`
+	Environment     string `pulumi:"environment"`
+	Project         string `pulumi:"project"`
+	Permission      string `pulumi:"permission"`
+	MaxOpenDuration string `pulumi:"maxOpenDuration"`
 }
 
 func (i *TeamEnvironmentPermissionInput) ToPropertyMap() resource.PropertyMap {
@@ -40,6 +42,22 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Name() string {
 }
 
 func (tp *PulumiServiceTeamEnvironmentPermissionResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
+	var input TeamEnvironmentPermissionInput
+	err := util.FromProperties(req.GetNews(), structTagKey, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	var failures []*pulumirpc.CheckFailure
+	if input.MaxOpenDuration != "" {
+		if _, err := time.ParseDuration(input.MaxOpenDuration); err != nil {
+			failures = append(failures, &pulumirpc.CheckFailure{
+				Property: "maxOpenDuration",
+				Reason:   fmt.Sprintf("malformed duration: %v", err),
+			})
+		}
+	}
+
 	return &pulumirpc.CheckResponse{
 		Inputs: req.GetNews(),
 	}, nil
@@ -52,13 +70,13 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Read(req *pulumirpc.Re
 		return nil, err
 	}
 
-	request := pulumiapi.TeamEnvironmentPermissionRequest{
+	request := pulumiapi.TeamEnvironmentSettingsRequest{
 		Organization: permId.Organization,
 		Team:         permId.Team,
 		Environment:  permId.Environment,
 		Project:      permId.Project,
 	}
-	permission, err := tp.Client.GetTeamEnvironmentPermission(ctx, request)
+	permission, maxOpenDuration, err := tp.Client.GetTeamEnvironmentSettings(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get team environment permission: %w", err)
 	}
@@ -66,12 +84,18 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Read(req *pulumirpc.Re
 		return &pulumirpc.ReadResponse{}, nil
 	}
 
+	var maxOpenDurationStr string
+	if maxOpenDuration != nil {
+		maxOpenDurationStr = (time.Duration)(*maxOpenDuration).String()
+	}
+
 	inputs := TeamEnvironmentPermissionInput{
-		Organization: permId.Organization,
-		Team:         permId.Team,
-		Project:      permId.Project,
-		Environment:  permId.Environment,
-		Permission:   *permission,
+		Organization:    permId.Organization,
+		Team:            permId.Team,
+		Project:         permId.Project,
+		Environment:     permId.Environment,
+		Permission:      *permission,
+		MaxOpenDuration: maxOpenDurationStr,
 	}
 
 	properties, err := plugin.MarshalProperties(inputs.ToPropertyMap(), plugin.MarshalOptions{})
@@ -92,17 +116,28 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Create(req *pulumirpc.
 	if err != nil {
 		return nil, err
 	}
-	request := pulumiapi.CreateTeamEnvironmentPermissionRequest{
-		TeamEnvironmentPermissionRequest: pulumiapi.TeamEnvironmentPermissionRequest{
+
+	var maxOpenDuration *pulumiapi.Duration
+	if input.MaxOpenDuration != "" {
+		d, err := time.ParseDuration(input.MaxOpenDuration)
+		if err != nil {
+			return nil, err
+		}
+		maxOpenDuration = (*pulumiapi.Duration)(&d)
+	}
+
+	request := pulumiapi.CreateTeamEnvironmentSettingsRequest{
+		TeamEnvironmentSettingsRequest: pulumiapi.TeamEnvironmentSettingsRequest{
 			Organization: input.Organization,
 			Team:         input.Team,
 			Project:      input.Project,
 			Environment:  input.Environment,
 		},
-		Permission: input.Permission,
+		Permission:      input.Permission,
+		MaxOpenDuration: maxOpenDuration,
 	}
 
-	err = tp.Client.AddEnvironmentPermission(ctx, request)
+	err = tp.Client.AddEnvironmentSettings(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -127,13 +162,13 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Delete(req *pulumirpc.
 	if err != nil {
 		return nil, err
 	}
-	request := pulumiapi.TeamEnvironmentPermissionRequest{
+	request := pulumiapi.TeamEnvironmentSettingsRequest{
 		Organization: input.Organization,
 		Team:         input.Team,
 		Project:      input.Project,
 		Environment:  input.Environment,
 	}
-	err = tp.Client.RemoveEnvironmentPermission(ctx, request)
+	err = tp.Client.RemoveEnvironmentSettings(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -150,8 +185,9 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Diff(req *pulumirpc.Di
 		changes = pulumirpc.DiffResponse_DIFF_SOME
 	}
 	return &pulumirpc.DiffResponse{
-		Changes:  changes,
-		Replaces: changedKeys,
+		Changes:             changes,
+		Replaces:            changedKeys,
+		DeleteBeforeReplace: true,
 	}, nil
 }
 

--- a/provider/pkg/resources/team_test.go
+++ b/provider/pkg/resources/team_test.go
@@ -44,14 +44,14 @@ func (c *TeamClientMock) RemoveStackPermission(ctx context.Context, stack pulumi
 func (c *TeamClientMock) GetTeamStackPermission(ctx context.Context, stack pulumiapi.StackIdentifier, teamName string) (*int, error) {
 	return nil, nil
 }
-func (c *TeamClientMock) AddEnvironmentPermission(ctx context.Context, req pulumiapi.CreateTeamEnvironmentPermissionRequest) error {
+func (c *TeamClientMock) AddEnvironmentSettings(ctx context.Context, req pulumiapi.CreateTeamEnvironmentSettingsRequest) error {
 	return nil
 }
-func (c *TeamClientMock) RemoveEnvironmentPermission(ctx context.Context, req pulumiapi.TeamEnvironmentPermissionRequest) error {
+func (c *TeamClientMock) RemoveEnvironmentSettings(ctx context.Context, req pulumiapi.TeamEnvironmentSettingsRequest) error {
 	return nil
 }
-func (c *TeamClientMock) GetTeamEnvironmentPermission(ctx context.Context, req pulumiapi.TeamEnvironmentPermissionRequest) (*string, error) {
-	return nil, nil
+func (c *TeamClientMock) GetTeamEnvironmentSettings(ctx context.Context, req pulumiapi.TeamEnvironmentSettingsRequest) (*string, *pulumiapi.Duration, error) {
+	return nil, nil, nil
 }
 
 func buildTeamClientMock(getTeamFunc getTeamFunc) *TeamClientMock {

--- a/sdk/dotnet/TeamEnvironmentPermission.cs
+++ b/sdk/dotnet/TeamEnvironmentPermission.cs
@@ -22,6 +22,12 @@ namespace Pulumi.PulumiService
         public Output<string?> Environment { get; private set; } = null!;
 
         /// <summary>
+        /// The maximum duration for which members of this team may open the environment.
+        /// </summary>
+        [Output("maxOpenDuration")]
+        public Output<string?> MaxOpenDuration { get; private set; } = null!;
+
+        /// <summary>
         /// Organization name.
         /// </summary>
         [Output("organization")]
@@ -95,6 +101,12 @@ namespace Pulumi.PulumiService
         /// </summary>
         [Input("environment", required: true)]
         public Input<string> Environment { get; set; } = null!;
+
+        /// <summary>
+        /// The maximum duration for which members of this team may open the environment.
+        /// </summary>
+        [Input("maxOpenDuration")]
+        public Input<string>? MaxOpenDuration { get; set; }
 
         /// <summary>
         /// Organization name.

--- a/sdk/go/pulumiservice/teamEnvironmentPermission.go
+++ b/sdk/go/pulumiservice/teamEnvironmentPermission.go
@@ -18,6 +18,8 @@ type TeamEnvironmentPermission struct {
 
 	// Environment name.
 	Environment pulumi.StringPtrOutput `pulumi:"environment"`
+	// The maximum duration for which members of this team may open the environment.
+	MaxOpenDuration pulumi.StringPtrOutput `pulumi:"maxOpenDuration"`
 	// Organization name.
 	Organization pulumi.StringPtrOutput `pulumi:"organization"`
 	// Which permission level to grant to the specified team.
@@ -85,6 +87,8 @@ func (TeamEnvironmentPermissionState) ElementType() reflect.Type {
 type teamEnvironmentPermissionArgs struct {
 	// Environment name.
 	Environment string `pulumi:"environment"`
+	// The maximum duration for which members of this team may open the environment.
+	MaxOpenDuration *string `pulumi:"maxOpenDuration"`
 	// Organization name.
 	Organization string `pulumi:"organization"`
 	// Which permission level to grant to the specified team.
@@ -99,6 +103,8 @@ type teamEnvironmentPermissionArgs struct {
 type TeamEnvironmentPermissionArgs struct {
 	// Environment name.
 	Environment pulumi.StringInput
+	// The maximum duration for which members of this team may open the environment.
+	MaxOpenDuration pulumi.StringPtrInput
 	// Organization name.
 	Organization pulumi.StringInput
 	// Which permission level to grant to the specified team.
@@ -199,6 +205,11 @@ func (o TeamEnvironmentPermissionOutput) ToTeamEnvironmentPermissionOutputWithCo
 // Environment name.
 func (o TeamEnvironmentPermissionOutput) Environment() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringPtrOutput { return v.Environment }).(pulumi.StringPtrOutput)
+}
+
+// The maximum duration for which members of this team may open the environment.
+func (o TeamEnvironmentPermissionOutput) MaxOpenDuration() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringPtrOutput { return v.MaxOpenDuration }).(pulumi.StringPtrOutput)
 }
 
 // Organization name.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
@@ -35,6 +35,20 @@ public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResour
         return Codegen.optional(this.environment);
     }
     /**
+     * The maximum duration for which members of this team may open the environment.
+     * 
+     */
+    @Export(name="maxOpenDuration", refs={String.class}, tree="[0]")
+    private Output</* @Nullable */ String> maxOpenDuration;
+
+    /**
+     * @return The maximum duration for which members of this team may open the environment.
+     * 
+     */
+    public Output<Optional<String>> maxOpenDuration() {
+        return Codegen.optional(this.maxOpenDuration);
+    }
+    /**
      * Organization name.
      * 
      */

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermissionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermissionArgs.java
@@ -34,6 +34,21 @@ public final class TeamEnvironmentPermissionArgs extends com.pulumi.resources.Re
     }
 
     /**
+     * The maximum duration for which members of this team may open the environment.
+     * 
+     */
+    @Import(name="maxOpenDuration")
+    private @Nullable Output<String> maxOpenDuration;
+
+    /**
+     * @return The maximum duration for which members of this team may open the environment.
+     * 
+     */
+    public Optional<Output<String>> maxOpenDuration() {
+        return Optional.ofNullable(this.maxOpenDuration);
+    }
+
+    /**
      * Organization name.
      * 
      */
@@ -97,6 +112,7 @@ public final class TeamEnvironmentPermissionArgs extends com.pulumi.resources.Re
 
     private TeamEnvironmentPermissionArgs(TeamEnvironmentPermissionArgs $) {
         this.environment = $.environment;
+        this.maxOpenDuration = $.maxOpenDuration;
         this.organization = $.organization;
         this.permission = $.permission;
         this.project = $.project;
@@ -140,6 +156,27 @@ public final class TeamEnvironmentPermissionArgs extends com.pulumi.resources.Re
          */
         public Builder environment(String environment) {
             return environment(Output.of(environment));
+        }
+
+        /**
+         * @param maxOpenDuration The maximum duration for which members of this team may open the environment.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder maxOpenDuration(@Nullable Output<String> maxOpenDuration) {
+            $.maxOpenDuration = maxOpenDuration;
+            return this;
+        }
+
+        /**
+         * @param maxOpenDuration The maximum duration for which members of this team may open the environment.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder maxOpenDuration(String maxOpenDuration) {
+            return maxOpenDuration(Output.of(maxOpenDuration));
         }
 
         /**

--- a/sdk/nodejs/teamEnvironmentPermission.ts
+++ b/sdk/nodejs/teamEnvironmentPermission.ts
@@ -42,6 +42,10 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
      */
     public readonly environment!: pulumi.Output<string | undefined>;
     /**
+     * The maximum duration for which members of this team may open the environment.
+     */
+    public readonly maxOpenDuration!: pulumi.Output<string | undefined>;
+    /**
      * Organization name.
      */
     public readonly organization!: pulumi.Output<string | undefined>;
@@ -82,12 +86,14 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
                 throw new Error("Missing required property 'team'");
             }
             resourceInputs["environment"] = args ? args.environment : undefined;
+            resourceInputs["maxOpenDuration"] = args ? args.maxOpenDuration : undefined;
             resourceInputs["organization"] = args ? args.organization : undefined;
             resourceInputs["permission"] = args ? args.permission : undefined;
             resourceInputs["project"] = (args ? args.project : undefined) ?? "default";
             resourceInputs["team"] = args ? args.team : undefined;
         } else {
             resourceInputs["environment"] = undefined /*out*/;
+            resourceInputs["maxOpenDuration"] = undefined /*out*/;
             resourceInputs["organization"] = undefined /*out*/;
             resourceInputs["permission"] = undefined /*out*/;
             resourceInputs["project"] = undefined /*out*/;
@@ -106,6 +112,10 @@ export interface TeamEnvironmentPermissionArgs {
      * Environment name.
      */
     environment: pulumi.Input<string>;
+    /**
+     * The maximum duration for which members of this team may open the environment.
+     */
+    maxOpenDuration?: pulumi.Input<string>;
     /**
      * Organization name.
      */

--- a/sdk/python/pulumi_pulumiservice/team_environment_permission.py
+++ b/sdk/python/pulumi_pulumiservice/team_environment_permission.py
@@ -24,6 +24,7 @@ class TeamEnvironmentPermissionArgs:
                  organization: pulumi.Input[str],
                  permission: pulumi.Input['EnvironmentPermission'],
                  team: pulumi.Input[str],
+                 max_open_duration: Optional[pulumi.Input[str]] = None,
                  project: Optional[pulumi.Input[str]] = None):
         """
         The set of arguments for constructing a TeamEnvironmentPermission resource.
@@ -31,12 +32,15 @@ class TeamEnvironmentPermissionArgs:
         :param pulumi.Input[str] organization: Organization name.
         :param pulumi.Input['EnvironmentPermission'] permission: Which permission level to grant to the specified team.
         :param pulumi.Input[str] team: Team name.
+        :param pulumi.Input[str] max_open_duration: The maximum duration for which members of this team may open the environment.
         :param pulumi.Input[str] project: Project name.
         """
         pulumi.set(__self__, "environment", environment)
         pulumi.set(__self__, "organization", organization)
         pulumi.set(__self__, "permission", permission)
         pulumi.set(__self__, "team", team)
+        if max_open_duration is not None:
+            pulumi.set(__self__, "max_open_duration", max_open_duration)
         if project is None:
             project = 'default'
         if project is not None:
@@ -91,6 +95,18 @@ class TeamEnvironmentPermissionArgs:
         pulumi.set(self, "team", value)
 
     @property
+    @pulumi.getter(name="maxOpenDuration")
+    def max_open_duration(self) -> Optional[pulumi.Input[str]]:
+        """
+        The maximum duration for which members of this team may open the environment.
+        """
+        return pulumi.get(self, "max_open_duration")
+
+    @max_open_duration.setter
+    def max_open_duration(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "max_open_duration", value)
+
+    @property
     @pulumi.getter
     def project(self) -> Optional[pulumi.Input[str]]:
         """
@@ -109,6 +125,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  environment: Optional[pulumi.Input[str]] = None,
+                 max_open_duration: Optional[pulumi.Input[str]] = None,
                  organization: Optional[pulumi.Input[str]] = None,
                  permission: Optional[pulumi.Input['EnvironmentPermission']] = None,
                  project: Optional[pulumi.Input[str]] = None,
@@ -120,6 +137,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] environment: Environment name.
+        :param pulumi.Input[str] max_open_duration: The maximum duration for which members of this team may open the environment.
         :param pulumi.Input[str] organization: Organization name.
         :param pulumi.Input['EnvironmentPermission'] permission: Which permission level to grant to the specified team.
         :param pulumi.Input[str] project: Project name.
@@ -150,6 +168,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  environment: Optional[pulumi.Input[str]] = None,
+                 max_open_duration: Optional[pulumi.Input[str]] = None,
                  organization: Optional[pulumi.Input[str]] = None,
                  permission: Optional[pulumi.Input['EnvironmentPermission']] = None,
                  project: Optional[pulumi.Input[str]] = None,
@@ -166,6 +185,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
             if environment is None and not opts.urn:
                 raise TypeError("Missing required property 'environment'")
             __props__.__dict__["environment"] = environment
+            __props__.__dict__["max_open_duration"] = max_open_duration
             if organization is None and not opts.urn:
                 raise TypeError("Missing required property 'organization'")
             __props__.__dict__["organization"] = organization
@@ -201,6 +221,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
         __props__ = TeamEnvironmentPermissionArgs.__new__(TeamEnvironmentPermissionArgs)
 
         __props__.__dict__["environment"] = None
+        __props__.__dict__["max_open_duration"] = None
         __props__.__dict__["organization"] = None
         __props__.__dict__["permission"] = None
         __props__.__dict__["project"] = None
@@ -214,6 +235,14 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
         Environment name.
         """
         return pulumi.get(self, "environment")
+
+    @property
+    @pulumi.getter(name="maxOpenDuration")
+    def max_open_duration(self) -> pulumi.Output[Optional[str]]:
+        """
+        The maximum duration for which members of this team may open the environment.
+        """
+        return pulumi.get(self, "max_open_duration")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
These changes add support to the TeamEnvironmentPermission resource for
configuring maximum open durations for ESC environments. The max open
duration is represented as a new property on the resource.