### PR TITLE
chore: Fixing up the oidc issuer examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+### Bug Fixes
+
+- Fixed OIDC issuer examples: removed unsupported runner token type and updated Pulumi OIDC thumbprint 
+
 ## 0.31.0
 
 ### Improvements

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,194 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the Pulumi Service Provider (PSP), a Pulumi provider built on top of the Pulumi Cloud REST API that allows managing Pulumi Cloud resources (Stacks, Environments, Teams, Tokens, Webhooks, Deployment Settings, etc.) using Pulumi programs.
+
+The provider is written in Go and generates SDKs for multiple languages (Node.js/TypeScript, Python, Go, .NET, Java).
+
+## Repository Structure
+
+- `provider/` - Core provider implementation in Go
+  - `provider/cmd/pulumi-resource-pulumiservice/` - Main provider binary and schema.json
+  - `provider/pkg/provider/` - Provider server implementation (gRPC)
+  - `provider/pkg/pulumiapi/` - HTTP client wrappers for Pulumi Cloud REST API
+  - `provider/pkg/resources/` - Resource implementations (teams, stacks, webhooks, etc.)
+  - `provider/pkg/util/` - Utility functions for property handling, diffs, secrets
+- `sdk/` - Generated SDKs for each language (dotnet, go, java, nodejs, python)
+- `examples/` - Example programs in various languages demonstrating provider usage
+
+## Build Commands
+
+### Essential Commands
+
+```bash
+# Restore/install build dependencies
+make ensure
+
+# Build provider binary only
+make provider
+
+# Build all SDKs (requires provider to be built first)
+make build_sdks
+
+# Build everything (provider + all SDKs)
+make build
+
+# Run provider tests
+make test_provider
+
+# Run linting (runs golangci-lint in provider, sdk, and examples directories)
+make lint
+```
+
+### SDK-Specific Commands
+
+```bash
+make nodejs_sdk    # Build Node.js/TypeScript SDK
+make python_sdk    # Build Python SDK
+make go_sdk        # Build Go SDK
+make dotnet_sdk    # Build .NET SDK
+make java_sdk      # Build Java SDK
+```
+
+### Installation Commands
+
+```bash
+make install              # Install provider binary and Node.js/dotnet SDKs
+make install_nodejs_sdk   # Link Node.js SDK locally via yarn
+make install_java_sdk     # Publish Java SDK to local Maven
+```
+
+## Environment Variables
+
+- **Integration Tests**: This project uses `.env` file for local testing credentials
+  - `PULUMI_ACCESS_TOKEN`: Token for authenticating with Pulumi Cloud
+  - `PULUMI_TEST_OWNER`: Organization name for tests (defaults to `service-provider-test-org` if not set)
+  - These variables are loaded automatically by the test framework when present in `.env`
+  - The `.env` file is gitignored for security
+
+### Testing
+
+```bash
+# Run provider unit tests
+cd provider/pkg && go test -short -v -count=1 -cover -timeout 2h -parallel 4 ./...
+
+# Run example tests (integration tests)
+cd examples && go test -tags=all -v -count=1 -timeout 3h -parallel 4
+
+# Run specific example test
+cd examples && go test -v -run TestYamlStackTagsPluralExample -tags yaml -timeout 10m
+```
+
+- Integration tests are located in `examples/` directory
+- Tests are tagged: use `-tags yaml`, `-tags nodejs`, `-tags python`, etc.
+- The `.env` file allows running integration tests locally against a custom organization
+- Every new resource should have unit tests in `provider/pkg/` with `_test.go` suffix
+- Add example programs in `examples/` for each new resource (examples serve as integration tests)
+- Examples are organized by language: `ts-*`, `py-*`, `go-*`, `cs-*`, `java-*`, `yaml-*`
+
+## Development Workflow
+
+### CHANGELOG Updates
+
+**IMPORTANT**: Always update `CHANGELOG.md` when making code changes that affect users:
+
+1. Add an entry under the `## Unreleased` section
+2. If `## Unreleased` doesn't exist, create it at the top of the file (after the `# CHANGELOG` header)
+3. Categorize changes appropriately:
+   - `### Improvements` - New features, enhancements, new resources
+   - `### Bug Fixes` - Bug fixes, corrections
+   - `### Breaking Changes` - Breaking changes (rare, requires major version bump)
+4. Format: `- Description of change [#issue_or_pr_number](link_to_issue_or_pr)`
+5. Examples:
+   - `- Added StackTags resource for managing multiple stack tags [#61](https://github.com/pulumi/pulumi-pulumiservice/issues/61)`
+   - `- Fixed OIDC Issuer policies order to prevent accidental drifts [#542](https://github.com/pulumi/pulumi-pulumiservice/pull/542)`
+
+### Schema Changes
+
+The provider schema is **manually maintained** at `provider/cmd/pulumi-resource-pulumiservice/schema.json`. When adding/modifying resources:
+
+1. Update `schema.json` with the new resource/property definitions
+2. Run `make provider` to regenerate the provider binary (uses `go generate`)
+3. Run `make build_sdks` to regenerate all language SDKs from the schema
+4. The schema is embedded into the provider binary at build time
+
+### Adding a New Resource
+
+1. Add resource definition to `provider/cmd/pulumi-resource-pulumiservice/schema.json`
+2. Create API client methods in `provider/pkg/pulumiapi/` (e.g., `teams.go`, `webhooks.go`)
+3. Create resource implementation in `provider/pkg/resources/` implementing `PulumiServiceResource` interface
+4. Register the resource in `provider/pkg/provider/provider.go`
+5. Rebuild provider and SDKs: `make build`
+6. Add examples in `examples/` directory
+
+### Resource Interface
+
+All resources must implement the `PulumiServiceResource` interface:
+
+```go
+type PulumiServiceResource interface {
+    Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error)
+    Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error)
+    Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error)
+    Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error)
+    Update(req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error)
+    Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error)
+    Name() string
+}
+```
+
+## API Client Architecture
+
+The `pulumiapi` package provides HTTP client wrappers for the Pulumi Cloud REST API:
+
+- `Client` - Base HTTP client with authentication and standard headers
+- Individual files for each resource type (e.g., `teams.go`, `stack.go`, `webhooks.go`)
+- All API calls use the standard headers: `X-Pulumi-Source: provider`, `Accept: application/vnd.pulumi+8`
+- Authentication via Bearer token in `Authorization` header
+
+## Release Process
+
+Releases are handled by Pulumi employees via `#release-ops` Slack channel. GitHub Actions automatically builds, tests, and publishes new releases to all package managers.
+
+## Configuration
+
+Provider accepts two configuration options:
+- `accessToken` (env: `PULUMI_ACCESS_TOKEN`) - Pulumi Service access token
+- `apiUrl` (env: `PULUMI_BACKEND_URL`) - Custom API URL for self-hosted instances
+
+## Version Management
+
+- Provider version is set via `PROVIDER_VERSION` environment variable or defaults to `1.0.0-alpha.0+dev`
+- Version is injected into provider binary via LDFLAGS at build time
+- The Pulumi CLI binary version used for SDK generation is automatically synced with the `github.com/pulumi/pulumi/pkg/v3` dependency version
+
+## Linting
+
+The Makefile references `.golangci.yml` but it may not exist in the repository root. The `make lint` command runs golangci-lint in three directories: `provider`, `sdk`, and `examples` with a 10-minute timeout.
+
+**Important**: When linting the `examples/` directory, you must use the `--build-tags all` flag because the test files use build tags (yaml, nodejs, python, etc.):
+
+```bash
+cd examples && golangci-lint run --timeout 10m --build-tags all
+```
+
+Without the build tags, golangci-lint may report false positives about unused functions that are actually used in files with specific build tags.
+
+## Debugging CI Failures
+
+When investigating CI test failures:
+
+1. **Use GitHub CLI to fetch logs**:
+   ```bash
+   gh run view <run_id> --log-failed
+   gh api repos/pulumi/pulumi-pulumiservice/actions/jobs/<job_id>/logs | grep "error:"
+   ```
+
+2. **Check for API validation errors**: The Pulumi Cloud API may reject values that are defined in the schema but not yet implemented (e.g., "runner" token type in OIDC policies)
+
+3. **Check for outdated test data**: Examples may contain hardcoded values like TLS certificate thumbprints that become stale when certificates are rotated
+
+4. **Look for related issues across examples**: If one language example fails, check all language examples (ts-, py-, go-, cs-, yaml-) for the same issue

--- a/examples/cs-oidc-issuer/MyStack.cs
+++ b/examples/cs-oidc-issuer/MyStack.cs
@@ -16,7 +16,7 @@ class MyStack : Pulumi.Stack
             Name = "pulumi_issuer",
             Url = "https://api.pulumi.com/oidc",
             Thumbprints = {
-              "df749a0f34ed673f8b0ec898445910c29c170d01d7d34073bd882235974a8a53"
+              "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"
             },
             Policies = {
               new AuthPolicyDefinitionArgs
@@ -73,16 +73,6 @@ class MyStack : Pulumi.Stack
               },
               TeamName = "dream-team",
               TokenType = AuthPolicyTokenType.Team
-            },
-            new AuthPolicyDefinitionArgs
-            {
-              Decision = AuthPolicyDecision.Allow,
-              Rules = new Dictionary<string, string> {
-                { "aud", "urn:pulumi:org:"+serviceOrg },
-                { "sub", "repo:organization/repo:*" },
-              },
-              RunnerID = "1234-5678-ABCD-XYZD",
-              TokenType = AuthPolicyTokenType.Runner
             }
           }
         });

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -6,7 +6,14 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	os.Setenv("PULUMI_TEST_OWNER", "service-provider-test-org")
-	os.Setenv("PULUMI_TEST_USE_SERVICE", "true")
+	// Set default test owner if not already set
+	if os.Getenv("PULUMI_TEST_OWNER") == "" {
+		if err := os.Setenv("PULUMI_TEST_OWNER", "service-provider-test-org"); err != nil {
+			panic("failed to set PULUMI_TEST_OWNER: " + err.Error())
+		}
+	}
+	if err := os.Setenv("PULUMI_TEST_USE_SERVICE", "true"); err != nil {
+		panic("failed to set PULUMI_TEST_USE_SERVICE: " + err.Error())
+	}
 	m.Run()
 }

--- a/examples/ts-oidc-issuer/index.ts
+++ b/examples/ts-oidc-issuer/index.ts
@@ -8,7 +8,7 @@ const pulumiOidcIssuer = new service.OidcIssuer("pulumi_issuer", {
   name: "pulumi_issuer",
   url: "https://api.pulumi.com/oidc",
   thumbprints: [
-    "df749a0f34ed673f8b0ec898445910c29c170d01d7d34073bd882235974a8a53"
+    "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"
   ],
   policies: [
     {
@@ -60,15 +60,6 @@ const githubOidcIssuer = new service.OidcIssuer("github_issuer", {
       },
       teamName: "dream-team",
       tokenType: "team"
-    },
-    {
-      decision: "allow",
-      rules: {
-          "aud": "urn:pulumi:org:"+serviceOrg,
-          "sub": "repo:organization/repo:*"
-      },
-      runnerID: "1234-5678-ABCD-XYZD",
-      tokenType: "runner"
     }
   ]
 })

--- a/examples/yaml-oidc-issuer/Pulumi.yaml
+++ b/examples/yaml-oidc-issuer/Pulumi.yaml
@@ -11,7 +11,7 @@ resources:
       name: pulumi_issuer
       url: https://api.pulumi.com/oidc
       thumbprints:
-        - df749a0f34ed673f8b0ec898445910c29c170d01d7d34073bd882235974a8a53
+        - 57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da
       policies:
         - decision: allow
           rules:
@@ -48,9 +48,3 @@ resources:
             sub: repo:organization/repo:*
           teamName: dream-team
           tokenType: team
-        - decision: allow
-          rules:
-            aud: urn:pulumi:org:service-provider-test-org
-            sub: repo:organization/repo:*
-          runnerID: 1234-5678-ABCD-XYZD,
-          tokenType: runner


### PR DESCRIPTION
This pull request primarily addresses a bug in the OIDC issuer examples by removing the unsupported "runner" token type and updating the Pulumi OIDC thumbprint to match the current certificate. It also adds a new contributor guide for Claude Code, clarifies test environment setup, and improves test reliability.

**OIDC Issuer Example Fixes:**

* Removed the unsupported `runner` token type from OIDC issuer policy definitions in TypeScript, C#, and YAML examples to prevent API validation errors. [[1]](diffhunk://#diff-acbebb1911a2c2d165d928b935951dc9a14e043dbdc8359c6a7c933d47aa20bcL63-L71) [[2]](diffhunk://#diff-b1b4fbd02135ad43ef5af29e46da139c217905091a0ceae687f09d178e37e57eL76-L85) [[3]](diffhunk://#diff-1c30c2098b27a7bc1a3e30da6b01c6a9a07a38489e7c32c8181993d4420bf68aL51-L56)
* Updated the Pulumi OIDC issuer thumbprint to the latest certificate value in all example files (`index.ts`, `MyStack.cs`, `Pulumi.yaml`). [[1]](diffhunk://#diff-acbebb1911a2c2d165d928b935951dc9a14e043dbdc8359c6a7c933d47aa20bcL11-R11) [[2]](diffhunk://#diff-b1b4fbd02135ad43ef5af29e46da139c217905091a0ceae687f09d178e37e57eL19-R19) [[3]](diffhunk://#diff-1c30c2098b27a7bc1a3e30da6b01c6a9a07a38489e7c32c8181993d4420bf68aL14-R14)

**Documentation and Contributor Guidance:**

* Added `CLAUDE.md`, a comprehensive contributor guide for Claude Code, detailing repository structure, build/test commands, environment variables, development workflow, and troubleshooting tips.

**Test Environment Improvements:**

* Improved test setup in `main_test.go` to only set the default test owner if not already specified, making tests more robust for local and CI environments.

**Changelog Updates:**

* Added a bug fix entry under the "Unreleased" section in `CHANGELOG.md` summarizing the OIDC issuer example corrections.