### PR TITLE
fix: Add required entityType and mode fields to PolicyGroup resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fixed PolicyGroup creation to include required entityType and mode fields [#563](https://github.com/pulumi/pulumi-pulumiservice/issues/563)
+
 ## 0.32.0
 
 ### Improvements

--- a/examples/yaml-policy-groups/Pulumi.yaml
+++ b/examples/yaml-policy-groups/Pulumi.yaml
@@ -39,6 +39,8 @@ resources:
     properties:
       name: test-policy-group-${digits}
       organizationName: ${organizationName}
+      entityType: stacks
+      mode: audit
       stacks: []
       policyPacks: []
 

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -2181,6 +2181,14 @@
           "description": "The name of the Pulumi organization the policy group belongs to.",
           "type": "string"
         },
+        "entityType": {
+          "description": "The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.",
+          "type": "string"
+        },
+        "mode": {
+          "description": "The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.",
+          "type": "string"
+        },
         "stacks": {
           "description": "List of stack references that belong to this policy group.",
           "type": "array",
@@ -2254,6 +2262,18 @@
         "organizationName": {
           "description": "The name of the Pulumi organization the policy group belongs to.",
           "type": "string",
+          "willReplaceOnChanges": true
+        },
+        "entityType": {
+          "description": "The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.",
+          "type": "string",
+          "default": "stacks",
+          "willReplaceOnChanges": true
+        },
+        "mode": {
+          "description": "The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.",
+          "type": "string",
+          "default": "audit",
           "willReplaceOnChanges": true
         },
         "stacks": {

--- a/provider/pkg/pulumiapi/policygroups_test.go
+++ b/provider/pkg/pulumiapi/policygroups_test.go
@@ -1,0 +1,201 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumiapi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreatePolicyGroup_HappyPath tests that CreatePolicyGroup sends all required fields
+func TestCreatePolicyGroup_HappyPath(t *testing.T) {
+	orgName := "test-org"
+	policyGroupName := "test-policy-group"
+	entityType := "stacks"
+	mode := "audit"
+
+	expectedReqBody := createPolicyGroupRequest{
+		Name:       policyGroupName,
+		EntityType: entityType,
+		Mode:       mode,
+	}
+
+	c, cleanup := startTestServer(t, testServerConfig{
+		ExpectedReqMethod: http.MethodPost,
+		ExpectedReqPath:   "/api/orgs/test-org/policygroups",
+		ExpectedReqBody:   expectedReqBody,
+		ResponseCode:      201,
+		ResponseBody:      nil,
+	})
+	defer cleanup()
+
+	err := c.CreatePolicyGroup(ctx, orgName, policyGroupName, entityType, mode)
+	assert.NoError(t, err)
+}
+
+// TestCreatePolicyGroup_AccountsPreventative tests creating a policy group with accounts and preventative mode
+func TestCreatePolicyGroup_AccountsPreventative(t *testing.T) {
+	orgName := "test-org"
+	policyGroupName := "test-policy-group"
+	entityType := "accounts"
+	mode := "preventative"
+
+	expectedReqBody := createPolicyGroupRequest{
+		Name:       policyGroupName,
+		EntityType: entityType,
+		Mode:       mode,
+	}
+
+	c, cleanup := startTestServer(t, testServerConfig{
+		ExpectedReqMethod: http.MethodPost,
+		ExpectedReqPath:   "/api/orgs/test-org/policygroups",
+		ExpectedReqBody:   expectedReqBody,
+		ResponseCode:      201,
+		ResponseBody:      nil,
+	})
+	defer cleanup()
+
+	err := c.CreatePolicyGroup(ctx, orgName, policyGroupName, entityType, mode)
+	assert.NoError(t, err)
+}
+
+// TestCreatePolicyGroup_EmptyOrgName tests that empty orgName returns validation error
+func TestCreatePolicyGroup_EmptyOrgName(t *testing.T) {
+	c := &Client{}
+
+	err := c.CreatePolicyGroup(ctx, "", "policy-group", "stacks", "audit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orgName must not be empty")
+}
+
+// TestCreatePolicyGroup_EmptyPolicyGroupName tests that empty policyGroupName returns validation error
+func TestCreatePolicyGroup_EmptyPolicyGroupName(t *testing.T) {
+	c := &Client{}
+
+	err := c.CreatePolicyGroup(ctx, "test-org", "", "stacks", "audit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policyGroupName must not be empty")
+}
+
+// TestCreatePolicyGroup_EmptyEntityType tests that empty entityType returns validation error
+func TestCreatePolicyGroup_EmptyEntityType(t *testing.T) {
+	c := &Client{}
+
+	err := c.CreatePolicyGroup(ctx, "test-org", "policy-group", "", "audit")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entityType must not be empty")
+}
+
+// TestCreatePolicyGroup_EmptyMode tests that empty mode returns validation error
+func TestCreatePolicyGroup_EmptyMode(t *testing.T) {
+	c := &Client{}
+
+	err := c.CreatePolicyGroup(ctx, "test-org", "policy-group", "stacks", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mode must not be empty")
+}
+
+// TestCreatePolicyGroup_APIError tests that API errors are properly propagated
+func TestCreatePolicyGroup_APIError(t *testing.T) {
+	orgName := "test-org"
+	policyGroupName := "test-policy-group"
+	entityType := "invalid"
+	mode := "audit"
+
+	expectedReqBody := createPolicyGroupRequest{
+		Name:       policyGroupName,
+		EntityType: entityType,
+		Mode:       mode,
+	}
+
+	c, cleanup := startTestServer(t, testServerConfig{
+		ExpectedReqMethod: http.MethodPost,
+		ExpectedReqPath:   "/api/orgs/test-org/policygroups",
+		ExpectedReqBody:   expectedReqBody,
+		ResponseCode:      400,
+		ResponseBody: ErrorResponse{
+			Message: "Invalid entity type",
+		},
+	})
+	defer cleanup()
+
+	err := c.CreatePolicyGroup(ctx, orgName, policyGroupName, entityType, mode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create policy group")
+	assert.Contains(t, err.Error(), "Invalid entity type")
+}
+
+// TestCreatePolicyGroup_Unauthorized tests that 401 errors are properly handled
+func TestCreatePolicyGroup_Unauthorized(t *testing.T) {
+	orgName := "test-org"
+	policyGroupName := "test-policy-group"
+	entityType := "stacks"
+	mode := "audit"
+
+	expectedReqBody := createPolicyGroupRequest{
+		Name:       policyGroupName,
+		EntityType: entityType,
+		Mode:       mode,
+	}
+
+	c, cleanup := startTestServer(t, testServerConfig{
+		ExpectedReqMethod: http.MethodPost,
+		ExpectedReqPath:   "/api/orgs/test-org/policygroups",
+		ExpectedReqBody:   expectedReqBody,
+		ResponseCode:      401,
+		ResponseBody: ErrorResponse{
+			Message: "unauthorized",
+		},
+	})
+	defer cleanup()
+
+	err := c.CreatePolicyGroup(ctx, orgName, policyGroupName, entityType, mode)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create policy group")
+	assert.Contains(t, err.Error(), "unauthorized")
+}
+
+// TestGetPolicyGroup_IncludesEntityTypeAndMode tests that GetPolicyGroup response includes new fields
+func TestGetPolicyGroup_IncludesEntityTypeAndMode(t *testing.T) {
+	orgName := "test-org"
+	policyGroupName := "test-policy-group"
+
+	expectedResponse := PolicyGroup{
+		Name:                policyGroupName,
+		IsOrgDefault:        false,
+		EntityType:          "accounts",
+		Mode:                "preventative",
+		Stacks:              []StackReference{},
+		AppliedPolicyPacks:  []PolicyPackMetadata{},
+		Accounts:            []string{},
+	}
+
+	c, cleanup := startTestServer(t, testServerConfig{
+		ExpectedReqMethod: http.MethodGet,
+		ExpectedReqPath:   "/api/orgs/test-org/policygroups/test-policy-group",
+		ResponseCode:      200,
+		ResponseBody:      expectedResponse,
+	})
+	defer cleanup()
+
+	result, err := c.GetPolicyGroup(ctx, orgName, policyGroupName)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "accounts", result.EntityType)
+	assert.Equal(t, "preventative", result.Mode)
+}

--- a/provider/pkg/resources/policy_group_test.go
+++ b/provider/pkg/resources/policy_group_test.go
@@ -1,0 +1,443 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Mock client for PolicyGroup tests
+type PolicyGroupClientMock struct {
+	getPolicyGroupFunc    func() (*pulumiapi.PolicyGroup, error)
+	createPolicyGroupFunc func(ctx context.Context, orgName, policyGroupName, entityType, mode string) error
+}
+
+func (c *PolicyGroupClientMock) ListPolicyGroups(ctx context.Context, orgName string) ([]pulumiapi.PolicyGroupSummary, error) {
+	return nil, nil
+}
+
+func (c *PolicyGroupClientMock) GetPolicyGroup(ctx context.Context, orgName string, policyGroupName string) (*pulumiapi.PolicyGroup, error) {
+	if c.getPolicyGroupFunc != nil {
+		return c.getPolicyGroupFunc()
+	}
+	return nil, nil
+}
+
+func (c *PolicyGroupClientMock) CreatePolicyGroup(ctx context.Context, orgName, policyGroupName, entityType, mode string) error {
+	if c.createPolicyGroupFunc != nil {
+		return c.createPolicyGroupFunc(ctx, orgName, policyGroupName, entityType, mode)
+	}
+	return nil
+}
+
+func (c *PolicyGroupClientMock) UpdatePolicyGroup(ctx context.Context, orgName, policyGroupName string, req pulumiapi.UpdatePolicyGroupRequest) error {
+	return nil
+}
+
+func (c *PolicyGroupClientMock) DeletePolicyGroup(ctx context.Context, orgName, policyGroupName string) error {
+	return nil
+}
+
+// TestPolicyGroup_Check_Defaults tests that Check applies default values when entityType and mode are not provided
+func TestPolicyGroup_Check_Defaults(t *testing.T) {
+	provider := PulumiServicePolicyGroupResource{
+		Client: &PolicyGroupClientMock{},
+	}
+
+	// Create input without entityType and mode
+	inputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	inputsStruct, err := structpb.NewStruct(inputs.Mappable())
+	require.NoError(t, err)
+
+	req := &pulumirpc.CheckRequest{
+		Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+		News: inputsStruct,
+	}
+
+	resp, err := provider.Check(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Failures, "Check should succeed with no failures")
+
+	// Verify defaults are applied
+	outputMap := resource.PropertyMap{}
+	for k, v := range resp.Inputs.GetFields() {
+		outputMap[resource.PropertyKey(k)] = resource.NewPropertyValue(v.AsInterface())
+	}
+
+	assert.True(t, outputMap["entityType"].HasValue(), "entityType should have a value")
+	assert.Equal(t, "stacks", outputMap["entityType"].StringValue(), "entityType should default to 'stacks'")
+
+	assert.True(t, outputMap["mode"].HasValue(), "mode should have a value")
+	assert.Equal(t, "audit", outputMap["mode"].StringValue(), "mode should default to 'audit'")
+}
+
+// TestPolicyGroup_Check_ExplicitValues tests that Check preserves explicit entityType and mode values
+func TestPolicyGroup_Check_ExplicitValues(t *testing.T) {
+	testCases := []struct {
+		name       string
+		entityType string
+		mode       string
+	}{
+		{
+			name:       "stacks and audit",
+			entityType: "stacks",
+			mode:       "audit",
+		},
+		{
+			name:       "stacks and preventative",
+			entityType: "stacks",
+			mode:       "preventative",
+		},
+		{
+			name:       "accounts and audit",
+			entityType: "accounts",
+			mode:       "audit",
+		},
+		{
+			name:       "accounts and preventative",
+			entityType: "accounts",
+			mode:       "preventative",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := PulumiServicePolicyGroupResource{
+				Client: &PolicyGroupClientMock{},
+			}
+
+			inputs := resource.PropertyMap{
+				"name":             resource.NewStringProperty("test-policy-group"),
+				"organizationName": resource.NewStringProperty("test-org"),
+				"entityType":       resource.NewStringProperty(tc.entityType),
+				"mode":             resource.NewStringProperty(tc.mode),
+				"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+				"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+			}
+
+			inputsStruct, err := structpb.NewStruct(inputs.Mappable())
+			require.NoError(t, err)
+
+			req := &pulumirpc.CheckRequest{
+				Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+				News: inputsStruct,
+			}
+
+			resp, err := provider.Check(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Empty(t, resp.Failures, "Check should succeed with no failures")
+
+			// Verify explicit values are preserved
+			outputMap := resource.PropertyMap{}
+			for k, v := range resp.Inputs.GetFields() {
+				outputMap[resource.PropertyKey(k)] = resource.NewPropertyValue(v.AsInterface())
+			}
+
+			assert.Equal(t, tc.entityType, outputMap["entityType"].StringValue(), "entityType should preserve explicit value")
+			assert.Equal(t, tc.mode, outputMap["mode"].StringValue(), "mode should preserve explicit value")
+		})
+	}
+}
+
+// TestPolicyGroup_Check_InvalidEntityType tests that Check validates entityType enum values
+func TestPolicyGroup_Check_InvalidEntityType(t *testing.T) {
+	testCases := []struct {
+		name       string
+		entityType string
+	}{
+		{name: "empty string", entityType: ""},
+		{name: "invalid value", entityType: "invalid"},
+		{name: "wrong case", entityType: "Stacks"},
+		{name: "typo", entityType: "stack"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := PulumiServicePolicyGroupResource{
+				Client: &PolicyGroupClientMock{},
+			}
+
+			inputs := resource.PropertyMap{
+				"name":             resource.NewStringProperty("test-policy-group"),
+				"organizationName": resource.NewStringProperty("test-org"),
+				"entityType":       resource.NewStringProperty(tc.entityType),
+				"mode":             resource.NewStringProperty("audit"),
+				"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+				"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+			}
+
+			inputsStruct, err := structpb.NewStruct(inputs.Mappable())
+			require.NoError(t, err)
+
+			req := &pulumirpc.CheckRequest{
+				Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+				News: inputsStruct,
+			}
+
+			resp, err := provider.Check(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotEmpty(t, resp.Failures, "Check should fail with validation error")
+
+			// Verify failure message mentions entityType
+			found := false
+			for _, failure := range resp.Failures {
+				if failure.Property == "entityType" {
+					found = true
+					assert.Contains(t, failure.Reason, "entityType must be either 'stacks' or 'accounts'")
+					break
+				}
+			}
+			assert.True(t, found, "Should have failure for entityType property")
+		})
+	}
+}
+
+// TestPolicyGroup_Check_InvalidMode tests that Check validates mode enum values
+func TestPolicyGroup_Check_InvalidMode(t *testing.T) {
+	testCases := []struct {
+		name string
+		mode string
+	}{
+		{name: "empty string", mode: ""},
+		{name: "invalid value", mode: "invalid"},
+		{name: "wrong case", mode: "Audit"},
+		{name: "typo", mode: "audits"},
+		{name: "preventive (typo)", mode: "preventive"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := PulumiServicePolicyGroupResource{
+				Client: &PolicyGroupClientMock{},
+			}
+
+			inputs := resource.PropertyMap{
+				"name":             resource.NewStringProperty("test-policy-group"),
+				"organizationName": resource.NewStringProperty("test-org"),
+				"entityType":       resource.NewStringProperty("stacks"),
+				"mode":             resource.NewStringProperty(tc.mode),
+				"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+				"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+			}
+
+			inputsStruct, err := structpb.NewStruct(inputs.Mappable())
+			require.NoError(t, err)
+
+			req := &pulumirpc.CheckRequest{
+				Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+				News: inputsStruct,
+			}
+
+			resp, err := provider.Check(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.NotEmpty(t, resp.Failures, "Check should fail with validation error")
+
+			// Verify failure message mentions mode
+			found := false
+			for _, failure := range resp.Failures {
+				if failure.Property == "mode" {
+					found = true
+					assert.Contains(t, failure.Reason, "mode must be either 'audit' or 'preventative'")
+					break
+				}
+			}
+			assert.True(t, found, "Should have failure for mode property")
+		})
+	}
+}
+
+// TestPolicyGroup_Diff_EntityTypeChange tests that changing entityType triggers replacement
+func TestPolicyGroup_Diff_EntityTypeChange(t *testing.T) {
+	provider := PulumiServicePolicyGroupResource{
+		Client: &PolicyGroupClientMock{},
+	}
+
+	// Old state: entityType = "stacks"
+	oldInputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"entityType":       resource.NewStringProperty("stacks"),
+		"mode":             resource.NewStringProperty("audit"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	oldState, err := structpb.NewStruct(oldInputs.Mappable())
+	require.NoError(t, err)
+
+	// New state: entityType = "accounts"
+	newInputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"entityType":       resource.NewStringProperty("accounts"),
+		"mode":             resource.NewStringProperty("audit"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	newState, err := structpb.NewStruct(newInputs.Mappable())
+	require.NoError(t, err)
+
+	req := &pulumirpc.DiffRequest{
+		Id:   "test-org/test-policy-group",
+		Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+		Olds: oldState,
+		News: newState,
+	}
+
+	resp, err := provider.Diff(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify that entityType change triggers replacement
+	assert.Contains(t, resp.Replaces, "entityType", "Changing entityType should trigger replacement")
+}
+
+// TestPolicyGroup_Diff_ModeChange tests that changing mode triggers replacement
+func TestPolicyGroup_Diff_ModeChange(t *testing.T) {
+	provider := PulumiServicePolicyGroupResource{
+		Client: &PolicyGroupClientMock{},
+	}
+
+	// Old state: mode = "audit"
+	oldInputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"entityType":       resource.NewStringProperty("stacks"),
+		"mode":             resource.NewStringProperty("audit"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	oldState, err := structpb.NewStruct(oldInputs.Mappable())
+	require.NoError(t, err)
+
+	// New state: mode = "preventative"
+	newInputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"entityType":       resource.NewStringProperty("stacks"),
+		"mode":             resource.NewStringProperty("preventative"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	newState, err := structpb.NewStruct(newInputs.Mappable())
+	require.NoError(t, err)
+
+	req := &pulumirpc.DiffRequest{
+		Id:   "test-org/test-policy-group",
+		Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+		Olds: oldState,
+		News: newState,
+	}
+
+	resp, err := provider.Diff(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify that mode change triggers replacement
+	assert.Contains(t, resp.Replaces, "mode", "Changing mode should trigger replacement")
+}
+
+// TestPolicyGroup_ToPropertyMap tests that ToPropertyMap includes entityType and mode
+func TestPolicyGroup_ToPropertyMap(t *testing.T) {
+	input := PulumiServicePolicyGroupInput{
+		Name:             "test-policy-group",
+		OrganizationName: "test-org",
+		EntityType:       "accounts",
+		Mode:             "preventative",
+		Stacks:           []pulumiapi.StackReference{},
+		PolicyPacks:      []pulumiapi.PolicyPackMetadata{},
+	}
+
+	pm := input.ToPropertyMap()
+
+	// Verify all fields are present
+	assert.True(t, pm["name"].HasValue())
+	assert.Equal(t, "test-policy-group", pm["name"].StringValue())
+
+	assert.True(t, pm["organizationName"].HasValue())
+	assert.Equal(t, "test-org", pm["organizationName"].StringValue())
+
+	assert.True(t, pm["entityType"].HasValue())
+	assert.Equal(t, "accounts", pm["entityType"].StringValue())
+
+	assert.True(t, pm["mode"].HasValue())
+	assert.Equal(t, "preventative", pm["mode"].StringValue())
+
+	assert.True(t, pm["stacks"].HasValue())
+	assert.True(t, pm["stacks"].IsArray())
+
+	assert.True(t, pm["policyPacks"].HasValue())
+	assert.True(t, pm["policyPacks"].IsArray())
+}
+
+// TestPolicyGroup_ToPulumiServicePolicyGroupInput tests parsing of entityType and mode from PropertyMap
+func TestPolicyGroup_ToPulumiServicePolicyGroupInput(t *testing.T) {
+	inputMap := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"entityType":       resource.NewStringProperty("accounts"),
+		"mode":             resource.NewStringProperty("preventative"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	result := ToPulumiServicePolicyGroupInput(inputMap)
+
+	assert.Equal(t, "test-policy-group", result.Name)
+	assert.Equal(t, "test-org", result.OrganizationName)
+	assert.Equal(t, "accounts", result.EntityType)
+	assert.Equal(t, "preventative", result.Mode)
+	assert.Empty(t, result.Stacks)
+	assert.Empty(t, result.PolicyPacks)
+}
+
+// TestPolicyGroup_ToPulumiServicePolicyGroupInput_MissingFields tests that missing entityType/mode are handled
+func TestPolicyGroup_ToPulumiServicePolicyGroupInput_MissingFields(t *testing.T) {
+	inputMap := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"stacks":           resource.NewArrayProperty([]resource.PropertyValue{}),
+		"policyPacks":      resource.NewArrayProperty([]resource.PropertyValue{}),
+	}
+
+	result := ToPulumiServicePolicyGroupInput(inputMap)
+
+	assert.Equal(t, "test-policy-group", result.Name)
+	assert.Equal(t, "test-org", result.OrganizationName)
+	// EntityType and Mode should be empty strings if not provided
+	assert.Equal(t, "", result.EntityType)
+	assert.Equal(t, "", result.Mode)
+}

--- a/sdk/dotnet/PolicyGroup.cs
+++ b/sdk/dotnet/PolicyGroup.cs
@@ -16,6 +16,18 @@ namespace Pulumi.PulumiService
     public partial class PolicyGroup : global::Pulumi.CustomResource
     {
         /// <summary>
+        /// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        /// </summary>
+        [Output("entityType")]
+        public Output<string?> EntityType { get; private set; } = null!;
+
+        /// <summary>
+        /// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+        /// </summary>
+        [Output("mode")]
+        public Output<string?> Mode { get; private set; } = null!;
+
+        /// <summary>
         /// The name of the policy group.
         /// </summary>
         [Output("name")]
@@ -85,6 +97,18 @@ namespace Pulumi.PulumiService
     public sealed class PolicyGroupArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
+        /// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        /// </summary>
+        [Input("entityType")]
+        public Input<string>? EntityType { get; set; }
+
+        /// <summary>
+        /// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+        /// </summary>
+        [Input("mode")]
+        public Input<string>? Mode { get; set; }
+
+        /// <summary>
         /// The name of the policy group.
         /// </summary>
         [Input("name", required: true)]
@@ -122,6 +146,8 @@ namespace Pulumi.PulumiService
 
         public PolicyGroupArgs()
         {
+            EntityType = "stacks";
+            Mode = "audit";
         }
         public static new PolicyGroupArgs Empty => new PolicyGroupArgs();
     }

--- a/sdk/go/pulumiservice/policyGroup.go
+++ b/sdk/go/pulumiservice/policyGroup.go
@@ -16,6 +16,10 @@ import (
 type PolicyGroup struct {
 	pulumi.CustomResourceState
 
+	// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+	EntityType pulumi.StringPtrOutput `pulumi:"entityType"`
+	// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+	Mode pulumi.StringPtrOutput `pulumi:"mode"`
 	// The name of the policy group.
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The name of the Pulumi organization the policy group belongs to.
@@ -38,6 +42,12 @@ func NewPolicyGroup(ctx *pulumi.Context,
 	}
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
+	}
+	if args.EntityType == nil {
+		args.EntityType = pulumi.StringPtr("stacks")
+	}
+	if args.Mode == nil {
+		args.Mode = pulumi.StringPtr("audit")
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource PolicyGroup
@@ -72,6 +82,10 @@ func (PolicyGroupState) ElementType() reflect.Type {
 }
 
 type policyGroupArgs struct {
+	// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+	EntityType *string `pulumi:"entityType"`
+	// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+	Mode *string `pulumi:"mode"`
 	// The name of the policy group.
 	Name string `pulumi:"name"`
 	// The name of the Pulumi organization the policy group belongs to.
@@ -84,6 +98,10 @@ type policyGroupArgs struct {
 
 // The set of arguments for constructing a PolicyGroup resource.
 type PolicyGroupArgs struct {
+	// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+	EntityType pulumi.StringPtrInput
+	// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+	Mode pulumi.StringPtrInput
 	// The name of the policy group.
 	Name pulumi.StringInput
 	// The name of the Pulumi organization the policy group belongs to.
@@ -179,6 +197,16 @@ func (o PolicyGroupOutput) ToPolicyGroupOutput() PolicyGroupOutput {
 
 func (o PolicyGroupOutput) ToPolicyGroupOutputWithContext(ctx context.Context) PolicyGroupOutput {
 	return o
+}
+
+// The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+func (o PolicyGroupOutput) EntityType() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *PolicyGroup) pulumi.StringPtrOutput { return v.EntityType }).(pulumi.StringPtrOutput)
+}
+
+// The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+func (o PolicyGroupOutput) Mode() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v *PolicyGroup) pulumi.StringPtrOutput { return v.Mode }).(pulumi.StringPtrOutput)
 }
 
 // The name of the policy group.

--- a/sdk/nodejs/policyGroup.ts
+++ b/sdk/nodejs/policyGroup.ts
@@ -35,6 +35,14 @@ export class PolicyGroup extends pulumi.CustomResource {
     }
 
     /**
+     * The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+     */
+    public readonly entityType!: pulumi.Output<string | undefined>;
+    /**
+     * The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+     */
+    public readonly mode!: pulumi.Output<string | undefined>;
+    /**
      * The name of the policy group.
      */
     public readonly name!: pulumi.Output<string>;
@@ -68,11 +76,15 @@ export class PolicyGroup extends pulumi.CustomResource {
             if ((!args || args.organizationName === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'organizationName'");
             }
+            resourceInputs["entityType"] = (args ? args.entityType : undefined) ?? "stacks";
+            resourceInputs["mode"] = (args ? args.mode : undefined) ?? "audit";
             resourceInputs["name"] = args ? args.name : undefined;
             resourceInputs["organizationName"] = args ? args.organizationName : undefined;
             resourceInputs["policyPacks"] = args ? args.policyPacks : undefined;
             resourceInputs["stacks"] = args ? args.stacks : undefined;
         } else {
+            resourceInputs["entityType"] = undefined /*out*/;
+            resourceInputs["mode"] = undefined /*out*/;
             resourceInputs["name"] = undefined /*out*/;
             resourceInputs["organizationName"] = undefined /*out*/;
             resourceInputs["policyPacks"] = undefined /*out*/;
@@ -87,6 +99,14 @@ export class PolicyGroup extends pulumi.CustomResource {
  * The set of arguments for constructing a PolicyGroup resource.
  */
 export interface PolicyGroupArgs {
+    /**
+     * The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+     */
+    entityType?: pulumi.Input<string>;
+    /**
+     * The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+     */
+    mode?: pulumi.Input<string>;
     /**
      * The name of the policy group.
      */

--- a/sdk/python/pulumi_pulumiservice/policy_group.py
+++ b/sdk/python/pulumi_pulumiservice/policy_group.py
@@ -21,17 +21,29 @@ class PolicyGroupArgs:
     def __init__(__self__, *,
                  name: pulumi.Input[str],
                  organization_name: pulumi.Input[str],
+                 entity_type: Optional[pulumi.Input[str]] = None,
+                 mode: Optional[pulumi.Input[str]] = None,
                  policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
                  stacks: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None):
         """
         The set of arguments for constructing a PolicyGroup resource.
         :param pulumi.Input[str] name: The name of the policy group.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the policy group belongs to.
+        :param pulumi.Input[str] entity_type: The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        :param pulumi.Input[str] mode: The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
         :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] policy_packs: List of policy packs applied to this policy group.
         :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] stacks: List of stack references that belong to this policy group.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
+        if entity_type is None:
+            entity_type = 'stacks'
+        if entity_type is not None:
+            pulumi.set(__self__, "entity_type", entity_type)
+        if mode is None:
+            mode = 'audit'
+        if mode is not None:
+            pulumi.set(__self__, "mode", mode)
         if policy_packs is not None:
             pulumi.set(__self__, "policy_packs", policy_packs)
         if stacks is not None:
@@ -60,6 +72,30 @@ class PolicyGroupArgs:
     @organization_name.setter
     def organization_name(self, value: pulumi.Input[str]):
         pulumi.set(self, "organization_name", value)
+
+    @property
+    @pulumi.getter(name="entityType")
+    def entity_type(self) -> Optional[pulumi.Input[str]]:
+        """
+        The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        """
+        return pulumi.get(self, "entity_type")
+
+    @entity_type.setter
+    def entity_type(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "entity_type", value)
+
+    @property
+    @pulumi.getter
+    def mode(self) -> Optional[pulumi.Input[str]]:
+        """
+        The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+        """
+        return pulumi.get(self, "mode")
+
+    @mode.setter
+    def mode(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "mode", value)
 
     @property
     @pulumi.getter(name="policyPacks")
@@ -91,6 +127,8 @@ class PolicyGroup(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 entity_type: Optional[pulumi.Input[str]] = None,
+                 mode: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -101,6 +139,8 @@ class PolicyGroup(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
+        :param pulumi.Input[str] entity_type: The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        :param pulumi.Input[str] mode: The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
         :param pulumi.Input[str] name: The name of the policy group.
         :param pulumi.Input[str] organization_name: The name of the Pulumi organization the policy group belongs to.
         :param pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]] policy_packs: List of policy packs applied to this policy group.
@@ -130,6 +170,8 @@ class PolicyGroup(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
+                 entity_type: Optional[pulumi.Input[str]] = None,
+                 mode: Optional[pulumi.Input[str]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  organization_name: Optional[pulumi.Input[str]] = None,
                  policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -143,6 +185,12 @@ class PolicyGroup(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = PolicyGroupArgs.__new__(PolicyGroupArgs)
 
+            if entity_type is None:
+                entity_type = 'stacks'
+            __props__.__dict__["entity_type"] = entity_type
+            if mode is None:
+                mode = 'audit'
+            __props__.__dict__["mode"] = mode
             if name is None and not opts.urn:
                 raise TypeError("Missing required property 'name'")
             __props__.__dict__["name"] = name
@@ -173,11 +221,29 @@ class PolicyGroup(pulumi.CustomResource):
 
         __props__ = PolicyGroupArgs.__new__(PolicyGroupArgs)
 
+        __props__.__dict__["entity_type"] = None
+        __props__.__dict__["mode"] = None
         __props__.__dict__["name"] = None
         __props__.__dict__["organization_name"] = None
         __props__.__dict__["policy_packs"] = None
         __props__.__dict__["stacks"] = None
         return PolicyGroup(resource_name, opts=opts, __props__=__props__)
+
+    @property
+    @pulumi.getter(name="entityType")
+    def entity_type(self) -> pulumi.Output[Optional[str]]:
+        """
+        The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
+        """
+        return pulumi.get(self, "entity_type")
+
+    @property
+    @pulumi.getter
+    def mode(self) -> pulumi.Output[Optional[str]]:
+        """
+        The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
+        """
+        return pulumi.get(self, "mode")
 
     @property
     @pulumi.getter


### PR DESCRIPTION
## Summary

Fixes PolicyGroup creation failing with "400 Bad Request: Invalid entity type" error. The Pulumi Cloud REST API now requires `entityType` and `mode` fields when creating policy groups, but the provider was not sending these fields.

## Changes

- Added `entityType` field (values: "stacks" | "accounts", default: "stacks")
- Added `mode` field (values: "audit" | "preventative", default: "audit")
- Both fields trigger resource replacement when changed (`willReplaceOnChanges: true`)
- Added enum validation in Check method with user-friendly error messages
- Updated schema.json with new fields and default values
- Regenerated all SDKs (dotnet, go, nodejs, python, java)
- Added comprehensive unit tests (21 test cases)

## Backward Compatibility

Existing Pulumi programs continue to work without changes due to default values:
- `entityType` defaults to `"stacks"` (most common use case)
- `mode` defaults to `"audit"` (non-blocking, safer default)

## Testing

- ✅ All 21 unit tests passing (9 API client + 12 resource tests)
- ✅ Provider builds successfully
- ✅ All 5 SDKs regenerated successfully
- ✅ Linting passes with 0 issues
- ✅ Example updated with explicit field values

Fixes #563