### PR TITLE
docs(schema): add import examples for all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added Java SDK support with Pulumi Java SDK v1.16.2
 - Upgraded Pulumi SDK to v3.204.0 with latest codegen improvements
+- Added import documentation for all resources [#344](https://github.com/pulumi/pulumi-pulumiservice/issues/344)
+- Added schema validation script to ensure all resources have import documentation
 
 ### Bug Fixes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ The provider schema is **manually maintained** at `provider/cmd/pulumi-resource-
 1. Add resource definition to `provider/cmd/pulumi-resource-pulumiservice/schema.json`
 2. Create API client methods in `provider/pkg/pulumiapi/` (e.g., `teams.go`, `webhooks.go`)
 3. Create resource implementation in `provider/pkg/resources/` implementing `PulumiServiceResource` interface
-4. Register the resource in `provider/pkg/provider/provider.go`
+4. Register the resource in `provider/pkg/provider/provider.go` (in the `pulumiResources` slice in `Configure`)
 5. Rebuild provider and SDKs: `make build`
 6. Add examples in `examples/` directory
 7. **IMPORTANT**: Always create a YAML example for the new resource:
@@ -135,6 +135,17 @@ The provider schema is **manually maintained** at `provider/cmd/pulumi-resource-
    - Create a `README.md` in the example directory that includes a link to the `pulumi convert` documentation (https://www.pulumi.com/docs/iac/cli/commands/pulumi_convert/) for converting the example to other programming languages
    - Register the example test in `examples/examples_yaml_test.go`
    - Test the YAML example before completing: `cd examples && go test -v -run TestYaml<ResourceName>Example -tags yaml -timeout 10m`
+
+### Adding a New Data Source (Function)
+
+Data sources are implemented as Invoke functions in the provider:
+
+1. Add function definition to `provider/cmd/pulumi-resource-pulumiservice/schema.json` under the `functions` section
+2. Create or update API client methods in `provider/pkg/pulumiapi/` for the required API calls
+3. Add a case for your function token in the `Invoke` method in `provider/pkg/provider/provider.go` (e.g., `"pulumiservice:index:getYourFunction"`)
+4. Implement the invoke function method (e.g., `invokeFunctionGetYourFunction`) in `provider.go`
+5. Rebuild provider and SDKs: `make build`
+6. Add examples demonstrating the data source usage in `examples/` directory
 
 ### Resource Interface
 
@@ -188,6 +199,30 @@ cd examples && golangci-lint run --timeout 10m --build-tags all
 ```
 
 Without the build tags, golangci-lint may report false positives about unused functions that are actually used in files with specific build tags.
+
+### Schema Import Documentation Validation
+
+The `make lint` target includes validation that all resources in `schema.json` have import documentation. The validation script `scripts/validate-schema-imports.sh` checks that every resource's `description` field contains a `### Import` section.
+
+To run the validation separately:
+
+```bash
+./scripts/validate-schema-imports.sh
+```
+
+All resources must include import documentation in the format:
+
+```markdown
+### Import
+
+[Resource] can be imported using the `id`, which for [resource] is `{format}` e.g.,
+
+```sh
+ $ pulumi import pulumiservice:index:[Resource] [name] [id-example]
+```
+```
+
+If the validation fails, it will list all resources missing import documentation.
 
 ## Debugging CI Failures
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ lint::
 	if [ -d examples ]; then \
 		pushd examples && golangci-lint run --timeout 10m --build-tags all && popd ; \
 	fi
+	./scripts/validate-schema-imports.sh
 
 
 install:: install_nodejs_sdk install_dotnet_sdk

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -460,7 +460,7 @@
       "properties": {
         "duration": {
           "type": "string",
-          "description": "Duration of the assume-role session in “XhYmZs” format"
+          "description": "Duration of the assume-role session in \u201cXhYmZs\u201d format"
         },
         "policyARNs": {
           "type": "array",
@@ -508,7 +508,7 @@
         },
         "tokenLifetime": {
           "type": "string",
-          "description": "The lifetime of the temporary credentials in “XhYmZs” format."
+          "description": "The lifetime of the temporary credentials in \u201cXhYmZs\u201d format."
         }
       },
       "required": [
@@ -819,7 +819,7 @@
   },
   "resources": {
     "pulumiservice:index:Stack": {
-      "description": "A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.",
+      "description": "A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.\n\n### Import\n\nStacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack\n```\n\n",
       "properties": {
         "organizationName": {
           "description": "The name of the organization.",
@@ -871,7 +871,7 @@
       ]
     },
     "pulumiservice:index:AgentPool": {
-      "description": "Agent Pool for customer managed deployments",
+      "description": "Agent Pool for customer managed deployments\n\n### Import\n\nAgent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345\n```\n\n",
       "properties": {
         "agentPoolId": {
           "description": "The agent pool identifier.",
@@ -931,7 +931,7 @@
       ]
     },
     "pulumiservice:index:AccessToken": {
-      "description": "Access tokens allow a user to authenticate against the Pulumi Cloud",
+      "description": "Access tokens allow a user to authenticate against the Pulumi Cloud\n\n### Import\n\nAccess tokens can be imported using the token `id` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:AccessToken my_token abc123def456\n```\n\n",
       "properties": {
         "description": {
           "description": "Description of the access token.",
@@ -958,7 +958,7 @@
       ]
     },
     "pulumiservice:index:Team": {
-      "description": "The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.",
+      "description": "The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.\n\n### Import\n\nTeams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:Team my_team my-org/my-team\n```\n\n",
       "properties": {
         "teamType": {
           "description": "The type of team. Must be either `pulumi` or `github`.",
@@ -1039,7 +1039,7 @@
       ]
     },
     "pulumiservice:index:TeamAccessToken": {
-      "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",
+      "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team\n\n### Import\n\nTeam access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456\n```\n\n",
       "properties": {
         "name": {
           "description": "The name for the token. This must be unique amongst all machine tokens within your organization.",
@@ -1097,7 +1097,7 @@
       ]
     },
     "pulumiservice:index:OrgAccessToken": {
-      "description": "The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org",
+      "description": "The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org\n\n### Import\n\nOrganization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789\n```\n\n",
       "properties": {
         "name": {
           "description": "The name for the token.",
@@ -1374,7 +1374,7 @@
       ]
     },
     "pulumiservice:index:StackTag": {
-      "description": "Stacks have associated metadata in the form of tags. Each tag consists of a name and value.",
+      "description": "Stacks have associated metadata in the form of tags. Each tag consists of a name and value.\n\n### Import\n\nStack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1439,7 +1439,7 @@
       ]
     },
     "pulumiservice:index:TeamStackPermission": {
-      "description": "Grants a team permissions to the specified stack.",
+      "description": "Grants a team permissions to the specified stack.\n\n### Import\n\nTeam stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team\n```\n\n",
       "inputProperties": {
         "team": {
           "description": "The name of the team to grant this stack permissions to. This is not the display name.",
@@ -1507,7 +1507,7 @@
       ]
     },
     "pulumiservice:index:DeploymentSchedule": {
-      "description": "A scheduled recurring or single time run of a pulumi command.",
+      "description": "A scheduled recurring or single time run of a pulumi command.\n\n### Import\n\nDeployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1584,7 +1584,7 @@
       ]
     },
     "pulumiservice:index:DriftSchedule": {
-      "description": "A cron schedule to run drift detection.",
+      "description": "A cron schedule to run drift detection.\n\n### Import\n\nDrift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1653,7 +1653,7 @@
       ]
     },
     "pulumiservice:index:TtlSchedule": {
-      "description": "A scheduled stack destroy run.",
+      "description": "A scheduled stack destroy run.\n\n### Import\n\nTTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1724,7 +1724,7 @@
       ]
     },
     "pulumiservice:index:Environment": {
-      "description": "An ESC Environment.",
+      "description": "An ESC Environment.\n\n### Import\n\nEnvironments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env\n```\n\nor using the legacy format (assumes \"default\" project):\n\n```sh\n $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1780,7 +1780,7 @@
       ]
     },
     "pulumiservice:index:TeamEnvironmentPermission": {
-      "description": "A permission for a team to use an environment.",
+      "description": "A permission for a team to use an environment.\n\n### Import\n\nTeam environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env\n```\n\nor using the legacy format (assumes \"default\" project):\n\n```sh\n $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1843,7 +1843,7 @@
       ]
     },
     "pulumiservice:index:EnvironmentVersionTag": {
-      "description": "A tag on a specific revision of an environment.",
+      "description": "A tag on a specific revision of an environment.\n\n### Import\n\nEnvironment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1\n```\n\nor using the legacy format (assumes \"default\" project):\n\n```sh\n $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -1904,7 +1904,7 @@
       ]
     },
     "pulumiservice:index:TemplateSource": {
-      "description": "A source for Pulumi templates",
+      "description": "A source for Pulumi templates\n\n### Import\n\nTemplate sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123\n```\n\n",
       "properties": {
         "organizationName": {
           "description": "Organization name.",
@@ -1953,7 +1953,7 @@
       ]
     },
     "pulumiservice:index:OidcIssuer": {
-      "description": "Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.",
+      "description": "Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.\n\n### Import\n\nOIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -2036,7 +2036,7 @@
       ]
     },
     "pulumiservice:index:EnvironmentRotationSchedule": {
-      "description": "A scheduled recurring or single time environment rotation.",
+      "description": "A scheduled recurring or single time environment rotation.\n\n### Import\n\nEnvironment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123\n```\n\n",
       "properties": {
         "organization": {
           "description": "Organization name.",
@@ -2103,7 +2103,7 @@
       ]
     },
     "pulumiservice:index:ApprovalRule": {
-      "description": "An approval rule for environment deployments.",
+      "description": "An approval rule for environment deployments.\n\n### Import\n\nApproval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123\n```\n\n",
       "properties": {
         "name": {
           "description": "Name of the approval rule.",
@@ -2171,7 +2171,7 @@
       ]
     },
     "pulumiservice:index:PolicyGroup": {
-      "description": "A Policy Group allows you to apply policy packs to a set of stacks in your organization.",
+      "description": "A Policy Group allows you to apply policy packs to a set of stacks in your organization.\n\n### Import\n\nPolicy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group\n```\n\n",
       "properties": {
         "name": {
           "description": "The name of the policy group.",

--- a/scripts/validate-schema-imports.sh
+++ b/scripts/validate-schema-imports.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2016-2025, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCHEMA_FILE="${1:-provider/cmd/pulumi-resource-pulumiservice/schema.json}"
+
+if [ ! -f "$SCHEMA_FILE" ]; then
+    echo "Error: Schema file not found: $SCHEMA_FILE"
+    exit 1
+fi
+
+echo "Validating import documentation in $SCHEMA_FILE..."
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed"
+    exit 1
+fi
+
+# Get all resources that are missing import documentation
+MISSING=$(jq -r '.resources | to_entries[] | select(.value.description | contains("### Import") | not) | .key' "$SCHEMA_FILE")
+
+if [ -n "$MISSING" ]; then
+    echo "❌ Error: The following resources are missing import documentation:"
+    echo "$MISSING" | while read -r resource; do
+        echo "  - $resource"
+    done
+    echo ""
+    echo "All resources must include import documentation in their description field."
+    echo "Format example:"
+    echo ""
+    echo "  ### Import"
+    echo ""
+    echo "  [Resource] can be imported using the \`id\`, which for [resource] is \`{format}\` e.g.,"
+    echo ""
+    echo "  \`\`\`sh"
+    echo "   $ pulumi import pulumiservice:index:[Resource] [name] [id-example]"
+    echo "  \`\`\`"
+    echo ""
+    exit 1
+fi
+
+TOTAL=$(jq -r '.resources | length' "$SCHEMA_FILE")
+echo "✅ All $TOTAL resources have import documentation"
+exit 0

--- a/sdk/dotnet/AccessToken.cs
+++ b/sdk/dotnet/AccessToken.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// Access tokens allow a user to authenticate against the Pulumi Cloud
+    /// 
+    /// ### Import
+    /// 
+    /// Access tokens can be imported using the token `id` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:AccessToken")]
     public partial class AccessToken : global::Pulumi.CustomResource

--- a/sdk/dotnet/AgentPool.cs
+++ b/sdk/dotnet/AgentPool.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// Agent Pool for customer managed deployments
+    /// 
+    /// ### Import
+    /// 
+    /// Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:AgentPool")]
     public partial class AgentPool : global::Pulumi.CustomResource

--- a/sdk/dotnet/ApprovalRule.cs
+++ b/sdk/dotnet/ApprovalRule.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// An approval rule for environment deployments.
+    /// 
+    /// ### Import
+    /// 
+    /// Approval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:ApprovalRule")]
     public partial class ApprovalRule : global::Pulumi.CustomResource

--- a/sdk/dotnet/DeploymentSchedule.cs
+++ b/sdk/dotnet/DeploymentSchedule.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A scheduled recurring or single time run of a pulumi command.
+    /// 
+    /// ### Import
+    /// 
+    /// Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:DeploymentSchedule")]
     public partial class DeploymentSchedule : global::Pulumi.CustomResource

--- a/sdk/dotnet/DriftSchedule.cs
+++ b/sdk/dotnet/DriftSchedule.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A cron schedule to run drift detection.
+    /// 
+    /// ### Import
+    /// 
+    /// Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:DriftSchedule")]
     public partial class DriftSchedule : global::Pulumi.CustomResource

--- a/sdk/dotnet/Environment.cs
+++ b/sdk/dotnet/Environment.cs
@@ -11,6 +11,20 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// An ESC Environment.
+    /// 
+    /// ### Import
+    /// 
+    /// Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+    /// ```
+    /// 
+    /// or using the legacy format (assumes "default" project):
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:Environment")]
     public partial class Environment : global::Pulumi.CustomResource

--- a/sdk/dotnet/EnvironmentRotationSchedule.cs
+++ b/sdk/dotnet/EnvironmentRotationSchedule.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A scheduled recurring or single time environment rotation.
+    /// 
+    /// ### Import
+    /// 
+    /// Environment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:EnvironmentRotationSchedule")]
     public partial class EnvironmentRotationSchedule : global::Pulumi.CustomResource

--- a/sdk/dotnet/EnvironmentVersionTag.cs
+++ b/sdk/dotnet/EnvironmentVersionTag.cs
@@ -11,6 +11,20 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A tag on a specific revision of an environment.
+    /// 
+    /// ### Import
+    /// 
+    /// Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+    /// ```
+    /// 
+    /// or using the legacy format (assumes "default" project):
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:EnvironmentVersionTag")]
     public partial class EnvironmentVersionTag : global::Pulumi.CustomResource

--- a/sdk/dotnet/OidcIssuer.cs
+++ b/sdk/dotnet/OidcIssuer.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.
+    /// 
+    /// ### Import
+    /// 
+    /// OIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:OidcIssuer")]
     public partial class OidcIssuer : global::Pulumi.CustomResource

--- a/sdk/dotnet/OrgAccessToken.cs
+++ b/sdk/dotnet/OrgAccessToken.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
+    /// 
+    /// ### Import
+    /// 
+    /// Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:OrgAccessToken")]
     public partial class OrgAccessToken : global::Pulumi.CustomResource

--- a/sdk/dotnet/PolicyGroup.cs
+++ b/sdk/dotnet/PolicyGroup.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A Policy Group allows you to apply policy packs to a set of stacks in your organization.
+    /// 
+    /// ### Import
+    /// 
+    /// Policy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:PolicyGroup")]
     public partial class PolicyGroup : global::Pulumi.CustomResource

--- a/sdk/dotnet/Stack.cs
+++ b/sdk/dotnet/Stack.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
+    /// 
+    /// ### Import
+    /// 
+    /// Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:Stack")]
     public partial class Stack : global::Pulumi.CustomResource

--- a/sdk/dotnet/StackTag.cs
+++ b/sdk/dotnet/StackTag.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
+    /// 
+    /// ### Import
+    /// 
+    /// Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:StackTag")]
     public partial class StackTag : global::Pulumi.CustomResource

--- a/sdk/dotnet/Team.cs
+++ b/sdk/dotnet/Team.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
+    /// 
+    /// ### Import
+    /// 
+    /// Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:Team my_team my-org/my-team
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:Team")]
     public partial class Team : global::Pulumi.CustomResource

--- a/sdk/dotnet/TeamAccessToken.cs
+++ b/sdk/dotnet/TeamAccessToken.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
+    /// 
+    /// ### Import
+    /// 
+    /// Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:TeamAccessToken")]
     public partial class TeamAccessToken : global::Pulumi.CustomResource

--- a/sdk/dotnet/TeamEnvironmentPermission.cs
+++ b/sdk/dotnet/TeamEnvironmentPermission.cs
@@ -11,6 +11,20 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A permission for a team to use an environment.
+    /// 
+    /// ### Import
+    /// 
+    /// Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+    /// ```
+    /// 
+    /// or using the legacy format (assumes "default" project):
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:TeamEnvironmentPermission")]
     public partial class TeamEnvironmentPermission : global::Pulumi.CustomResource

--- a/sdk/dotnet/TeamStackPermission.cs
+++ b/sdk/dotnet/TeamStackPermission.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// Grants a team permissions to the specified stack.
+    /// 
+    /// ### Import
+    /// 
+    /// Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:TeamStackPermission")]
     public partial class TeamStackPermission : global::Pulumi.CustomResource

--- a/sdk/dotnet/TemplateSource.cs
+++ b/sdk/dotnet/TemplateSource.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A source for Pulumi templates
+    /// 
+    /// ### Import
+    /// 
+    /// Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:TemplateSource")]
     public partial class TemplateSource : global::Pulumi.CustomResource

--- a/sdk/dotnet/TtlSchedule.cs
+++ b/sdk/dotnet/TtlSchedule.cs
@@ -11,6 +11,14 @@ namespace Pulumi.PulumiService
 {
     /// <summary>
     /// A scheduled stack destroy run.
+    /// 
+    /// ### Import
+    /// 
+    /// TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+    /// 
+    /// ```sh
+    ///  $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+    /// ```
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:TtlSchedule")]
     public partial class TtlSchedule : global::Pulumi.CustomResource

--- a/sdk/go/pulumiservice/accessToken.go
+++ b/sdk/go/pulumiservice/accessToken.go
@@ -13,6 +13,16 @@ import (
 )
 
 // Access tokens allow a user to authenticate against the Pulumi Cloud
+//
+// ### Import
+//
+// Access tokens can be imported using the token `id` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+//
+// ```
 type AccessToken struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/agentPool.go
+++ b/sdk/go/pulumiservice/agentPool.go
@@ -13,6 +13,16 @@ import (
 )
 
 // Agent Pool for customer managed deployments
+//
+// ### Import
+//
+// Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+//
+// ```
 type AgentPool struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/approvalRule.go
+++ b/sdk/go/pulumiservice/approvalRule.go
@@ -13,6 +13,16 @@ import (
 )
 
 // An approval rule for environment deployments.
+//
+// ### Import
+//
+// Approval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123
+//
+// ```
 type ApprovalRule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/deploymentSchedule.go
+++ b/sdk/go/pulumiservice/deploymentSchedule.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A scheduled recurring or single time run of a pulumi command.
+//
+// ### Import
+//
+// Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+//
+// ```
 type DeploymentSchedule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/driftSchedule.go
+++ b/sdk/go/pulumiservice/driftSchedule.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A cron schedule to run drift detection.
+//
+// ### Import
+//
+// Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+//
+// ```
 type DriftSchedule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/environment.go
+++ b/sdk/go/pulumiservice/environment.go
@@ -13,6 +13,24 @@ import (
 )
 
 // An ESC Environment.
+//
+// ### Import
+//
+// Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+//
+// ```
+//
+// or using the legacy format (assumes "default" project):
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+//
+// ```
 type Environment struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/environmentRotationSchedule.go
+++ b/sdk/go/pulumiservice/environmentRotationSchedule.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A scheduled recurring or single time environment rotation.
+//
+// ### Import
+//
+// Environment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123
+//
+// ```
 type EnvironmentRotationSchedule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/environmentVersionTag.go
+++ b/sdk/go/pulumiservice/environmentVersionTag.go
@@ -13,6 +13,24 @@ import (
 )
 
 // A tag on a specific revision of an environment.
+//
+// ### Import
+//
+// Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+//
+// ```
+//
+// or using the legacy format (assumes "default" project):
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+//
+// ```
 type EnvironmentVersionTag struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/oidcIssuer.go
+++ b/sdk/go/pulumiservice/oidcIssuer.go
@@ -13,6 +13,16 @@ import (
 )
 
 // Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.
+//
+// ### Import
+//
+// OIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123
+//
+// ```
 type OidcIssuer struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/orgAccessToken.go
+++ b/sdk/go/pulumiservice/orgAccessToken.go
@@ -13,6 +13,16 @@ import (
 )
 
 // The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
+//
+// ### Import
+//
+// Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+//
+// ```
 type OrgAccessToken struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/policyGroup.go
+++ b/sdk/go/pulumiservice/policyGroup.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A Policy Group allows you to apply policy packs to a set of stacks in your organization.
+//
+// ### Import
+//
+// Policy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group
+//
+// ```
 type PolicyGroup struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/stack.go
+++ b/sdk/go/pulumiservice/stack.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
+//
+// ### Import
+//
+// Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+//
+// ```
 type Stack struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/stackTag.go
+++ b/sdk/go/pulumiservice/stackTag.go
@@ -13,6 +13,16 @@ import (
 )
 
 // Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
+//
+// ### Import
+//
+// Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+//
+// ```
 type StackTag struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/team.go
+++ b/sdk/go/pulumiservice/team.go
@@ -13,6 +13,16 @@ import (
 )
 
 // The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
+//
+// ### Import
+//
+// Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:Team my_team my-org/my-team
+//
+// ```
 type Team struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/teamAccessToken.go
+++ b/sdk/go/pulumiservice/teamAccessToken.go
@@ -13,6 +13,16 @@ import (
 )
 
 // The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
+//
+// ### Import
+//
+// Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+//
+// ```
 type TeamAccessToken struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/teamEnvironmentPermission.go
+++ b/sdk/go/pulumiservice/teamEnvironmentPermission.go
@@ -13,6 +13,24 @@ import (
 )
 
 // A permission for a team to use an environment.
+//
+// ### Import
+//
+// Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+//
+// ```
+//
+// or using the legacy format (assumes "default" project):
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+//
+// ```
 type TeamEnvironmentPermission struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/teamStackPermission.go
+++ b/sdk/go/pulumiservice/teamStackPermission.go
@@ -13,6 +13,16 @@ import (
 )
 
 // Grants a team permissions to the specified stack.
+//
+// ### Import
+//
+// Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+//
+// ```
 type TeamStackPermission struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/templateSource.go
+++ b/sdk/go/pulumiservice/templateSource.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A source for Pulumi templates
+//
+// ### Import
+//
+// Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+//
+// ```
 type TemplateSource struct {
 	pulumi.CustomResourceState
 

--- a/sdk/go/pulumiservice/ttlSchedule.go
+++ b/sdk/go/pulumiservice/ttlSchedule.go
@@ -13,6 +13,16 @@ import (
 )
 
 // A scheduled stack destroy run.
+//
+// ### Import
+//
+// TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+//
+// ```sh
+//
+//	$ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+//
+// ```
 type TtlSchedule struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
@@ -16,6 +16,14 @@ import javax.annotation.Nullable;
 /**
  * Access tokens allow a user to authenticate against the Pulumi Cloud
  * 
+ * ### Import
+ * 
+ * Access tokens can be imported using the token `id` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:AccessToken")
 public class AccessToken extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
@@ -18,6 +18,14 @@ import javax.annotation.Nullable;
 /**
  * Agent Pool for customer managed deployments
  * 
+ * ### Import
+ * 
+ * Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:AgentPool")
 public class AgentPool extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/DeploymentSchedule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/DeploymentSchedule.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * A scheduled recurring or single time run of a pulumi command.
  * 
+ * ### Import
+ * 
+ * Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:DeploymentSchedule")
 public class DeploymentSchedule extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/DriftSchedule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/DriftSchedule.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * A cron schedule to run drift detection.
  * 
+ * ### Import
+ * 
+ * Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:DriftSchedule")
 public class DriftSchedule extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Environment.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Environment.java
@@ -17,6 +17,20 @@ import javax.annotation.Nullable;
 /**
  * An ESC Environment.
  * 
+ * ### Import
+ * 
+ * Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+ * ```
+ * 
+ * or using the legacy format (assumes &#34;default&#34; project):
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:Environment")
 public class Environment extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/EnvironmentVersionTag.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/EnvironmentVersionTag.java
@@ -16,6 +16,20 @@ import javax.annotation.Nullable;
 /**
  * A tag on a specific revision of an environment.
  * 
+ * ### Import
+ * 
+ * Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+ * ```
+ * 
+ * or using the legacy format (assumes &#34;default&#34; project):
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:EnvironmentVersionTag")
 public class EnvironmentVersionTag extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
@@ -18,6 +18,14 @@ import javax.annotation.Nullable;
 /**
  * The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
  * 
+ * ### Import
+ * 
+ * Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:OrgAccessToken")
 public class OrgAccessToken extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
  * 
+ * ### Import
+ * 
+ * Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:Stack")
 public class Stack extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/StackTag.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/StackTag.java
@@ -15,6 +15,14 @@ import javax.annotation.Nullable;
 /**
  * Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
  * 
+ * ### Import
+ * 
+ * Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:StackTag")
 public class StackTag extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Team.java
@@ -18,6 +18,14 @@ import javax.annotation.Nullable;
 /**
  * The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
  * 
+ * ### Import
+ * 
+ * Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Team my_team my-org/my-team
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:Team")
 public class Team extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessToken.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
  * 
+ * ### Import
+ * 
+ * Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:TeamAccessToken")
 public class TeamAccessToken extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
@@ -17,6 +17,20 @@ import javax.annotation.Nullable;
 /**
  * A permission for a team to use an environment.
  * 
+ * ### Import
+ * 
+ * Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+ * ```
+ * 
+ * or using the legacy format (assumes &#34;default&#34; project):
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:TeamEnvironmentPermission")
 public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermission.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermission.java
@@ -16,6 +16,14 @@ import javax.annotation.Nullable;
 /**
  * Grants a team permissions to the specified stack.
  * 
+ * ### Import
+ * 
+ * Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:TeamStackPermission")
 public class TeamStackPermission extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TemplateSource.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TemplateSource.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * A source for Pulumi templates
  * 
+ * ### Import
+ * 
+ * Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:TemplateSource")
 public class TemplateSource extends com.pulumi.resources.CustomResource {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlSchedule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlSchedule.java
@@ -17,6 +17,14 @@ import javax.annotation.Nullable;
 /**
  * A scheduled stack destroy run.
  * 
+ * ### Import
+ * 
+ * TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+ * 
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+ * ```
+ * 
  */
 @ResourceType(type="pulumiservice:index:TtlSchedule")
 public class TtlSchedule extends com.pulumi.resources.CustomResource {

--- a/sdk/nodejs/accessToken.ts
+++ b/sdk/nodejs/accessToken.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * Access tokens allow a user to authenticate against the Pulumi Cloud
+ *
+ * ### Import
+ *
+ * Access tokens can be imported using the token `id` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+ * ```
  */
 export class AccessToken extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/agentPool.ts
+++ b/sdk/nodejs/agentPool.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * Agent Pool for customer managed deployments
+ *
+ * ### Import
+ *
+ * Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+ * ```
  */
 export class AgentPool extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/approvalRule.ts
+++ b/sdk/nodejs/approvalRule.ts
@@ -9,6 +9,14 @@ import * as utilities from "./utilities";
 
 /**
  * An approval rule for environment deployments.
+ *
+ * ### Import
+ *
+ * Approval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123
+ * ```
  */
 export class ApprovalRule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/deploymentSchedule.ts
+++ b/sdk/nodejs/deploymentSchedule.ts
@@ -9,6 +9,14 @@ import * as utilities from "./utilities";
 
 /**
  * A scheduled recurring or single time run of a pulumi command.
+ *
+ * ### Import
+ *
+ * Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+ * ```
  */
 export class DeploymentSchedule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/driftSchedule.ts
+++ b/sdk/nodejs/driftSchedule.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * A cron schedule to run drift detection.
+ *
+ * ### Import
+ *
+ * Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+ * ```
  */
 export class DriftSchedule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/environment.ts
+++ b/sdk/nodejs/environment.ts
@@ -6,6 +6,20 @@ import * as utilities from "./utilities";
 
 /**
  * An ESC Environment.
+ *
+ * ### Import
+ *
+ * Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+ * ```
+ *
+ * or using the legacy format (assumes "default" project):
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+ * ```
  */
 export class Environment extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/environmentRotationSchedule.ts
+++ b/sdk/nodejs/environmentRotationSchedule.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * A scheduled recurring or single time environment rotation.
+ *
+ * ### Import
+ *
+ * Environment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123
+ * ```
  */
 export class EnvironmentRotationSchedule extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/environmentVersionTag.ts
+++ b/sdk/nodejs/environmentVersionTag.ts
@@ -6,6 +6,20 @@ import * as utilities from "./utilities";
 
 /**
  * A tag on a specific revision of an environment.
+ *
+ * ### Import
+ *
+ * Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+ * ```
+ *
+ * or using the legacy format (assumes "default" project):
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+ * ```
  */
 export class EnvironmentVersionTag extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/oidcIssuer.ts
+++ b/sdk/nodejs/oidcIssuer.ts
@@ -9,6 +9,14 @@ import * as utilities from "./utilities";
 
 /**
  * Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.
+ *
+ * ### Import
+ *
+ * OIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123
+ * ```
  */
 export class OidcIssuer extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/orgAccessToken.ts
+++ b/sdk/nodejs/orgAccessToken.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
+ *
+ * ### Import
+ *
+ * Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+ * ```
  */
 export class OrgAccessToken extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/policyGroup.ts
+++ b/sdk/nodejs/policyGroup.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * A Policy Group allows you to apply policy packs to a set of stacks in your organization.
+ *
+ * ### Import
+ *
+ * Policy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group
+ * ```
  */
 export class PolicyGroup extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/stack.ts
+++ b/sdk/nodejs/stack.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
+ *
+ * ### Import
+ *
+ * Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+ * ```
  */
 export class Stack extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/stackTag.ts
+++ b/sdk/nodejs/stackTag.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
+ *
+ * ### Import
+ *
+ * Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+ * ```
  */
 export class StackTag extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/team.ts
+++ b/sdk/nodejs/team.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
+ *
+ * ### Import
+ *
+ * Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:Team my_team my-org/my-team
+ * ```
  */
 export class Team extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/teamAccessToken.ts
+++ b/sdk/nodejs/teamAccessToken.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
+ *
+ * ### Import
+ *
+ * Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+ * ```
  */
 export class TeamAccessToken extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/teamEnvironmentPermission.ts
+++ b/sdk/nodejs/teamEnvironmentPermission.ts
@@ -9,6 +9,20 @@ import * as utilities from "./utilities";
 
 /**
  * A permission for a team to use an environment.
+ *
+ * ### Import
+ *
+ * Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+ * ```
+ *
+ * or using the legacy format (assumes "default" project):
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+ * ```
  */
 export class TeamEnvironmentPermission extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/teamStackPermission.ts
+++ b/sdk/nodejs/teamStackPermission.ts
@@ -9,6 +9,14 @@ import * as utilities from "./utilities";
 
 /**
  * Grants a team permissions to the specified stack.
+ *
+ * ### Import
+ *
+ * Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+ * ```
  */
 export class TeamStackPermission extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/templateSource.ts
+++ b/sdk/nodejs/templateSource.ts
@@ -9,6 +9,14 @@ import * as utilities from "./utilities";
 
 /**
  * A source for Pulumi templates
+ *
+ * ### Import
+ *
+ * Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+ * ```
  */
 export class TemplateSource extends pulumi.CustomResource {
     /**

--- a/sdk/nodejs/ttlSchedule.ts
+++ b/sdk/nodejs/ttlSchedule.ts
@@ -6,6 +6,14 @@ import * as utilities from "./utilities";
 
 /**
  * A scheduled stack destroy run.
+ *
+ * ### Import
+ *
+ * TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+ *
+ * ```sh
+ *  $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+ * ```
  */
 export class TtlSchedule extends pulumi.CustomResource {
     /**

--- a/sdk/python/pulumi_pulumiservice/access_token.py
+++ b/sdk/python/pulumi_pulumiservice/access_token.py
@@ -50,6 +50,14 @@ class AccessToken(pulumi.CustomResource):
         """
         Access tokens allow a user to authenticate against the Pulumi Cloud
 
+        ### Import
+
+        Access tokens can be imported using the token `id` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Description of the access token.
@@ -62,6 +70,14 @@ class AccessToken(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Access tokens allow a user to authenticate against the Pulumi Cloud
+
+        ### Import
+
+        Access tokens can be imported using the token `id` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:AccessToken my_token abc123def456
+        ```
 
         :param str resource_name: The name of the resource.
         :param AccessTokenArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/agent_pool.py
+++ b/sdk/python/pulumi_pulumiservice/agent_pool.py
@@ -100,6 +100,14 @@ class AgentPool(pulumi.CustomResource):
         """
         Agent Pool for customer managed deployments
 
+        ### Import
+
+        Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Description of the agent pool.
@@ -115,6 +123,14 @@ class AgentPool(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Agent Pool for customer managed deployments
+
+        ### Import
+
+        Agent pools can be imported using the `id`, which for agent pools is `{org}/{name}/{agentPoolId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:AgentPool my_pool my-org/my-pool/pool-12345
+        ```
 
         :param str resource_name: The name of the resource.
         :param AgentPoolArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/approval_rule.py
+++ b/sdk/python/pulumi_pulumiservice/approval_rule.py
@@ -117,6 +117,14 @@ class ApprovalRule(pulumi.CustomResource):
         """
         An approval rule for environment deployments.
 
+        ### Import
+
+        Approval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['ApprovalRuleConfigArgs', 'ApprovalRuleConfigArgsDict']] approval_rule_config: The approval rule configuration.
@@ -133,6 +141,14 @@ class ApprovalRule(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         An approval rule for environment deployments.
+
+        ### Import
+
+        Approval rules can be imported using the `id`, which for approval rules is `environment/{org}/{project}/{environment}/{ruleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:ApprovalRule my_rule environment/my-org/my-project/my-env/rule-123
+        ```
 
         :param str resource_name: The name of the resource.
         :param ApprovalRuleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/deployment_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/deployment_schedule.py
@@ -133,6 +133,14 @@ class DeploymentSchedule(pulumi.CustomResource):
         """
         A scheduled recurring or single time run of a pulumi command.
 
+        ### Import
+
+        Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] organization: Organization name.
@@ -150,6 +158,14 @@ class DeploymentSchedule(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A scheduled recurring or single time run of a pulumi command.
+
+        ### Import
+
+        Deployment schedules can be imported using the `id`, which for deployment schedules is `{org}/{project}/{stack}/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:DeploymentSchedule my_schedule my-org/my-project/my-stack/sched-789
+        ```
 
         :param str resource_name: The name of the resource.
         :param DeploymentScheduleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/drift_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/drift_schedule.py
@@ -117,6 +117,14 @@ class DriftSchedule(pulumi.CustomResource):
         """
         A cron schedule to run drift detection.
 
+        ### Import
+
+        Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] auto_remediate: Whether any drift detected should be remediated after a drift run.
@@ -133,6 +141,14 @@ class DriftSchedule(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A cron schedule to run drift detection.
+
+        ### Import
+
+        Drift schedules can be imported using the `id`, which for drift schedules is `{org}/{project}/{stack}/drift/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:DriftSchedule my_drift_schedule my-org/my-project/my-stack/drift/sched-456
+        ```
 
         :param str resource_name: The name of the resource.
         :param DriftScheduleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/environment.py
+++ b/sdk/python/pulumi_pulumiservice/environment.py
@@ -101,6 +101,20 @@ class Environment(pulumi.CustomResource):
         """
         An ESC Environment.
 
+        ### Import
+
+        Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] name: Environment name.
@@ -116,6 +130,20 @@ class Environment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         An ESC Environment.
+
+        ### Import
+
+        Environments can be imported using the `id`, which for environments is `{org}/{project}/{environment}` or `{org}/{environment}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Environment my_environment my-org/my-project/my-env
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:Environment my_environment my-org/my-env
+        ```
 
         :param str resource_name: The name of the resource.
         :param EnvironmentArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/environment_rotation_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/environment_rotation_schedule.py
@@ -116,6 +116,14 @@ class EnvironmentRotationSchedule(pulumi.CustomResource):
         """
         A scheduled recurring or single time environment rotation.
 
+        ### Import
+
+        Environment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] environment: Environment name.
@@ -132,6 +140,14 @@ class EnvironmentRotationSchedule(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A scheduled recurring or single time environment rotation.
+
+        ### Import
+
+        Environment rotation schedules can be imported using the `id`, which for environment rotation schedules is `{org}/{project}/{environment}/rotations/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentRotationSchedule my_rotation my-org/my-project/my-env/rotations/sched-123
+        ```
 
         :param str resource_name: The name of the resource.
         :param EnvironmentRotationScheduleArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/environment_version_tag.py
+++ b/sdk/python/pulumi_pulumiservice/environment_version_tag.py
@@ -117,6 +117,20 @@ class EnvironmentVersionTag(pulumi.CustomResource):
         """
         A tag on a specific revision of an environment.
 
+        ### Import
+
+        Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] environment: Environment name.
@@ -133,6 +147,20 @@ class EnvironmentVersionTag(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A tag on a specific revision of an environment.
+
+        ### Import
+
+        Environment version tags can be imported using the `id`, which for environment version tags is `{org}/{project}/{environment}/{tagName}` or `{org}/{environment}/{tagName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-project/my-env/tag-v1
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:EnvironmentVersionTag my_tag my-org/my-env/tag-v1
+        ```
 
         :param str resource_name: The name of the resource.
         :param EnvironmentVersionTagArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/oidc_issuer.py
+++ b/sdk/python/pulumi_pulumiservice/oidc_issuer.py
@@ -136,6 +136,14 @@ class OidcIssuer(pulumi.CustomResource):
         """
         Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.
 
+        ### Import
+
+        OIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.int] max_expiration_seconds: The maximum duration of the Pulumi access token working after an exchange, specified in seconds.
@@ -153,6 +161,14 @@ class OidcIssuer(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Register an OIDC Provider to establish a trust relationship between third-party systems like GitHub Actions and Pulumi Cloud, obviating the need to store a hard-coded Pulumi Cloud token in systems that need to run Pulumi commands or consume Pulumi Cloud APIs. Instead of a hard-coded, static token that must be manually rotated, trusted systems are granted temporary Pulumi Cloud tokens on an as-needed basis, which is more secure than static tokens.
+
+        ### Import
+
+        OIDC issuers can be imported using the `id`, which for OIDC issuers is `{org}/{issuerId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:OidcIssuer my_issuer my-org/issuer-abc123
+        ```
 
         :param str resource_name: The name of the resource.
         :param OidcIssuerArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/org_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/org_access_token.py
@@ -102,6 +102,14 @@ class OrgAccessToken(pulumi.CustomResource):
         """
         The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
 
+        ### Import
+
+        Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token.
@@ -117,6 +125,14 @@ class OrgAccessToken(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org
+
+        ### Import
+
+        Organization access tokens can be imported using the `id`, which for organization access tokens is `{org}/{tokenName}/{tokenId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:OrgAccessToken my_org_token my-org/my-token/token-xyz789
+        ```
 
         :param str resource_name: The name of the resource.
         :param OrgAccessTokenArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/policy_group.py
+++ b/sdk/python/pulumi_pulumiservice/policy_group.py
@@ -138,6 +138,14 @@ class PolicyGroup(pulumi.CustomResource):
         """
         A Policy Group allows you to apply policy packs to a set of stacks in your organization.
 
+        ### Import
+
+        Policy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] entity_type: The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
@@ -155,6 +163,14 @@ class PolicyGroup(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A Policy Group allows you to apply policy packs to a set of stacks in your organization.
+
+        ### Import
+
+        Policy groups can be imported using the `id`, which for policy groups is `{org}/{policyGroupName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:PolicyGroup my_policy_group my-org/my-policy-group
+        ```
 
         :param str resource_name: The name of the resource.
         :param PolicyGroupArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/stack.py
+++ b/sdk/python/pulumi_pulumiservice/stack.py
@@ -99,6 +99,14 @@ class Stack(pulumi.CustomResource):
         """
         A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
 
+        ### Import
+
+        Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the stack even if it still contains resources.
@@ -114,6 +122,14 @@ class Stack(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.
+
+        ### Import
+
+        Stacks can be imported using the `id`, which for stacks is `{org}/{project}/{stack}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Stack my_stack my-org/my-project/my-stack
+        ```
 
         :param str resource_name: The name of the resource.
         :param StackArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/stack_tag.py
+++ b/sdk/python/pulumi_pulumiservice/stack_tag.py
@@ -114,6 +114,14 @@ class StackTag(pulumi.CustomResource):
         """
         Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
 
+        ### Import
+
+        Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] name: Name of the tag. The 'key' part of the key=value pair
@@ -130,6 +138,14 @@ class StackTag(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Stacks have associated metadata in the form of tags. Each tag consists of a name and value.
+
+        ### Import
+
+        Stack tags can be imported using the `id`, which for stack tags is `{org}/{project}/{stack}/{tagName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:StackTag my_tag my-org/my-project/my-stack/my-tag
+        ```
 
         :param str resource_name: The name of the resource.
         :param StackTagArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/team.py
+++ b/sdk/python/pulumi_pulumiservice/team.py
@@ -151,6 +151,14 @@ class Team(pulumi.CustomResource):
         """
         The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
 
+        ### Import
+
+        Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Team my_team my-org/my-team
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Optional. Team description.
@@ -169,6 +177,14 @@ class Team(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The Pulumi Cloud offers role-based access control (RBAC) using teams. Teams allow organization admins to assign a set of stack permissions to a group of users.
+
+        ### Import
+
+        Teams can be imported using the `id`, which for teams is `{org}/{teamName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:Team my_team my-org/my-team
+        ```
 
         :param str resource_name: The name of the resource.
         :param TeamArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/team_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/team_access_token.py
@@ -99,6 +99,14 @@ class TeamAccessToken(pulumi.CustomResource):
         """
         The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
 
+        ### Import
+
+        Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Optional. Team description.
@@ -114,6 +122,14 @@ class TeamAccessToken(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team
+
+        ### Import
+
+        Team access tokens can be imported using the `id`, which for team access tokens is `{org}/{teamName}/{tokenName}/{tokenId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamAccessToken my_team_token my-org/my-team/my-token/token-456
+        ```
 
         :param str resource_name: The name of the resource.
         :param TeamAccessTokenArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/team_environment_permission.py
+++ b/sdk/python/pulumi_pulumiservice/team_environment_permission.py
@@ -135,6 +135,20 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
         """
         A permission for a team to use an environment.
 
+        ### Import
+
+        Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] environment: Environment name.
@@ -152,6 +166,20 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A permission for a team to use an environment.
+
+        ### Import
+
+        Team environment permissions can be imported using the `id`, which for team environment permissions is `{org}/{team}/{project}+{environment}` or `{org}/{team}/{environment}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-project+my-env
+        ```
+
+        or using the legacy format (assumes "default" project):
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamEnvironmentPermission my_perm my-org/my-team/my-env
+        ```
 
         :param str resource_name: The name of the resource.
         :param TeamEnvironmentPermissionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/team_stack_permission.py
+++ b/sdk/python/pulumi_pulumiservice/team_stack_permission.py
@@ -115,6 +115,14 @@ class TeamStackPermission(pulumi.CustomResource):
         """
         Grants a team permissions to the specified stack.
 
+        ### Import
+
+        Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] organization: The organization or the personal account name of the stack.
@@ -131,6 +139,14 @@ class TeamStackPermission(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Grants a team permissions to the specified stack.
+
+        ### Import
+
+        Team stack permissions can be imported using the `id`, which for team stack permissions is `{org}/{project}/{stack}/{teamName}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TeamStackPermission my_perm my-org/my-project/my-stack/my-team
+        ```
 
         :param str resource_name: The name of the resource.
         :param TeamStackPermissionArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/template_source.py
+++ b/sdk/python/pulumi_pulumiservice/template_source.py
@@ -101,6 +101,14 @@ class TemplateSource(pulumi.CustomResource):
         """
         A source for Pulumi templates
 
+        ### Import
+
+        Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Union['TemplateSourceDestinationArgs', 'TemplateSourceDestinationArgsDict']] destination: The default destination for projects using templates from this source.
@@ -116,6 +124,14 @@ class TemplateSource(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A source for Pulumi templates
+
+        ### Import
+
+        Template sources can be imported using the `id`, which for template sources is `{org}/{templateId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TemplateSource my_template my-org/template-abc123
+        ```
 
         :param str resource_name: The name of the resource.
         :param TemplateSourceArgs args: The arguments to use to populate this resource's properties.

--- a/sdk/python/pulumi_pulumiservice/ttl_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/ttl_schedule.py
@@ -117,6 +117,14 @@ class TtlSchedule(pulumi.CustomResource):
         """
         A scheduled stack destroy run.
 
+        ### Import
+
+        TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+        ```
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] delete_after_destroy: True if the stack and all associated history and settings should be deleted.
@@ -133,6 +141,14 @@ class TtlSchedule(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         A scheduled stack destroy run.
+
+        ### Import
+
+        TTL schedules can be imported using the `id`, which for TTL schedules is `{org}/{project}/{stack}/ttl/{scheduleId}` e.g.,
+
+        ```sh
+         $ pulumi import pulumiservice:index:TtlSchedule my_ttl_schedule my-org/my-project/my-stack/ttl/sched-789
+        ```
 
         :param str resource_name: The name of the resource.
         :param TtlScheduleArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
Adds import documentation to all 21 resources in the schema, following the format established by DeploymentSettings. Each resource now includes clear import instructions with example commands showing the correct import ID format.

## Changes

### Schema Documentation
- Added import documentation to 19 resources that were missing it
- All resources now include:
  - Import ID format specification
  - Example `pulumi import` command
  - Legacy format documentation where applicable (Environment, EnvironmentVersionTag, TeamEnvironmentPermission)

### Validation
- Created `scripts/validate-schema-imports.sh` to enforce import documentation
- Integrated validation into `make lint` target
- Validation script checks that all resources have `### Import` section in their description
- Provides clear error messages and format guidance when validation fails

### Documentation
- Updated `CLAUDE.md` with validation instructions and format requirements
- Updated `CHANGELOG.md` with the changes

## Import Format Examples

Resources use various import ID formats depending on their scope:

- **Stack-based**: `{org}/{project}/{stack}`
- **Environment-based**: `{org}/{project}/{environment}` or `{org}/{environment}` (legacy)
- **Team-based**: `{org}/{teamName}`
- **Token-based**: `{org}/{tokenName}/{tokenId}` (org tokens), `{org}/{teamName}/{tokenName}/{tokenId}` (team tokens)
- **Schedules**: Includes type indicators like `drift`, `ttl`, or `rotations` in the path

## Testing

- ✅ Schema validates as valid JSON
- ✅ Provider builds successfully
- ✅ Validation script tested with success and failure cases
- ✅ All 21 resources verified to have import documentation

Fixes #344
