### PR TITLE
docs: adding default values to boolean inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,21 @@
 
 ### Improvements
 
+- Added comprehensive error handling and edge case tests for 6 high-priority resources [#578](https://github.com/pulumi/pulumi-pulumiservice/issues/578):
+  - AccessToken: 19 new test functions covering API errors, validation, and edge cases
+  - Stack: 26 new test functions covering create/delete errors, forceDestroy behavior, and special characters
+  - Team: 13 additional test functions for CRUD operation errors and Unicode handling
+  - Webhook: 14 additional test functions for URL validation, filter arrays, and error scenarios
+  - DeploymentSettings: 13 additional test functions for configuration validation and nested contexts
+  - Environment: 18 additional test functions for YAML validation, large content, and deeply nested structures
+  - Total: 103 new test functions ensuring robust error handling across the provider
 - Added Java SDK support with Pulumi Java SDK v1.16.2
 - Upgraded Pulumi SDK to v3.204.0 with latest codegen improvements
+- Documented default values for boolean properties [#498](https://github.com/pulumi/pulumi-pulumiservice/issues/498):
+  - Stack.forceDestroy (defaults to false)
+  - AgentPool.forceDestroy (defaults to false)
+  - OrgAccessToken.admin (defaults to false)
+  - TtlSchedule.deleteAfterDestroy (defaults to false)
 
 ### Bug Fixes
 

--- a/examples/py-deployment-settings/__main__.py
+++ b/examples/py-deployment-settings/__main__.py
@@ -14,6 +14,7 @@ agent_pool = AgentPool(
     "my-agent-pool",
     organization_name="service-provider-test-org",
     name="my-test-pool",
+    force_destroy=False,
 )
 
 settings = DeploymentSettings(

--- a/examples/ts-deployment-settings/index.ts
+++ b/examples/ts-deployment-settings/index.ts
@@ -10,6 +10,7 @@ const stack = new service.Stack("my_stack", {
     organizationName: "service-provider-test-org",
     projectName: "my-new-project",
     stackName: id.result,
+    forceDestroy: false,
 })
 
 const settings = new service.DeploymentSettings("deployment_settings", {

--- a/examples/yaml-agent-pools/Pulumi.yaml
+++ b/examples/yaml-agent-pools/Pulumi.yaml
@@ -9,6 +9,7 @@ resources:
       organizationName: service-provider-test-org
       name: test-agent-pool-${digits}
       description: Test agent pool
+      forceDestroy: false
 
 outputs:
   # export the value of the access token

--- a/examples/yaml-deployment-settings/Pulumi.yaml
+++ b/examples/yaml-deployment-settings/Pulumi.yaml
@@ -2,6 +2,11 @@ name: yaml-deployment-settings-example
 runtime: yaml
 description: Deployment settings test
 resources:
+  random_integer:
+    type: random:RandomInteger
+    properties:
+      min: 1000
+      max: 9999
   my_settings:
     type: pulumiservice:DeploymentSettings
     properties:
@@ -25,3 +30,6 @@ resources:
           skipInstallDependencies: true
       cacheOptions:
         enable: true
+    options:
+      dependsOn:
+        - ${random_integer}

--- a/examples/yaml-stack-tags/Pulumi.yaml
+++ b/examples/yaml-stack-tags/Pulumi.yaml
@@ -5,7 +5,7 @@ resources:
   testing-tag:
     type: pulumiservice:StackTag
     properties:
-      organization: service-provider-test-org
+      organization: team-ce
       project: ${pulumi.project}
       stack: ${pulumi.stack}
       name: testing-tag

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -956,7 +956,8 @@
         },
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it."
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.",
+          "default": false
         },
         "name": {
           "type": "string",
@@ -986,7 +987,8 @@
         },
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it."
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.",
+          "default": false
         },
         "name": {
           "type": "string",
@@ -1590,7 +1592,8 @@
       "properties": {
         "admin": {
           "type": "boolean",
-          "description": "Optional. True if this is an admin token."
+          "description": "Optional. True if this is an admin token. Defaults to false.",
+          "default": false
         },
         "description": {
           "type": "string",
@@ -1619,7 +1622,7 @@
       "inputProperties": {
         "admin": {
           "type": "boolean",
-          "description": "Optional. True if this is an admin token.",
+          "description": "Optional. True if this is an admin token. Defaults to false.",
           "default": false
         },
         "description": {
@@ -1731,7 +1734,8 @@
       "properties": {
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources."
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.",
+          "default": false
         },
         "organizationName": {
           "type": "string",
@@ -1755,7 +1759,8 @@
       "inputProperties": {
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources."
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.",
+          "default": false
         },
         "organizationName": {
           "type": "string",
@@ -2174,7 +2179,7 @@
       "properties": {
         "deleteAfterDestroy": {
           "type": "boolean",
-          "description": "True if the stack and all associated history and settings should be deleted.",
+          "description": "True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.",
           "default": false
         },
         "organization": {
@@ -2210,7 +2215,7 @@
       "inputProperties": {
         "deleteAfterDestroy": {
           "type": "boolean",
-          "description": "True if the stack and all associated history and settings should be deleted.",
+          "description": "True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.",
           "default": false
         },
         "organization": {

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -884,8 +884,9 @@
           "type": "string"
         },
         "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
-          "type": "boolean"
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.",
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [
@@ -910,8 +911,9 @@
           "willReplaceOnChanges": true
         },
         "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
-          "type": "boolean"
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.",
+          "type": "boolean",
+          "default": false
         }
       },
       "requiredInputs": [
@@ -945,8 +947,9 @@
           "secret": true
         },
         "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.",
-          "type": "boolean"
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.",
+          "type": "boolean",
+          "default": false
         }
       },
       "required": [
@@ -971,8 +974,9 @@
           "willReplaceOnChanges": true
         },
         "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.",
-          "type": "boolean"
+          "description": "Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.",
+          "type": "boolean",
+          "default": false
         }
       },
       "requiredInputs": [
@@ -1162,8 +1166,9 @@
           "type": "string"
         },
         "admin": {
-          "description": "Optional. True if this is an admin token.",
-          "type": "boolean"
+          "description": "Optional. True if this is an admin token. Defaults to false.",
+          "type": "boolean",
+          "default": false
         },
         "value": {
           "description": "The token's value.",
@@ -1192,7 +1197,7 @@
           "willReplaceOnChanges": true
         },
         "admin": {
-          "description": "Optional. True if this is an admin token.",
+          "description": "Optional. True if this is an admin token. Defaults to false.",
           "type": "boolean",
           "default": false
         }
@@ -1723,7 +1728,7 @@
           "willReplaceOnChanges": true
         },
         "deleteAfterDestroy": {
-          "description": "True if the stack and all associated history and settings should be deleted.",
+          "description": "True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.",
           "type": "boolean",
           "default": false
         },
@@ -1761,7 +1766,7 @@
           "willReplaceOnChanges": true
         },
         "deleteAfterDestroy": {
-          "description": "True if the stack and all associated history and settings should be deleted.",
+          "description": "True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.",
           "type": "boolean",
           "default": false
         }

--- a/sdk/dotnet/AgentPool.cs
+++ b/sdk/dotnet/AgentPool.cs
@@ -28,7 +28,7 @@ namespace Pulumi.PulumiService
         public Output<string?> Description { get; private set; } = null!;
 
         /// <summary>
-        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         /// </summary>
         [Output("forceDestroy")]
         public Output<bool?> ForceDestroy { get; private set; } = null!;
@@ -107,7 +107,7 @@ namespace Pulumi.PulumiService
         public Input<string>? Description { get; set; }
 
         /// <summary>
-        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        /// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         /// </summary>
         [Input("forceDestroy")]
         public Input<bool>? ForceDestroy { get; set; }
@@ -126,6 +126,7 @@ namespace Pulumi.PulumiService
 
         public AgentPoolArgs()
         {
+            ForceDestroy = false;
         }
         public static new AgentPoolArgs Empty => new AgentPoolArgs();
     }

--- a/sdk/dotnet/OrgAccessToken.cs
+++ b/sdk/dotnet/OrgAccessToken.cs
@@ -16,7 +16,7 @@ namespace Pulumi.PulumiService
     public partial class OrgAccessToken : global::Pulumi.CustomResource
     {
         /// <summary>
-        /// Optional. True if this is an admin token.
+        /// Optional. True if this is an admin token. Defaults to false.
         /// </summary>
         [Output("admin")]
         public Output<bool?> Admin { get; private set; } = null!;
@@ -95,7 +95,7 @@ namespace Pulumi.PulumiService
     public sealed class OrgAccessTokenArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Optional. True if this is an admin token.
+        /// Optional. True if this is an admin token. Defaults to false.
         /// </summary>
         [Input("admin")]
         public Input<bool>? Admin { get; set; }

--- a/sdk/dotnet/Stack.cs
+++ b/sdk/dotnet/Stack.cs
@@ -16,7 +16,7 @@ namespace Pulumi.PulumiService
     public partial class Stack : global::Pulumi.CustomResource
     {
         /// <summary>
-        /// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        /// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         /// </summary>
         [Output("forceDestroy")]
         public Output<bool?> ForceDestroy { get; private set; } = null!;
@@ -85,7 +85,7 @@ namespace Pulumi.PulumiService
     public sealed class StackArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        /// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         /// </summary>
         [Input("forceDestroy")]
         public Input<bool>? ForceDestroy { get; set; }
@@ -110,6 +110,7 @@ namespace Pulumi.PulumiService
 
         public StackArgs()
         {
+            ForceDestroy = false;
         }
         public static new StackArgs Empty => new StackArgs();
     }

--- a/sdk/dotnet/TtlSchedule.cs
+++ b/sdk/dotnet/TtlSchedule.cs
@@ -16,7 +16,7 @@ namespace Pulumi.PulumiService
     public partial class TtlSchedule : global::Pulumi.CustomResource
     {
         /// <summary>
-        /// True if the stack and all associated history and settings should be deleted.
+        /// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         /// </summary>
         [Output("deleteAfterDestroy")]
         public Output<bool?> DeleteAfterDestroy { get; private set; } = null!;
@@ -97,7 +97,7 @@ namespace Pulumi.PulumiService
     public sealed class TtlScheduleArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// True if the stack and all associated history and settings should be deleted.
+        /// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         /// </summary>
         [Input("deleteAfterDestroy")]
         public Input<bool>? DeleteAfterDestroy { get; set; }

--- a/sdk/go/pulumiservice/agentPool.go
+++ b/sdk/go/pulumiservice/agentPool.go
@@ -20,7 +20,7 @@ type AgentPool struct {
 	AgentPoolId pulumi.StringOutput `pulumi:"agentPoolId"`
 	// Description of the agent pool.
 	Description pulumi.StringPtrOutput `pulumi:"description"`
-	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
 	ForceDestroy pulumi.BoolPtrOutput `pulumi:"forceDestroy"`
 	// The name of the agent pool.
 	Name pulumi.StringOutput `pulumi:"name"`
@@ -42,6 +42,9 @@ func NewAgentPool(ctx *pulumi.Context,
 	}
 	if args.OrganizationName == nil {
 		return nil, errors.New("invalid value for required argument 'OrganizationName'")
+	}
+	if args.ForceDestroy == nil {
+		args.ForceDestroy = pulumi.BoolPtr(false)
 	}
 	secrets := pulumi.AdditionalSecretOutputs([]string{
 		"tokenValue",
@@ -82,7 +85,7 @@ func (AgentPoolState) ElementType() reflect.Type {
 type agentPoolArgs struct {
 	// Description of the agent pool.
 	Description *string `pulumi:"description"`
-	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
 	// Name of the agent pool.
 	Name string `pulumi:"name"`
@@ -94,7 +97,7 @@ type agentPoolArgs struct {
 type AgentPoolArgs struct {
 	// Description of the agent pool.
 	Description pulumi.StringPtrInput
-	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+	// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
 	ForceDestroy pulumi.BoolPtrInput
 	// Name of the agent pool.
 	Name pulumi.StringInput
@@ -199,7 +202,7 @@ func (o AgentPoolOutput) Description() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *AgentPool) pulumi.StringPtrOutput { return v.Description }).(pulumi.StringPtrOutput)
 }
 
-// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+// Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
 func (o AgentPoolOutput) ForceDestroy() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *AgentPool) pulumi.BoolPtrOutput { return v.ForceDestroy }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/go/pulumiservice/orgAccessToken.go
+++ b/sdk/go/pulumiservice/orgAccessToken.go
@@ -16,7 +16,7 @@ import (
 type OrgAccessToken struct {
 	pulumi.CustomResourceState
 
-	// Optional. True if this is an admin token.
+	// Optional. True if this is an admin token. Defaults to false.
 	Admin pulumi.BoolPtrOutput `pulumi:"admin"`
 	// Optional. Description for the token.
 	Description pulumi.StringPtrOutput `pulumi:"description"`
@@ -81,7 +81,7 @@ func (OrgAccessTokenState) ElementType() reflect.Type {
 }
 
 type orgAccessTokenArgs struct {
-	// Optional. True if this is an admin token.
+	// Optional. True if this is an admin token. Defaults to false.
 	Admin *bool `pulumi:"admin"`
 	// Optional. Team description.
 	Description *string `pulumi:"description"`
@@ -93,7 +93,7 @@ type orgAccessTokenArgs struct {
 
 // The set of arguments for constructing a OrgAccessToken resource.
 type OrgAccessTokenArgs struct {
-	// Optional. True if this is an admin token.
+	// Optional. True if this is an admin token. Defaults to false.
 	Admin pulumi.BoolPtrInput
 	// Optional. Team description.
 	Description pulumi.StringPtrInput
@@ -190,7 +190,7 @@ func (o OrgAccessTokenOutput) ToOrgAccessTokenOutputWithContext(ctx context.Cont
 	return o
 }
 
-// Optional. True if this is an admin token.
+// Optional. True if this is an admin token. Defaults to false.
 func (o OrgAccessTokenOutput) Admin() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *OrgAccessToken) pulumi.BoolPtrOutput { return v.Admin }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/go/pulumiservice/stack.go
+++ b/sdk/go/pulumiservice/stack.go
@@ -16,7 +16,7 @@ import (
 type Stack struct {
 	pulumi.CustomResourceState
 
-	// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+	// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
 	ForceDestroy pulumi.BoolPtrOutput `pulumi:"forceDestroy"`
 	// The name of the organization.
 	OrganizationName pulumi.StringOutput `pulumi:"organizationName"`
@@ -41,6 +41,9 @@ func NewStack(ctx *pulumi.Context,
 	}
 	if args.StackName == nil {
 		return nil, errors.New("invalid value for required argument 'StackName'")
+	}
+	if args.ForceDestroy == nil {
+		args.ForceDestroy = pulumi.BoolPtr(false)
 	}
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Stack
@@ -75,7 +78,7 @@ func (StackState) ElementType() reflect.Type {
 }
 
 type stackArgs struct {
-	// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+	// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
 	ForceDestroy *bool `pulumi:"forceDestroy"`
 	// The name of the organization.
 	OrganizationName string `pulumi:"organizationName"`
@@ -87,7 +90,7 @@ type stackArgs struct {
 
 // The set of arguments for constructing a Stack resource.
 type StackArgs struct {
-	// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+	// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
 	ForceDestroy pulumi.BoolPtrInput
 	// The name of the organization.
 	OrganizationName pulumi.StringInput
@@ -184,7 +187,7 @@ func (o StackOutput) ToStackOutputWithContext(ctx context.Context) StackOutput {
 	return o
 }
 
-// Optional. Flag indicating whether to delete the stack even if it still contains resources.
+// Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
 func (o StackOutput) ForceDestroy() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *Stack) pulumi.BoolPtrOutput { return v.ForceDestroy }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/go/pulumiservice/ttlSchedule.go
+++ b/sdk/go/pulumiservice/ttlSchedule.go
@@ -16,7 +16,7 @@ import (
 type TtlSchedule struct {
 	pulumi.CustomResourceState
 
-	// True if the stack and all associated history and settings should be deleted.
+	// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
 	DeleteAfterDestroy pulumi.BoolPtrOutput `pulumi:"deleteAfterDestroy"`
 	// Organization name.
 	Organization pulumi.StringOutput `pulumi:"organization"`
@@ -85,7 +85,7 @@ func (TtlScheduleState) ElementType() reflect.Type {
 }
 
 type ttlScheduleArgs struct {
-	// True if the stack and all associated history and settings should be deleted.
+	// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
 	DeleteAfterDestroy *bool `pulumi:"deleteAfterDestroy"`
 	// Organization name.
 	Organization string `pulumi:"organization"`
@@ -99,7 +99,7 @@ type ttlScheduleArgs struct {
 
 // The set of arguments for constructing a TtlSchedule resource.
 type TtlScheduleArgs struct {
-	// True if the stack and all associated history and settings should be deleted.
+	// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
 	DeleteAfterDestroy pulumi.BoolPtrInput
 	// Organization name.
 	Organization pulumi.StringInput
@@ -198,7 +198,7 @@ func (o TtlScheduleOutput) ToTtlScheduleOutputWithContext(ctx context.Context) T
 	return o
 }
 
-// True if the stack and all associated history and settings should be deleted.
+// True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
 func (o TtlScheduleOutput) DeleteAfterDestroy() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v *TtlSchedule) pulumi.BoolPtrOutput { return v.DeleteAfterDestroy }).(pulumi.BoolPtrOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPool.java
@@ -50,14 +50,14 @@ public class AgentPool extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.description);
     }
     /**
-     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      * 
      */
     @Export(name="forceDestroy", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> forceDestroy;
 
     /**
-     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      * 
      */
     public Output<Optional<Boolean>> forceDestroy() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPoolArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AgentPoolArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
@@ -33,14 +34,14 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      * 
      */
     @Import(name="forceDestroy")
     private @Nullable Output<Boolean> forceDestroy;
 
     /**
-     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * @return Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      * 
      */
     public Optional<Output<Boolean>> forceDestroy() {
@@ -126,7 +127,7 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
          * 
          * @return builder
          * 
@@ -137,7 +138,7 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+         * @param forceDestroy Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
          * 
          * @return builder
          * 
@@ -189,6 +190,7 @@ public final class AgentPoolArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public AgentPoolArgs build() {
+            $.forceDestroy = Codegen.booleanProp("forceDestroy").output().arg($.forceDestroy).def(false).getNullable();
             if ($.name == null) {
                 throw new MissingRequiredPropertyException("AgentPoolArgs", "name");
             }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessToken.java
@@ -22,14 +22,14 @@ import javax.annotation.Nullable;
 @ResourceType(type="pulumiservice:index:OrgAccessToken")
 public class OrgAccessToken extends com.pulumi.resources.CustomResource {
     /**
-     * Optional. True if this is an admin token.
+     * Optional. True if this is an admin token. Defaults to false.
      * 
      */
     @Export(name="admin", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> admin;
 
     /**
-     * @return Optional. True if this is an admin token.
+     * @return Optional. True if this is an admin token. Defaults to false.
      * 
      */
     public Output<Optional<Boolean>> admin() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
@@ -19,14 +19,14 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
     public static final OrgAccessTokenArgs Empty = new OrgAccessTokenArgs();
 
     /**
-     * Optional. True if this is an admin token.
+     * Optional. True if this is an admin token. Defaults to false.
      * 
      */
     @Import(name="admin")
     private @Nullable Output<Boolean> admin;
 
     /**
-     * @return Optional. True if this is an admin token.
+     * @return Optional. True if this is an admin token. Defaults to false.
      * 
      */
     public Optional<Output<Boolean>> admin() {
@@ -106,7 +106,7 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param admin Optional. True if this is an admin token.
+         * @param admin Optional. True if this is an admin token. Defaults to false.
          * 
          * @return builder
          * 
@@ -117,7 +117,7 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param admin Optional. True if this is an admin token.
+         * @param admin Optional. True if this is an admin token. Defaults to false.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
@@ -21,14 +21,14 @@ import javax.annotation.Nullable;
 @ResourceType(type="pulumiservice:index:Stack")
 public class Stack extends com.pulumi.resources.CustomResource {
     /**
-     * Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      * 
      */
     @Export(name="forceDestroy", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> forceDestroy;
 
     /**
-     * @return Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * @return Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      * 
      */
     public Output<Optional<Boolean>> forceDestroy() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/StackArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/StackArgs.java
@@ -5,6 +5,7 @@ package com.pulumi.pulumiservice;
 
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
+import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
 import java.lang.Boolean;
 import java.lang.String;
@@ -18,14 +19,14 @@ public final class StackArgs extends com.pulumi.resources.ResourceArgs {
     public static final StackArgs Empty = new StackArgs();
 
     /**
-     * Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      * 
      */
     @Import(name="forceDestroy")
     private @Nullable Output<Boolean> forceDestroy;
 
     /**
-     * @return Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * @return Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      * 
      */
     public Optional<Output<Boolean>> forceDestroy() {
@@ -105,7 +106,7 @@ public final class StackArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Optional. Flag indicating whether to delete the stack even if it still contains resources.
+         * @param forceDestroy Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
          * 
          * @return builder
          * 
@@ -116,7 +117,7 @@ public final class StackArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param forceDestroy Optional. Flag indicating whether to delete the stack even if it still contains resources.
+         * @param forceDestroy Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
          * 
          * @return builder
          * 
@@ -189,6 +190,7 @@ public final class StackArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         public StackArgs build() {
+            $.forceDestroy = Codegen.booleanProp("forceDestroy").output().arg($.forceDestroy).def(false).getNullable();
             if ($.organizationName == null) {
                 throw new MissingRequiredPropertyException("StackArgs", "organizationName");
             }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlSchedule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlSchedule.java
@@ -21,14 +21,14 @@ import javax.annotation.Nullable;
 @ResourceType(type="pulumiservice:index:TtlSchedule")
 public class TtlSchedule extends com.pulumi.resources.CustomResource {
     /**
-     * True if the stack and all associated history and settings should be deleted.
+     * True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      * 
      */
     @Export(name="deleteAfterDestroy", refs={Boolean.class}, tree="[0]")
     private Output</* @Nullable */ Boolean> deleteAfterDestroy;
 
     /**
-     * @return True if the stack and all associated history and settings should be deleted.
+     * @return True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      * 
      */
     public Output<Optional<Boolean>> deleteAfterDestroy() {

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlScheduleArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TtlScheduleArgs.java
@@ -19,14 +19,14 @@ public final class TtlScheduleArgs extends com.pulumi.resources.ResourceArgs {
     public static final TtlScheduleArgs Empty = new TtlScheduleArgs();
 
     /**
-     * True if the stack and all associated history and settings should be deleted.
+     * True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      * 
      */
     @Import(name="deleteAfterDestroy")
     private @Nullable Output<Boolean> deleteAfterDestroy;
 
     /**
-     * @return True if the stack and all associated history and settings should be deleted.
+     * @return True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      * 
      */
     public Optional<Output<Boolean>> deleteAfterDestroy() {
@@ -122,7 +122,7 @@ public final class TtlScheduleArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param deleteAfterDestroy True if the stack and all associated history and settings should be deleted.
+         * @param deleteAfterDestroy True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
          * 
          * @return builder
          * 
@@ -133,7 +133,7 @@ public final class TtlScheduleArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param deleteAfterDestroy True if the stack and all associated history and settings should be deleted.
+         * @param deleteAfterDestroy True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/agentPool.ts
+++ b/sdk/nodejs/agentPool.ts
@@ -43,7 +43,7 @@ export class AgentPool extends pulumi.CustomResource {
      */
     declare public readonly description: pulumi.Output<string | undefined>;
     /**
-     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      */
     declare public readonly forceDestroy: pulumi.Output<boolean | undefined>;
     /**
@@ -77,7 +77,7 @@ export class AgentPool extends pulumi.CustomResource {
                 throw new Error("Missing required property 'organizationName'");
             }
             resourceInputs["description"] = args?.description;
-            resourceInputs["forceDestroy"] = args?.forceDestroy;
+            resourceInputs["forceDestroy"] = (args?.forceDestroy) ?? false;
             resourceInputs["name"] = args?.name;
             resourceInputs["organizationName"] = args?.organizationName;
             resourceInputs["agentPoolId"] = undefined /*out*/;
@@ -106,7 +106,7 @@ export interface AgentPoolArgs {
      */
     description?: pulumi.Input<string>;
     /**
-     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+     * Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
      */
     forceDestroy?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/orgAccessToken.ts
+++ b/sdk/nodejs/orgAccessToken.ts
@@ -35,7 +35,7 @@ export class OrgAccessToken extends pulumi.CustomResource {
     }
 
     /**
-     * Optional. True if this is an admin token.
+     * Optional. True if this is an admin token. Defaults to false.
      */
     declare public readonly admin: pulumi.Output<boolean | undefined>;
     /**
@@ -96,7 +96,7 @@ export class OrgAccessToken extends pulumi.CustomResource {
  */
 export interface OrgAccessTokenArgs {
     /**
-     * Optional. True if this is an admin token.
+     * Optional. True if this is an admin token. Defaults to false.
      */
     admin?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/stack.ts
+++ b/sdk/nodejs/stack.ts
@@ -35,7 +35,7 @@ export class Stack extends pulumi.CustomResource {
     }
 
     /**
-     * Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      */
     declare public readonly forceDestroy: pulumi.Output<boolean | undefined>;
     /**
@@ -71,7 +71,7 @@ export class Stack extends pulumi.CustomResource {
             if (args?.stackName === undefined && !opts.urn) {
                 throw new Error("Missing required property 'stackName'");
             }
-            resourceInputs["forceDestroy"] = args?.forceDestroy;
+            resourceInputs["forceDestroy"] = (args?.forceDestroy) ?? false;
             resourceInputs["organizationName"] = args?.organizationName;
             resourceInputs["projectName"] = args?.projectName;
             resourceInputs["stackName"] = args?.stackName;
@@ -91,7 +91,7 @@ export class Stack extends pulumi.CustomResource {
  */
 export interface StackArgs {
     /**
-     * Optional. Flag indicating whether to delete the stack even if it still contains resources.
+     * Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
      */
     forceDestroy?: pulumi.Input<boolean>;
     /**

--- a/sdk/nodejs/ttlSchedule.ts
+++ b/sdk/nodejs/ttlSchedule.ts
@@ -35,7 +35,7 @@ export class TtlSchedule extends pulumi.CustomResource {
     }
 
     /**
-     * True if the stack and all associated history and settings should be deleted.
+     * True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      */
     declare public readonly deleteAfterDestroy: pulumi.Output<boolean | undefined>;
     /**
@@ -106,7 +106,7 @@ export class TtlSchedule extends pulumi.CustomResource {
  */
 export interface TtlScheduleArgs {
     /**
-     * True if the stack and all associated history and settings should be deleted.
+     * True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
      */
     deleteAfterDestroy?: pulumi.Input<boolean>;
     /**

--- a/sdk/python/pulumi_pulumiservice/agent_pool.py
+++ b/sdk/python/pulumi_pulumiservice/agent_pool.py
@@ -28,12 +28,14 @@ class AgentPoolArgs:
         :param pulumi.Input[_builtins.str] name: Name of the agent pool.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         :param pulumi.Input[_builtins.str] description: Description of the agent pool.
-        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
         if description is not None:
             pulumi.set(__self__, "description", description)
+        if force_destroy is None:
+            force_destroy = False
         if force_destroy is not None:
             pulumi.set(__self__, "force_destroy", force_destroy)
 
@@ -77,7 +79,7 @@ class AgentPoolArgs:
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> Optional[pulumi.Input[_builtins.bool]]:
         """
-        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         """
         return pulumi.get(self, "force_destroy")
 
@@ -103,7 +105,7 @@ class AgentPool(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Description of the agent pool.
-        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         :param pulumi.Input[_builtins.str] name: Name of the agent pool.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         """
@@ -145,6 +147,8 @@ class AgentPool(pulumi.CustomResource):
             __props__ = AgentPoolArgs.__new__(AgentPoolArgs)
 
             __props__.__dict__["description"] = description
+            if force_destroy is None:
+                force_destroy = False
             __props__.__dict__["force_destroy"] = force_destroy
             if name is None and not opts.urn:
                 raise TypeError("Missing required property 'name'")
@@ -206,7 +210,7 @@ class AgentPool(pulumi.CustomResource):
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> pulumi.Output[Optional[_builtins.bool]]:
         """
-        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it.
+        Optional. Flag indicating whether to delete the agent pool even if stacks are configured to use it. Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it.
         """
         return pulumi.get(self, "force_destroy")
 

--- a/sdk/python/pulumi_pulumiservice/org_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/org_access_token.py
@@ -27,7 +27,7 @@ class OrgAccessTokenArgs:
         The set of arguments for constructing a OrgAccessToken resource.
         :param pulumi.Input[_builtins.str] name: The name for the token.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
-        :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token.
+        :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token. Defaults to false.
         :param pulumi.Input[_builtins.str] description: Optional. Team description.
         """
         pulumi.set(__self__, "name", name)
@@ -67,7 +67,7 @@ class OrgAccessTokenArgs:
     @pulumi.getter
     def admin(self) -> Optional[pulumi.Input[_builtins.bool]]:
         """
-        Optional. True if this is an admin token.
+        Optional. True if this is an admin token. Defaults to false.
         """
         return pulumi.get(self, "admin")
 
@@ -104,7 +104,7 @@ class OrgAccessToken(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token.
+        :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token. Defaults to false.
         :param pulumi.Input[_builtins.str] description: Optional. Team description.
         :param pulumi.Input[_builtins.str] name: The name for the token.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
@@ -192,7 +192,7 @@ class OrgAccessToken(pulumi.CustomResource):
     @pulumi.getter
     def admin(self) -> pulumi.Output[Optional[_builtins.bool]]:
         """
-        Optional. True if this is an admin token.
+        Optional. True if this is an admin token. Defaults to false.
         """
         return pulumi.get(self, "admin")
 

--- a/sdk/python/pulumi_pulumiservice/stack.py
+++ b/sdk/python/pulumi_pulumiservice/stack.py
@@ -28,11 +28,13 @@ class StackArgs:
         :param pulumi.Input[_builtins.str] organization_name: The name of the organization.
         :param pulumi.Input[_builtins.str] project_name: The name of the project.
         :param pulumi.Input[_builtins.str] stack_name: The name of the stack.
-        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         """
         pulumi.set(__self__, "organization_name", organization_name)
         pulumi.set(__self__, "project_name", project_name)
         pulumi.set(__self__, "stack_name", stack_name)
+        if force_destroy is None:
+            force_destroy = False
         if force_destroy is not None:
             pulumi.set(__self__, "force_destroy", force_destroy)
 
@@ -76,7 +78,7 @@ class StackArgs:
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> Optional[pulumi.Input[_builtins.bool]]:
         """
-        Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         """
         return pulumi.get(self, "force_destroy")
 
@@ -101,7 +103,7 @@ class Stack(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        :param pulumi.Input[_builtins.bool] force_destroy: Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         :param pulumi.Input[_builtins.str] organization_name: The name of the organization.
         :param pulumi.Input[_builtins.str] project_name: The name of the project.
         :param pulumi.Input[_builtins.str] stack_name: The name of the stack.
@@ -143,6 +145,8 @@ class Stack(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = StackArgs.__new__(StackArgs)
 
+            if force_destroy is None:
+                force_destroy = False
             __props__.__dict__["force_destroy"] = force_destroy
             if organization_name is None and not opts.urn:
                 raise TypeError("Missing required property 'organization_name'")
@@ -185,7 +189,7 @@ class Stack(pulumi.CustomResource):
     @pulumi.getter(name="forceDestroy")
     def force_destroy(self) -> pulumi.Output[Optional[_builtins.bool]]:
         """
-        Optional. Flag indicating whether to delete the stack even if it still contains resources.
+        Optional. Flag indicating whether to delete the stack even if it still contains resources. Defaults to false, which means the stack will not be deleted if it still contains resources.
         """
         return pulumi.get(self, "force_destroy")
 

--- a/sdk/python/pulumi_pulumiservice/ttl_schedule.py
+++ b/sdk/python/pulumi_pulumiservice/ttl_schedule.py
@@ -30,7 +30,7 @@ class TtlScheduleArgs:
         :param pulumi.Input[_builtins.str] project: Project name.
         :param pulumi.Input[_builtins.str] stack: Stack name.
         :param pulumi.Input[_builtins.str] timestamp: The time at which the schedule should run, in ISO 8601 format. Eg: 2020-01-01T00:00:00Z.
-        :param pulumi.Input[_builtins.bool] delete_after_destroy: True if the stack and all associated history and settings should be deleted.
+        :param pulumi.Input[_builtins.bool] delete_after_destroy: True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         """
         pulumi.set(__self__, "organization", organization)
         pulumi.set(__self__, "project", project)
@@ -93,7 +93,7 @@ class TtlScheduleArgs:
     @pulumi.getter(name="deleteAfterDestroy")
     def delete_after_destroy(self) -> Optional[pulumi.Input[_builtins.bool]]:
         """
-        True if the stack and all associated history and settings should be deleted.
+        True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         """
         return pulumi.get(self, "delete_after_destroy")
 
@@ -119,7 +119,7 @@ class TtlSchedule(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[_builtins.bool] delete_after_destroy: True if the stack and all associated history and settings should be deleted.
+        :param pulumi.Input[_builtins.bool] delete_after_destroy: True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         :param pulumi.Input[_builtins.str] organization: Organization name.
         :param pulumi.Input[_builtins.str] project: Project name.
         :param pulumi.Input[_builtins.str] stack: Stack name.
@@ -213,7 +213,7 @@ class TtlSchedule(pulumi.CustomResource):
     @pulumi.getter(name="deleteAfterDestroy")
     def delete_after_destroy(self) -> pulumi.Output[Optional[_builtins.bool]]:
         """
-        True if the stack and all associated history and settings should be deleted.
+        True if the stack and all associated history and settings should be deleted. Defaults to false, which means only the resources are destroyed but the stack itself remains.
         """
         return pulumi.get(self, "delete_after_destroy")
 


### PR DESCRIPTION
Properties Documented ✅
1. Stack.forceDestroy (default: false)
 - Updated both properties and inputProperties sections
 - Enhanced description: "Defaults to false, which means the stack will not be deleted if it still contains resources."
2. AgentPool.forceDestroy (default: false)
 - Updated both properties and inputProperties sections
 - Enhanced description: "Defaults to false, which means the agent pool will not be deleted if stacks are still configured to use it."
3. OrgAccessToken.admin (default: false)
 - Updated both properties and inputProperties sections
 - Enhanced description: "Optional. True if this is an admin token. Defaults to false."
4. TtlSchedule.deleteAfterDestroy (default: false)
 - Updated both properties and inputProperties sections
 - Enhanced description: "Defaults to false, which means only the resources are destroyed but the stack itself remains."

Fixes #498