### PR TITLE
Fix Environment resource crash with computed values in yaml property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+- Fixed Environment resource crash when yaml property contains computed values from Outputs (e.g., template execution results) [#606](https://github.com/pulumi/pulumi-pulumiservice/issues/606)
 - Fixed PolicyGroup schema syntax error preventing proper nested object definitions in policyPacks field [#595](https://github.com/pulumi/pulumi-pulumiservice/pull/595)
 - Fixed PolicyGroup creation to include required entityType and mode fields [#563](https://github.com/pulumi/pulumi-pulumiservice/issues/563)
 - Fixed PolicyGroup resource to properly handle policy pack config arrays (e.g., approvedAmiIds) as string arrays instead of object arrays

--- a/provider/pkg/resources/environment.go
+++ b/provider/pkg/resources/environment.go
@@ -253,14 +253,17 @@ func (st *PulumiServiceEnvironmentResource) Check(req *pulumirpc.CheckRequest) (
 			inputYaml = inputYaml.SecretValue().Element
 		}
 
-		if inputYaml.IsAsset() {
-			yamlBytes, err := getBytesFromAsset(inputYaml.AssetValue())
-			if err != nil {
-				return nil, err
+		// After unwrapping secret, check again if the inner value is computed
+		if !inputYaml.IsComputed() {
+			if inputYaml.IsAsset() {
+				yamlBytes, err := getBytesFromAsset(inputYaml.AssetValue())
+				if err != nil {
+					return nil, err
+				}
+				stringYaml = string(yamlBytes)
+			} else {
+				stringYaml = inputYaml.StringValue()
 			}
-			stringYaml = string(yamlBytes)
-		} else {
-			stringYaml = inputYaml.StringValue()
 		}
 	}
 

--- a/provider/pkg/resources/environment_test.go
+++ b/provider/pkg/resources/environment_test.go
@@ -258,6 +258,28 @@ foo: bar
 		_, err := provider.Check(&req)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Check when yaml is secret wrapping computed resource", func(t *testing.T) {
+		// This tests the bug fix for issue #606:
+		// Secret wraps a computed value (from Output.ApplyT), causing panic in Check()
+		computedValue := resource.NewComputedProperty(resource.Computed{Element: resource.NewStringProperty("")})
+		propertyMap["yaml"] = resource.MakeSecret(computedValue)
+
+		properties, _ := plugin.MarshalProperties(
+			propertyMap,
+			plugin.MarshalOptions{
+				KeepUnknowns: true,
+				SkipNulls:    true,
+				KeepSecrets:  true,
+			},
+		)
+		req := pulumirpc.CheckRequest{
+			News: properties,
+		}
+
+		_, err := provider.Check(&req)
+		assert.NoError(t, err)
+	})
 }
 
 func TestEnvironment(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a panic in the `Environment` resource's `Check()` method when the `yaml` property contains a computed value wrapped in a secret. This issue occurs when users generate YAML content using `Output.ApplyT()` (e.g., from template execution results).

Fixes #606

## Problem Description

The provider crashes during preview with the error:
```
interface conversion: interface {} is resource.Computed, not string
```

This occurs at `environment.go:263` when:
1. The `yaml` property is wrapped in a secret
2. The secret contains a computed value (an Output that hasn't been resolved yet)
3. The `Check()` method unwraps the secret and attempts to call `StringValue()` on the computed value

## Root Cause

In the `Check()` method, the code:
1. Checks if the outer `yaml` value is computed
2. If it's a secret, unwraps it to get the inner element
3. **BUG**: Does not re-check if the inner element is computed
4. Attempts to call `StringValue()` on what could be a computed value, causing a panic

## Solution

Add a nested `IsComputed()` check after unwrapping secrets. If the inner element is computed, skip the string extraction (it will be handled when the value is resolved).

### Code Changes

**`provider/pkg/resources/environment.go`**:
```go
// After unwrapping secret, check again if the inner value is computed
if !inputYaml.IsComputed() {
    if inputYaml.IsAsset() {
        // ... asset handling
    } else {
        stringYaml = inputYaml.StringValue()
    }
}
```

**`provider/pkg/resources/environment_test.go`**:
- Added test case `Check when yaml is secret wrapping computed resource` that specifically validates the fix

**`CHANGELOG.md`**:
- Added bug fix entry under Unreleased section

## Testing

✅ All existing provider tests pass  
✅ New test case specifically validates secret-wrapped computed values  
✅ Provider builds successfully

### Test Coverage

The new test case creates a secret that wraps a computed value:
```go
computedValue := resource.NewComputedProperty(resource.Computed{Element: resource.NewStringProperty("")})
propertyMap["yaml"] = resource.MakeSecret(computedValue)
```

This reproduces the exact scenario from the bug report and verifies it no longer panics.

## Impact

- **User Impact**: Users can now use `Output.ApplyT()` to generate YAML content for environments without crashes during preview
- **Breaking Changes**: None
- **Risk**: Very low - the fix only adds a safety check; all existing functionality remains unchanged

## Example Usage (Fixed)

```go
secretValue := pulumi.ToSecret("some-secret").(pulumi.StringOutput)

yamlContent := secretValue.ApplyT(func(val string) string {
    return "values:\n  secret: " + val
}).(pulumi.StringOutput)

pulumiservice.NewEnvironment(ctx, "test-env", &pulumiservice.EnvironmentArgs{
    Organization: pulumi.String("my-org"),
    Name:         pulumi.String("test"),
    Yaml:         yamlContent,  // Now works correctly!
})
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)