### PR TITLE
Fix test_provider for native Go provider

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -27,3 +27,9 @@ useNodejsPackageGenSdk: true
 useGoPackageGenSdk: true
 usePythonPackageGenSdk: true
 useProviderBinarySchemaGen: true
+testProviderCmd: >-
+  cd provider && $(GO_TEST_EXEC) -v -short
+  -coverprofile="coverage.txt"
+  -coverpkg="./...,github.com/hashicorp/terraform-provider-..."
+  -parallel $(TESTPARALLELISM)
+  ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -247,11 +247,7 @@ test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)
 .PHONY: test
-test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short \
-	-coverprofile="coverage.txt" \
-	-coverpkg="./...,github.com/hashicorp/terraform-provider-..." \
-	-parallel $(TESTPARALLELISM) \
-	./...
+test_provider_cmd = cd provider && $(GO_TEST_EXEC) -v -short -coverprofile="coverage.txt" -coverpkg="./...,github.com/hashicorp/terraform-provider-..." -parallel $(TESTPARALLELISM) ./pkg/...
 test_provider:
 	$(call test_provider_cmd)
 .PHONY: test_provider


### PR DESCRIPTION
## Summary

- ci-mgmt#2113 changed `test_provider_cmd` from `./...` to `.` to avoid `cmd/` build failures on Terraform-bridged providers
- `pulumi-pulumiservice` is a native Go provider whose `provider/` directory has no Go source files (only `cmd/` and `pkg/` subdirectories), so `cd provider && go test .` fails with `FAIL . [setup failed]`
- Added `testProviderCmd` override in `.ci-mgmt.yaml` using `./pkg/...` to test the `pkg/` subtree while skipping `cmd/`
- Regenerated Makefile via `provider-ci generate`

Fixes #729

## Test plan

- [x] `make test_provider` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>