### PR TITLE
Fix PolicyGroup losing applied packs when adding more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 - Fixed TeamEnvironmentPermission refresh returning wrong permission when the same environment name exists in multiple projects [#674](https://github.com/pulumi/pulumi-pulumiservice/issues/674)
+- Fixed PolicyGroup losing previously-applied policy packs when adding more packs, caused by using the server-normalized numeric version as pack identity [#727](https://github.com/pulumi/pulumi-pulumiservice/issues/727)
 
 ## 0.35.0
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -286,6 +286,7 @@ func (k *pulumiserviceProvider) Configure(
 		},
 		&resources.PulumiServicePolicyGroupResource{
 			Client: client,
+			Host:   k.host,
 		},
 	}
 

--- a/provider/pkg/resources/policy_group.go
+++ b/provider/pkg/resources/policy_group.go
@@ -24,6 +24,8 @@ import (
 	pbempty "google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
@@ -35,6 +37,7 @@ import (
 
 type PulumiServicePolicyGroupResource struct {
 	Client pulumiapi.PolicyGroupClient
+	Host   *provider.HostClient
 }
 
 type PulumiServicePolicyGroupInput struct {
@@ -250,12 +253,47 @@ func (p *PulumiServicePolicyGroupResource) Check(req *pulumirpc.CheckRequest) (*
 		}
 	}
 
+	p.warnIfPolicyPackVersionSet(newsMap, req.GetUrn())
+
 	inputs, err := plugin.MarshalProperties(newsMap, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
 	}
 
 	return &pulumirpc.CheckResponse{Inputs: inputs, Failures: failures}, nil
+}
+
+// warnIfPolicyPackVersionSet emits a warning when the user sets the server-derived `version` field
+// on any policy pack. The numeric `version` is normalized by Pulumi Cloud based on `versionTag`,
+// so user input is ignored or silently overridden. Tracked for schema removal in a follow-up issue.
+func (p *PulumiServicePolicyGroupResource) warnIfPolicyPackVersionSet(news resource.PropertyMap, urn string) {
+	if p.Host == nil {
+		return
+	}
+	packs, ok := news["policyPacks"]
+	if !ok || !packs.IsArray() {
+		return
+	}
+	for _, item := range packs.ArrayValue() {
+		if !item.IsObject() {
+			continue
+		}
+		obj := item.ObjectValue()
+		v, has := obj["version"]
+		if !has || !v.HasValue() {
+			continue
+		}
+		name := ""
+		if n, ok := obj["name"]; ok && n.IsString() {
+			name = n.StringValue()
+		}
+		msg := fmt.Sprintf(
+			"PolicyGroup policy pack %q: the numeric `version` field is server-derived from "+
+				"`versionTag` and will be ignored. Specify only `name` and `versionTag`.",
+			name,
+		)
+		_ = p.Host.Log(context.Background(), diag.Warning, resource.URN(urn), msg)
+	}
 }
 
 func (p *PulumiServicePolicyGroupResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
@@ -653,10 +691,10 @@ func comparePolicyPacks(i, j pulumiapi.PolicyPackMetadata) int {
 	if i.Name > j.Name {
 		return 1
 	}
-	if i.Version < j.Version {
+	if i.VersionTag < j.VersionTag {
 		return -1
 	}
-	if i.Version > j.Version {
+	if i.VersionTag > j.VersionTag {
 		return 1
 	}
 	return 0
@@ -666,9 +704,13 @@ func policyPacksEq(x, y pulumiapi.PolicyPackMetadata) bool {
 	return x.Name == y.Name && x.Version == y.Version && x.VersionTag == y.VersionTag
 }
 
+// containsPolicyPack checks membership by Name + VersionTag. The numeric Version field is
+// server-owned (normalized to the current published version), so it cannot be used as identity:
+// state carries the server's Version while user inputs carry the user's Version, and comparing
+// them would cause spurious remove+add pairs whose add silently fails server-side.
 func containsPolicyPack(packs []pulumiapi.PolicyPackMetadata, target pulumiapi.PolicyPackMetadata) bool {
 	for _, pp := range packs {
-		if pp.Name == target.Name && pp.Version == target.Version {
+		if pp.Name == target.Name && pp.VersionTag == target.VersionTag {
 			return true
 		}
 	}

--- a/provider/pkg/resources/policy_group_test.go
+++ b/provider/pkg/resources/policy_group_test.go
@@ -107,8 +107,9 @@ type stackRef struct {
 }
 
 type policyPackRef struct {
-	name    string
-	version int
+	name       string
+	version    int
+	versionTag string
 }
 
 func newPolicyGroupInput() *policyGroupInputBuilder {
@@ -161,10 +162,14 @@ func (b *policyGroupInputBuilder) build() resource.PropertyMap {
 	// Build policy packs array
 	ppValues := make([]resource.PropertyValue, len(b.policyPacks))
 	for i, pp := range b.policyPacks {
-		ppValues[i] = resource.NewObjectProperty(resource.PropertyMap{
+		ppm := resource.PropertyMap{
 			"name":    resource.NewStringProperty(pp.name),
 			"version": resource.NewNumberProperty(float64(pp.version)),
-		})
+		}
+		if pp.versionTag != "" {
+			ppm["versionTag"] = resource.NewStringProperty(pp.versionTag)
+		}
+		ppValues[i] = resource.NewObjectProperty(ppm)
 	}
 	pm["policyPacks"] = resource.NewArrayProperty(ppValues)
 
@@ -211,7 +216,9 @@ func (b *mockPolicyGroupBuilder) withStacks(stacks ...stackRef) *mockPolicyGroup
 func (b *mockPolicyGroupBuilder) withPolicyPacks(packs ...policyPackRef) *mockPolicyGroupBuilder {
 	b.pg.AppliedPolicyPacks = make([]pulumiapi.PolicyPackMetadata, len(packs))
 	for i, p := range packs {
-		b.pg.AppliedPolicyPacks[i] = pulumiapi.PolicyPackMetadata{Name: p.name, Version: p.version}
+		b.pg.AppliedPolicyPacks[i] = pulumiapi.PolicyPackMetadata{
+			Name: p.name, Version: p.version, VersionTag: p.versionTag,
+		}
 	}
 	return b
 }
@@ -1392,6 +1399,48 @@ func TestPolicyGroup_Update(t *testing.T) {
 		assert.Equal(t, pp1.name, removeReq.RemovePolicyPack.Name)
 		require.NotNil(t, addReq)
 		assert.Equal(t, pp2.name, addReq.AddPolicyPack.Name)
+	})
+
+	// Regression for https://github.com/pulumi/pulumi-pulumiservice/issues/727.
+	// Old state carries the server-normalized numeric Version while new inputs carry the user's
+	// Version. Identity must key off VersionTag, otherwise the provider would remove the existing
+	// pack and re-add it with a stale Version that the server silently drops.
+	t.Run("keeps unchanged pack when server-normalized Version differs from input Version", func(t *testing.T) {
+		existing := policyPackRef{name: "cis-aws", version: 2, versionTag: "1.0.1"}      // server-normalized
+		existingInput := policyPackRef{name: "cis-aws", version: 1, versionTag: "1.0.1"} // user input
+		added := policyPackRef{name: "cis-azure", version: 1, versionTag: "1.0.0"}
+
+		var capturedReqs []pulumiapi.UpdatePolicyGroupRequest
+		provider := PulumiServicePolicyGroupResource{
+			Client: &PolicyGroupClientMock{
+				batchUpdatePolicyGroupFunc: func(_ context.Context, _, _ string, reqs []pulumiapi.UpdatePolicyGroupRequest) error {
+					capturedReqs = reqs
+					return nil
+				},
+				getPolicyGroupFunc: func() (*pulumiapi.PolicyGroup, error) {
+					return newMockPolicyGroup().withPolicyPacks(existing, added).build(), nil
+				},
+			},
+		}
+
+		req := &pulumirpc.UpdateRequest{
+			Id:   testPolicyGroupID,
+			Urn:  testPolicyGroupURN,
+			Olds: newPolicyGroupInput().withPolicyPacks(existing).buildStruct(t),
+			News: newPolicyGroupInput().withPolicyPacks(existingInput, added).buildStruct(t),
+		}
+
+		resp, err := provider.Update(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		for _, r := range capturedReqs {
+			require.Nil(t, r.RemovePolicyPack, "must not remove a pack whose VersionTag is unchanged")
+		}
+		require.Len(t, capturedReqs, 1)
+		require.NotNil(t, capturedReqs[0].AddPolicyPack)
+		assert.Equal(t, added.name, capturedReqs[0].AddPolicyPack.Name)
+		assert.Equal(t, added.versionTag, capturedReqs[0].AddPolicyPack.VersionTag)
 	})
 
 	t.Run("adds accounts", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fix #727: adding a new policy pack to a `PolicyGroup` no longer silently removes the previously-applied pack.
- Root cause: Pulumi Cloud normalizes the numeric `version` field on policy packs to the current published number, but the provider used `Name + Version` as the pack identity. Old state carried the server's Version; new inputs carried the user's Version; the provider issued a `RemovePolicyPack` + `AddPolicyPack`, and the add with a stale Version was silently dropped server-side.
- Verified end-to-end against Pulumi Cloud (`jkodroff-bc/issue-727-pg`) reproducing the exact scenario from #727.
- Switched pack identity to `Name + VersionTag` (user-controlled) in `containsPolicyPack` / `comparePolicyPacks`.
- Added a provider warning via `HostClient.Log` when the user sets `version` on a policy pack, since it's server-derived and ignored.
- Schema-level fix (making `version` output-only) tracked separately in #737.

## Test plan

- [x] Unit tests: added regression subtest in `TestPolicyGroup_Update` covering the server/input Version divergence scenario; all existing policy group tests pass.
- [x] Lint clean (`golangci-lint run --timeout 10m ./...`).
- [x] End-to-end against Pulumi Cloud:
  - Create group with one pack → pack present.
  - Add two more packs → all three present (previously the original would disappear).
  - Remove one pack → only that pack removed, others untouched.
  - Destroy → group deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)