### PR TITLE
Make PolicyGroup policyPacks version output-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking Changes
+- Removed the numeric `version` field from `PolicyGroup.policyPacks` inputs; it is now output-only, since the value is server-derived from `versionTag`. Use `versionTag` to pin pack versions. [#737](https://github.com/pulumi/pulumi-pulumiservice/issues/737)
+
 ### Improvements
 
 ### Bug Fixes

--- a/examples/yaml-policy-groups/Pulumi.yaml
+++ b/examples/yaml-policy-groups/Pulumi.yaml
@@ -45,7 +45,6 @@ resources:
       policyPacks:
         - name: hitrust-aws
           displayName: ""
-          version: 1
           versionTag: 2.4.1
           config:
             hardened-os-image:

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -708,7 +708,35 @@
         },
         "version": {
           "type": "number",
-          "description": "The version of the policy pack."
+          "description": "The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version."
+        },
+        "versionTag": {
+          "type": "string",
+          "description": "The version tag of the policy pack."
+        }
+      },
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "pulumiservice:index:PolicyGroupPolicyPackReferenceInput": {
+      "description": "A reference to a policy pack within a policy group (input).",
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          },
+          "description": "Optional configuration for the policy pack."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the policy pack."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the policy pack."
         },
         "versionTag": {
           "type": "string",
@@ -2004,7 +2032,7 @@
         "policyPacks": {
           "type": "array",
           "items": {
-            "$ref": "#/types/pulumiservice:index:PolicyGroupPolicyPackReference"
+            "$ref": "#/types/pulumiservice:index:PolicyGroupPolicyPackReferenceInput"
           },
           "description": "List of policy packs applied to this policy group."
         },

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -847,8 +847,36 @@
           "type": "string"
         },
         "version": {
-          "description": "The version of the policy pack.",
+          "description": "The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.",
           "type": "number"
+        },
+        "versionTag": {
+          "description": "The version tag of the policy pack.",
+          "type": "string"
+        },
+        "config": {
+          "description": "Optional configuration for the policy pack.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "pulumi.json#/Any"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "pulumiservice:index:PolicyGroupPolicyPackReferenceInput": {
+      "type": "object",
+      "description": "A reference to a policy pack within a policy group (input).",
+      "properties": {
+        "name": {
+          "description": "The name of the policy pack.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The display name of the policy pack.",
+          "type": "string"
         },
         "versionTag": {
           "description": "The version tag of the policy pack.",
@@ -2202,7 +2230,7 @@
           "description": "List of policy packs applied to this policy group.",
           "type": "array",
           "items": {
-            "$ref": "#/types/pulumiservice:index:PolicyGroupPolicyPackReference"
+            "$ref": "#/types/pulumiservice:index:PolicyGroupPolicyPackReferenceInput"
           }
         }
       },

--- a/provider/pkg/resources/policy_group.go
+++ b/provider/pkg/resources/policy_group.go
@@ -250,6 +250,11 @@ func (p *PulumiServicePolicyGroupResource) Check(req *pulumirpc.CheckRequest) (*
 		}
 	}
 
+	// The numeric `version` on policy packs is server-derived from `versionTag`
+	// and is output-only. Strip it from inputs so legacy programs that still set
+	// it upgrade cleanly without spurious diffs.
+	stripPolicyPackVersion(newsMap)
+
 	inputs, err := plugin.MarshalProperties(newsMap, plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
 	if err != nil {
 		return nil, err
@@ -653,26 +658,47 @@ func comparePolicyPacks(i, j pulumiapi.PolicyPackMetadata) int {
 	if i.Name > j.Name {
 		return 1
 	}
-	if i.Version < j.Version {
+	if i.VersionTag < j.VersionTag {
 		return -1
 	}
-	if i.Version > j.Version {
+	if i.VersionTag > j.VersionTag {
 		return 1
 	}
 	return 0
 }
 
 func policyPacksEq(x, y pulumiapi.PolicyPackMetadata) bool {
-	return x.Name == y.Name && x.Version == y.Version && x.VersionTag == y.VersionTag
+	return x.Name == y.Name && x.VersionTag == y.VersionTag
 }
 
 func containsPolicyPack(packs []pulumiapi.PolicyPackMetadata, target pulumiapi.PolicyPackMetadata) bool {
 	for _, pp := range packs {
-		if pp.Name == target.Name && pp.Version == target.Version {
+		if pp.Name == target.Name && pp.VersionTag == target.VersionTag {
 			return true
 		}
 	}
 	return false
+}
+
+// stripPolicyPackVersion removes the server-derived `version` field from each
+// policy pack in the given inputs map. See Check for rationale.
+func stripPolicyPackVersion(news resource.PropertyMap) {
+	packs, ok := news["policyPacks"]
+	if !ok || !packs.IsArray() {
+		return
+	}
+	items := packs.ArrayValue()
+	for i, item := range items {
+		if !item.IsObject() {
+			continue
+		}
+		obj := item.ObjectValue()
+		if _, has := obj["version"]; has {
+			delete(obj, "version")
+			items[i] = resource.NewObjectProperty(obj)
+		}
+	}
+	news["policyPacks"] = resource.NewArrayProperty(items)
 }
 
 // parsePreviousAccounts extracts the accounts from previous state and inputs.

--- a/provider/pkg/resources/policy_group_test.go
+++ b/provider/pkg/resources/policy_group_test.go
@@ -107,8 +107,9 @@ type stackRef struct {
 }
 
 type policyPackRef struct {
-	name    string
-	version int
+	name       string
+	version    int
+	versionTag string
 }
 
 func newPolicyGroupInput() *policyGroupInputBuilder {
@@ -158,12 +159,13 @@ func (b *policyGroupInputBuilder) build() resource.PropertyMap {
 	}
 	pm["stacks"] = resource.NewArrayProperty(stackValues)
 
-	// Build policy packs array
+	// Build policy packs array. `version` is intentionally omitted from inputs:
+	// it is server-derived and output-only.
 	ppValues := make([]resource.PropertyValue, len(b.policyPacks))
 	for i, pp := range b.policyPacks {
 		ppValues[i] = resource.NewObjectProperty(resource.PropertyMap{
-			"name":    resource.NewStringProperty(pp.name),
-			"version": resource.NewNumberProperty(float64(pp.version)),
+			"name":       resource.NewStringProperty(pp.name),
+			"versionTag": resource.NewStringProperty(pp.versionTag),
 		})
 	}
 	pm["policyPacks"] = resource.NewArrayProperty(ppValues)
@@ -211,7 +213,7 @@ func (b *mockPolicyGroupBuilder) withStacks(stacks ...stackRef) *mockPolicyGroup
 func (b *mockPolicyGroupBuilder) withPolicyPacks(packs ...policyPackRef) *mockPolicyGroupBuilder {
 	b.pg.AppliedPolicyPacks = make([]pulumiapi.PolicyPackMetadata, len(packs))
 	for i, p := range packs {
-		b.pg.AppliedPolicyPacks[i] = pulumiapi.PolicyPackMetadata{Name: p.name, Version: p.version}
+		b.pg.AppliedPolicyPacks[i] = pulumiapi.PolicyPackMetadata{Name: p.name, Version: p.version, VersionTag: p.versionTag}
 	}
 	return b
 }
@@ -267,6 +269,50 @@ func TestPolicyGroup_Check_Defaults(t *testing.T) {
 
 	assert.True(t, outputMap["mode"].HasValue(), "mode should have a value")
 	assert.Equal(t, "audit", outputMap["mode"].StringValue(), "mode should default to 'audit'")
+}
+
+// TestPolicyGroup_Check_StripsPolicyPackVersion verifies that the server-derived
+// `version` field is stripped from policy pack inputs during Check, so legacy
+// programs (or stacks with old state) that still supply it upgrade cleanly.
+func TestPolicyGroup_Check_StripsPolicyPackVersion(t *testing.T) {
+	provider := PulumiServicePolicyGroupResource{
+		Client: &PolicyGroupClientMock{},
+	}
+
+	inputs := resource.PropertyMap{
+		"name":             resource.NewStringProperty("test-policy-group"),
+		"organizationName": resource.NewStringProperty("test-org"),
+		"policyPacks": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewObjectProperty(resource.PropertyMap{
+				"name":       resource.NewStringProperty("pp1"),
+				"version":    resource.NewNumberProperty(5),
+				"versionTag": resource.NewStringProperty("1.0.0"),
+			}),
+		}),
+	}
+
+	inputsStruct, err := structpb.NewStruct(inputs.Mappable())
+	require.NoError(t, err)
+
+	resp, err := provider.Check(&pulumirpc.CheckRequest{
+		Urn:  "urn:pulumi:dev::test::pulumiservice:index:PolicyGroup::testPolicyGroup",
+		News: inputsStruct,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Failures)
+
+	outputMap := resource.PropertyMap{}
+	for k, v := range resp.Inputs.GetFields() {
+		outputMap[resource.PropertyKey(k)] = resource.NewPropertyValue(v.AsInterface())
+	}
+
+	packs := outputMap["policyPacks"].ArrayValue()
+	require.Len(t, packs, 1)
+	pp := packs[0].ObjectValue()
+	_, hasVersion := pp["version"]
+	assert.False(t, hasVersion, "version should be stripped from policy pack inputs")
+	assert.Equal(t, "pp1", pp["name"].StringValue())
+	assert.Equal(t, "1.0.0", pp["versionTag"].StringValue())
 }
 
 // TestPolicyGroup_Check_ExplicitValues tests that Check preserves explicit entityType and mode values
@@ -1037,7 +1083,7 @@ func TestParsePreviousAccounts(t *testing.T) {
 func TestPolicyGroup_Create(t *testing.T) {
 	stack1 := stackRef{name: "stack-1", project: "project-1"}
 	stack2 := stackRef{name: "stack-2", project: "project-2"}
-	pp1 := policyPackRef{name: "policy-pack-1", version: 1}
+	pp1 := policyPackRef{name: "policy-pack-1", version: 1, versionTag: "1.0.0"}
 	account1 := "account-1"
 	account2 := "account-2"
 
@@ -1282,8 +1328,8 @@ func TestPolicyGroup_Create(t *testing.T) {
 func TestPolicyGroup_Update(t *testing.T) {
 	stack1 := stackRef{name: "stack-1", project: "project-1"}
 	stack2 := stackRef{name: "stack-2", project: "project-2"}
-	pp1 := policyPackRef{name: "policy-pack-1", version: 1}
-	pp2 := policyPackRef{name: "policy-pack-2", version: 1}
+	pp1 := policyPackRef{name: "policy-pack-1", version: 1, versionTag: "1.0.0"}
+	pp2 := policyPackRef{name: "policy-pack-2", version: 1, versionTag: "1.0.0"}
 	account1 := "account-1"
 	account2 := "account-2"
 	parentAccount := "parent-account"

--- a/sdk/dotnet/Inputs/PolicyGroupPolicyPackReferenceInputArgs.cs
+++ b/sdk/dotnet/Inputs/PolicyGroupPolicyPackReferenceInputArgs.cs
@@ -11,9 +11,9 @@ namespace Pulumi.PulumiService.Inputs
 {
 
     /// <summary>
-    /// A reference to a policy pack within a policy group.
+    /// A reference to a policy pack within a policy group (input).
     /// </summary>
-    public sealed class PolicyGroupPolicyPackReferenceArgs : global::Pulumi.ResourceArgs
+    public sealed class PolicyGroupPolicyPackReferenceInputArgs : global::Pulumi.ResourceArgs
     {
         [Input("config")]
         private InputMap<object>? _config;
@@ -40,20 +40,14 @@ namespace Pulumi.PulumiService.Inputs
         public Input<string> Name { get; set; } = null!;
 
         /// <summary>
-        /// The version of the policy pack.
-        /// </summary>
-        [Input("version")]
-        public Input<double>? Version { get; set; }
-
-        /// <summary>
         /// The version tag of the policy pack.
         /// </summary>
         [Input("versionTag")]
         public Input<string>? VersionTag { get; set; }
 
-        public PolicyGroupPolicyPackReferenceArgs()
+        public PolicyGroupPolicyPackReferenceInputArgs()
         {
         }
-        public static new PolicyGroupPolicyPackReferenceArgs Empty => new PolicyGroupPolicyPackReferenceArgs();
+        public static new PolicyGroupPolicyPackReferenceInputArgs Empty => new PolicyGroupPolicyPackReferenceInputArgs();
     }
 }

--- a/sdk/dotnet/Outputs/PolicyGroupPolicyPackReference.cs
+++ b/sdk/dotnet/Outputs/PolicyGroupPolicyPackReference.cs
@@ -29,7 +29,7 @@ namespace Pulumi.PulumiService.Outputs
         /// </summary>
         public readonly string Name;
         /// <summary>
-        /// The version of the policy pack.
+        /// The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
         /// </summary>
         public readonly double? Version;
         /// <summary>

--- a/sdk/dotnet/PolicyGroup.cs
+++ b/sdk/dotnet/PolicyGroup.cs
@@ -139,14 +139,14 @@ namespace Pulumi.PulumiService
         public Input<string> OrganizationName { get; set; } = null!;
 
         [Input("policyPacks")]
-        private InputList<Inputs.PolicyGroupPolicyPackReferenceArgs>? _policyPacks;
+        private InputList<Inputs.PolicyGroupPolicyPackReferenceInputArgs>? _policyPacks;
 
         /// <summary>
         /// List of policy packs applied to this policy group.
         /// </summary>
-        public InputList<Inputs.PolicyGroupPolicyPackReferenceArgs> PolicyPacks
+        public InputList<Inputs.PolicyGroupPolicyPackReferenceInputArgs> PolicyPacks
         {
-            get => _policyPacks ?? (_policyPacks = new InputList<Inputs.PolicyGroupPolicyPackReferenceArgs>());
+            get => _policyPacks ?? (_policyPacks = new InputList<Inputs.PolicyGroupPolicyPackReferenceInputArgs>());
             set => _policyPacks = value;
         }
 

--- a/sdk/go/pulumiservice/policyGroup.go
+++ b/sdk/go/pulumiservice/policyGroup.go
@@ -95,7 +95,7 @@ type policyGroupArgs struct {
 	// The name of the Pulumi organization the policy group belongs to.
 	OrganizationName string `pulumi:"organizationName"`
 	// List of policy packs applied to this policy group.
-	PolicyPacks []PolicyGroupPolicyPackReference `pulumi:"policyPacks"`
+	PolicyPacks []PolicyGroupPolicyPackReferenceInputType `pulumi:"policyPacks"`
 	// List of stack references that belong to this policy group.
 	Stacks []PolicyGroupStackReference `pulumi:"stacks"`
 }
@@ -113,7 +113,7 @@ type PolicyGroupArgs struct {
 	// The name of the Pulumi organization the policy group belongs to.
 	OrganizationName pulumi.StringInput
 	// List of policy packs applied to this policy group.
-	PolicyPacks PolicyGroupPolicyPackReferenceArrayInput
+	PolicyPacks PolicyGroupPolicyPackReferenceInputTypeArrayInput
 	// List of stack references that belong to this policy group.
 	Stacks PolicyGroupStackReferenceArrayInput
 }

--- a/sdk/go/pulumiservice/pulumiTypes.go
+++ b/sdk/go/pulumiservice/pulumiTypes.go
@@ -3398,72 +3398,10 @@ type PolicyGroupPolicyPackReference struct {
 	DisplayName *string `pulumi:"displayName"`
 	// The name of the policy pack.
 	Name string `pulumi:"name"`
-	// The version of the policy pack.
+	// The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
 	Version *float64 `pulumi:"version"`
 	// The version tag of the policy pack.
 	VersionTag *string `pulumi:"versionTag"`
-}
-
-// PolicyGroupPolicyPackReferenceInput is an input type that accepts PolicyGroupPolicyPackReferenceArgs and PolicyGroupPolicyPackReferenceOutput values.
-// You can construct a concrete instance of `PolicyGroupPolicyPackReferenceInput` via:
-//
-//	PolicyGroupPolicyPackReferenceArgs{...}
-type PolicyGroupPolicyPackReferenceInput interface {
-	pulumi.Input
-
-	ToPolicyGroupPolicyPackReferenceOutput() PolicyGroupPolicyPackReferenceOutput
-	ToPolicyGroupPolicyPackReferenceOutputWithContext(context.Context) PolicyGroupPolicyPackReferenceOutput
-}
-
-// A reference to a policy pack within a policy group.
-type PolicyGroupPolicyPackReferenceArgs struct {
-	// Optional configuration for the policy pack.
-	Config pulumi.MapInput `pulumi:"config"`
-	// The display name of the policy pack.
-	DisplayName pulumi.StringPtrInput `pulumi:"displayName"`
-	// The name of the policy pack.
-	Name pulumi.StringInput `pulumi:"name"`
-	// The version of the policy pack.
-	Version pulumi.Float64PtrInput `pulumi:"version"`
-	// The version tag of the policy pack.
-	VersionTag pulumi.StringPtrInput `pulumi:"versionTag"`
-}
-
-func (PolicyGroupPolicyPackReferenceArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*PolicyGroupPolicyPackReference)(nil)).Elem()
-}
-
-func (i PolicyGroupPolicyPackReferenceArgs) ToPolicyGroupPolicyPackReferenceOutput() PolicyGroupPolicyPackReferenceOutput {
-	return i.ToPolicyGroupPolicyPackReferenceOutputWithContext(context.Background())
-}
-
-func (i PolicyGroupPolicyPackReferenceArgs) ToPolicyGroupPolicyPackReferenceOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PolicyGroupPolicyPackReferenceOutput)
-}
-
-// PolicyGroupPolicyPackReferenceArrayInput is an input type that accepts PolicyGroupPolicyPackReferenceArray and PolicyGroupPolicyPackReferenceArrayOutput values.
-// You can construct a concrete instance of `PolicyGroupPolicyPackReferenceArrayInput` via:
-//
-//	PolicyGroupPolicyPackReferenceArray{ PolicyGroupPolicyPackReferenceArgs{...} }
-type PolicyGroupPolicyPackReferenceArrayInput interface {
-	pulumi.Input
-
-	ToPolicyGroupPolicyPackReferenceArrayOutput() PolicyGroupPolicyPackReferenceArrayOutput
-	ToPolicyGroupPolicyPackReferenceArrayOutputWithContext(context.Context) PolicyGroupPolicyPackReferenceArrayOutput
-}
-
-type PolicyGroupPolicyPackReferenceArray []PolicyGroupPolicyPackReferenceInput
-
-func (PolicyGroupPolicyPackReferenceArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]PolicyGroupPolicyPackReference)(nil)).Elem()
-}
-
-func (i PolicyGroupPolicyPackReferenceArray) ToPolicyGroupPolicyPackReferenceArrayOutput() PolicyGroupPolicyPackReferenceArrayOutput {
-	return i.ToPolicyGroupPolicyPackReferenceArrayOutputWithContext(context.Background())
-}
-
-func (i PolicyGroupPolicyPackReferenceArray) ToPolicyGroupPolicyPackReferenceArrayOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceArrayOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PolicyGroupPolicyPackReferenceArrayOutput)
 }
 
 // A reference to a policy pack within a policy group.
@@ -3496,7 +3434,7 @@ func (o PolicyGroupPolicyPackReferenceOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v PolicyGroupPolicyPackReference) string { return v.Name }).(pulumi.StringOutput)
 }
 
-// The version of the policy pack.
+// The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
 func (o PolicyGroupPolicyPackReferenceOutput) Version() pulumi.Float64PtrOutput {
 	return o.ApplyT(func(v PolicyGroupPolicyPackReference) *float64 { return v.Version }).(pulumi.Float64PtrOutput)
 }
@@ -3524,6 +3462,133 @@ func (o PolicyGroupPolicyPackReferenceArrayOutput) Index(i pulumi.IntInput) Poli
 	return pulumi.All(o, i).ApplyT(func(vs []interface{}) PolicyGroupPolicyPackReference {
 		return vs[0].([]PolicyGroupPolicyPackReference)[vs[1].(int)]
 	}).(PolicyGroupPolicyPackReferenceOutput)
+}
+
+// A reference to a policy pack within a policy group (input).
+type PolicyGroupPolicyPackReferenceInputType struct {
+	// Optional configuration for the policy pack.
+	Config map[string]interface{} `pulumi:"config"`
+	// The display name of the policy pack.
+	DisplayName *string `pulumi:"displayName"`
+	// The name of the policy pack.
+	Name string `pulumi:"name"`
+	// The version tag of the policy pack.
+	VersionTag *string `pulumi:"versionTag"`
+}
+
+// PolicyGroupPolicyPackReferenceInputTypeInput is an input type that accepts PolicyGroupPolicyPackReferenceInputTypeArgs and PolicyGroupPolicyPackReferenceInputTypeOutput values.
+// You can construct a concrete instance of `PolicyGroupPolicyPackReferenceInputTypeInput` via:
+//
+//	PolicyGroupPolicyPackReferenceInputTypeArgs{...}
+type PolicyGroupPolicyPackReferenceInputTypeInput interface {
+	pulumi.Input
+
+	ToPolicyGroupPolicyPackReferenceInputTypeOutput() PolicyGroupPolicyPackReferenceInputTypeOutput
+	ToPolicyGroupPolicyPackReferenceInputTypeOutputWithContext(context.Context) PolicyGroupPolicyPackReferenceInputTypeOutput
+}
+
+// A reference to a policy pack within a policy group (input).
+type PolicyGroupPolicyPackReferenceInputTypeArgs struct {
+	// Optional configuration for the policy pack.
+	Config pulumi.MapInput `pulumi:"config"`
+	// The display name of the policy pack.
+	DisplayName pulumi.StringPtrInput `pulumi:"displayName"`
+	// The name of the policy pack.
+	Name pulumi.StringInput `pulumi:"name"`
+	// The version tag of the policy pack.
+	VersionTag pulumi.StringPtrInput `pulumi:"versionTag"`
+}
+
+func (PolicyGroupPolicyPackReferenceInputTypeArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*PolicyGroupPolicyPackReferenceInputType)(nil)).Elem()
+}
+
+func (i PolicyGroupPolicyPackReferenceInputTypeArgs) ToPolicyGroupPolicyPackReferenceInputTypeOutput() PolicyGroupPolicyPackReferenceInputTypeOutput {
+	return i.ToPolicyGroupPolicyPackReferenceInputTypeOutputWithContext(context.Background())
+}
+
+func (i PolicyGroupPolicyPackReferenceInputTypeArgs) ToPolicyGroupPolicyPackReferenceInputTypeOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceInputTypeOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(PolicyGroupPolicyPackReferenceInputTypeOutput)
+}
+
+// PolicyGroupPolicyPackReferenceInputTypeArrayInput is an input type that accepts PolicyGroupPolicyPackReferenceInputTypeArray and PolicyGroupPolicyPackReferenceInputTypeArrayOutput values.
+// You can construct a concrete instance of `PolicyGroupPolicyPackReferenceInputTypeArrayInput` via:
+//
+//	PolicyGroupPolicyPackReferenceInputTypeArray{ PolicyGroupPolicyPackReferenceInputTypeArgs{...} }
+type PolicyGroupPolicyPackReferenceInputTypeArrayInput interface {
+	pulumi.Input
+
+	ToPolicyGroupPolicyPackReferenceInputTypeArrayOutput() PolicyGroupPolicyPackReferenceInputTypeArrayOutput
+	ToPolicyGroupPolicyPackReferenceInputTypeArrayOutputWithContext(context.Context) PolicyGroupPolicyPackReferenceInputTypeArrayOutput
+}
+
+type PolicyGroupPolicyPackReferenceInputTypeArray []PolicyGroupPolicyPackReferenceInputTypeInput
+
+func (PolicyGroupPolicyPackReferenceInputTypeArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]PolicyGroupPolicyPackReferenceInputType)(nil)).Elem()
+}
+
+func (i PolicyGroupPolicyPackReferenceInputTypeArray) ToPolicyGroupPolicyPackReferenceInputTypeArrayOutput() PolicyGroupPolicyPackReferenceInputTypeArrayOutput {
+	return i.ToPolicyGroupPolicyPackReferenceInputTypeArrayOutputWithContext(context.Background())
+}
+
+func (i PolicyGroupPolicyPackReferenceInputTypeArray) ToPolicyGroupPolicyPackReferenceInputTypeArrayOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceInputTypeArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(PolicyGroupPolicyPackReferenceInputTypeArrayOutput)
+}
+
+// A reference to a policy pack within a policy group (input).
+type PolicyGroupPolicyPackReferenceInputTypeOutput struct{ *pulumi.OutputState }
+
+func (PolicyGroupPolicyPackReferenceInputTypeOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*PolicyGroupPolicyPackReferenceInputType)(nil)).Elem()
+}
+
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) ToPolicyGroupPolicyPackReferenceInputTypeOutput() PolicyGroupPolicyPackReferenceInputTypeOutput {
+	return o
+}
+
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) ToPolicyGroupPolicyPackReferenceInputTypeOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceInputTypeOutput {
+	return o
+}
+
+// Optional configuration for the policy pack.
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) Config() pulumi.MapOutput {
+	return o.ApplyT(func(v PolicyGroupPolicyPackReferenceInputType) map[string]interface{} { return v.Config }).(pulumi.MapOutput)
+}
+
+// The display name of the policy pack.
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) DisplayName() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v PolicyGroupPolicyPackReferenceInputType) *string { return v.DisplayName }).(pulumi.StringPtrOutput)
+}
+
+// The name of the policy pack.
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) Name() pulumi.StringOutput {
+	return o.ApplyT(func(v PolicyGroupPolicyPackReferenceInputType) string { return v.Name }).(pulumi.StringOutput)
+}
+
+// The version tag of the policy pack.
+func (o PolicyGroupPolicyPackReferenceInputTypeOutput) VersionTag() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v PolicyGroupPolicyPackReferenceInputType) *string { return v.VersionTag }).(pulumi.StringPtrOutput)
+}
+
+type PolicyGroupPolicyPackReferenceInputTypeArrayOutput struct{ *pulumi.OutputState }
+
+func (PolicyGroupPolicyPackReferenceInputTypeArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]PolicyGroupPolicyPackReferenceInputType)(nil)).Elem()
+}
+
+func (o PolicyGroupPolicyPackReferenceInputTypeArrayOutput) ToPolicyGroupPolicyPackReferenceInputTypeArrayOutput() PolicyGroupPolicyPackReferenceInputTypeArrayOutput {
+	return o
+}
+
+func (o PolicyGroupPolicyPackReferenceInputTypeArrayOutput) ToPolicyGroupPolicyPackReferenceInputTypeArrayOutputWithContext(ctx context.Context) PolicyGroupPolicyPackReferenceInputTypeArrayOutput {
+	return o
+}
+
+func (o PolicyGroupPolicyPackReferenceInputTypeArrayOutput) Index(i pulumi.IntInput) PolicyGroupPolicyPackReferenceInputTypeOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) PolicyGroupPolicyPackReferenceInputType {
+		return vs[0].([]PolicyGroupPolicyPackReferenceInputType)[vs[1].(int)]
+	}).(PolicyGroupPolicyPackReferenceInputTypeOutput)
 }
 
 // A reference to a stack within a policy group.
@@ -3809,8 +3874,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*OperationContextOIDCPtrInput)(nil)).Elem(), OperationContextOIDCArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*OperationContextOptionsInput)(nil)).Elem(), OperationContextOptionsArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*OperationContextOptionsPtrInput)(nil)).Elem(), OperationContextOptionsArgs{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupPolicyPackReferenceInput)(nil)).Elem(), PolicyGroupPolicyPackReferenceArgs{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupPolicyPackReferenceArrayInput)(nil)).Elem(), PolicyGroupPolicyPackReferenceArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupPolicyPackReferenceInputTypeInput)(nil)).Elem(), PolicyGroupPolicyPackReferenceInputTypeArgs{})
+	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupPolicyPackReferenceInputTypeArrayInput)(nil)).Elem(), PolicyGroupPolicyPackReferenceInputTypeArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupStackReferenceInput)(nil)).Elem(), PolicyGroupStackReferenceArgs{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PolicyGroupStackReferenceArrayInput)(nil)).Elem(), PolicyGroupStackReferenceArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*TemplateSourceDestinationInput)(nil)).Elem(), TemplateSourceDestinationArgs{})
@@ -3855,6 +3920,8 @@ func init() {
 	pulumi.RegisterOutputType(OperationContextOptionsPtrOutput{})
 	pulumi.RegisterOutputType(PolicyGroupPolicyPackReferenceOutput{})
 	pulumi.RegisterOutputType(PolicyGroupPolicyPackReferenceArrayOutput{})
+	pulumi.RegisterOutputType(PolicyGroupPolicyPackReferenceInputTypeOutput{})
+	pulumi.RegisterOutputType(PolicyGroupPolicyPackReferenceInputTypeArrayOutput{})
 	pulumi.RegisterOutputType(PolicyGroupStackReferenceOutput{})
 	pulumi.RegisterOutputType(PolicyGroupStackReferenceArrayOutput{})
 	pulumi.RegisterOutputType(TemplateSourceDestinationOutput{})

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/PolicyGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/PolicyGroupArgs.java
@@ -7,7 +7,7 @@ import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import com.pulumi.pulumiservice.inputs.PolicyGroupPolicyPackReferenceArgs;
+import com.pulumi.pulumiservice.inputs.PolicyGroupPolicyPackReferenceInputArgs;
 import com.pulumi.pulumiservice.inputs.PolicyGroupStackReferenceArgs;
 import java.lang.String;
 import java.util.List;
@@ -100,13 +100,13 @@ public final class PolicyGroupArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="policyPacks")
-    private @Nullable Output<List<PolicyGroupPolicyPackReferenceArgs>> policyPacks;
+    private @Nullable Output<List<PolicyGroupPolicyPackReferenceInputArgs>> policyPacks;
 
     /**
      * @return List of policy packs applied to this policy group.
      * 
      */
-    public Optional<Output<List<PolicyGroupPolicyPackReferenceArgs>>> policyPacks() {
+    public Optional<Output<List<PolicyGroupPolicyPackReferenceInputArgs>>> policyPacks() {
         return Optional.ofNullable(this.policyPacks);
     }
 
@@ -276,7 +276,7 @@ public final class PolicyGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder policyPacks(@Nullable Output<List<PolicyGroupPolicyPackReferenceArgs>> policyPacks) {
+        public Builder policyPacks(@Nullable Output<List<PolicyGroupPolicyPackReferenceInputArgs>> policyPacks) {
             $.policyPacks = policyPacks;
             return this;
         }
@@ -287,7 +287,7 @@ public final class PolicyGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder policyPacks(List<PolicyGroupPolicyPackReferenceArgs> policyPacks) {
+        public Builder policyPacks(List<PolicyGroupPolicyPackReferenceInputArgs> policyPacks) {
             return policyPacks(Output.of(policyPacks));
         }
 
@@ -297,7 +297,7 @@ public final class PolicyGroupArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder policyPacks(PolicyGroupPolicyPackReferenceArgs... policyPacks) {
+        public Builder policyPacks(PolicyGroupPolicyPackReferenceInputArgs... policyPacks) {
             return policyPacks(List.of(policyPacks));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/PolicyGroupPolicyPackReferenceInputArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/PolicyGroupPolicyPackReferenceInputArgs.java
@@ -6,7 +6,6 @@ package com.pulumi.pulumiservice.inputs;
 import com.pulumi.core.Output;
 import com.pulumi.core.annotations.Import;
 import com.pulumi.exceptions.MissingRequiredPropertyException;
-import java.lang.Double;
 import java.lang.Object;
 import java.lang.String;
 import java.util.Map;
@@ -16,12 +15,12 @@ import javax.annotation.Nullable;
 
 
 /**
- * A reference to a policy pack within a policy group.
+ * A reference to a policy pack within a policy group (input).
  * 
  */
-public final class PolicyGroupPolicyPackReferenceArgs extends com.pulumi.resources.ResourceArgs {
+public final class PolicyGroupPolicyPackReferenceInputArgs extends com.pulumi.resources.ResourceArgs {
 
-    public static final PolicyGroupPolicyPackReferenceArgs Empty = new PolicyGroupPolicyPackReferenceArgs();
+    public static final PolicyGroupPolicyPackReferenceInputArgs Empty = new PolicyGroupPolicyPackReferenceInputArgs();
 
     /**
      * Optional configuration for the policy pack.
@@ -69,21 +68,6 @@ public final class PolicyGroupPolicyPackReferenceArgs extends com.pulumi.resourc
     }
 
     /**
-     * The version of the policy pack.
-     * 
-     */
-    @Import(name="version")
-    private @Nullable Output<Double> version;
-
-    /**
-     * @return The version of the policy pack.
-     * 
-     */
-    public Optional<Output<Double>> version() {
-        return Optional.ofNullable(this.version);
-    }
-
-    /**
      * The version tag of the policy pack.
      * 
      */
@@ -98,32 +82,31 @@ public final class PolicyGroupPolicyPackReferenceArgs extends com.pulumi.resourc
         return Optional.ofNullable(this.versionTag);
     }
 
-    private PolicyGroupPolicyPackReferenceArgs() {}
+    private PolicyGroupPolicyPackReferenceInputArgs() {}
 
-    private PolicyGroupPolicyPackReferenceArgs(PolicyGroupPolicyPackReferenceArgs $) {
+    private PolicyGroupPolicyPackReferenceInputArgs(PolicyGroupPolicyPackReferenceInputArgs $) {
         this.config = $.config;
         this.displayName = $.displayName;
         this.name = $.name;
-        this.version = $.version;
         this.versionTag = $.versionTag;
     }
 
     public static Builder builder() {
         return new Builder();
     }
-    public static Builder builder(PolicyGroupPolicyPackReferenceArgs defaults) {
+    public static Builder builder(PolicyGroupPolicyPackReferenceInputArgs defaults) {
         return new Builder(defaults);
     }
 
     public static final class Builder {
-        private PolicyGroupPolicyPackReferenceArgs $;
+        private PolicyGroupPolicyPackReferenceInputArgs $;
 
         public Builder() {
-            $ = new PolicyGroupPolicyPackReferenceArgs();
+            $ = new PolicyGroupPolicyPackReferenceInputArgs();
         }
 
-        public Builder(PolicyGroupPolicyPackReferenceArgs defaults) {
-            $ = new PolicyGroupPolicyPackReferenceArgs(Objects.requireNonNull(defaults));
+        public Builder(PolicyGroupPolicyPackReferenceInputArgs defaults) {
+            $ = new PolicyGroupPolicyPackReferenceInputArgs(Objects.requireNonNull(defaults));
         }
 
         /**
@@ -190,27 +173,6 @@ public final class PolicyGroupPolicyPackReferenceArgs extends com.pulumi.resourc
         }
 
         /**
-         * @param version The version of the policy pack.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(@Nullable Output<Double> version) {
-            $.version = version;
-            return this;
-        }
-
-        /**
-         * @param version The version of the policy pack.
-         * 
-         * @return builder
-         * 
-         */
-        public Builder version(Double version) {
-            return version(Output.of(version));
-        }
-
-        /**
          * @param versionTag The version tag of the policy pack.
          * 
          * @return builder
@@ -231,9 +193,9 @@ public final class PolicyGroupPolicyPackReferenceArgs extends com.pulumi.resourc
             return versionTag(Output.of(versionTag));
         }
 
-        public PolicyGroupPolicyPackReferenceArgs build() {
+        public PolicyGroupPolicyPackReferenceInputArgs build() {
             if ($.name == null) {
-                throw new MissingRequiredPropertyException("PolicyGroupPolicyPackReferenceArgs", "name");
+                throw new MissingRequiredPropertyException("PolicyGroupPolicyPackReferenceInputArgs", "name");
             }
             return $;
         }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/outputs/PolicyGroupPolicyPackReference.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/outputs/PolicyGroupPolicyPackReference.java
@@ -31,7 +31,7 @@ public final class PolicyGroupPolicyPackReference {
      */
     private String name;
     /**
-     * @return The version of the policy pack.
+     * @return The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
      * 
      */
     private @Nullable Double version;
@@ -64,7 +64,7 @@ public final class PolicyGroupPolicyPackReference {
         return this.name;
     }
     /**
-     * @return The version of the policy pack.
+     * @return The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
      * 
      */
     public Optional<Double> version() {

--- a/sdk/nodejs/policyGroup.ts
+++ b/sdk/nodejs/policyGroup.ts
@@ -131,7 +131,7 @@ export interface PolicyGroupArgs {
     /**
      * List of policy packs applied to this policy group.
      */
-    policyPacks?: pulumi.Input<pulumi.Input<inputs.PolicyGroupPolicyPackReferenceArgs>[]>;
+    policyPacks?: pulumi.Input<pulumi.Input<inputs.PolicyGroupPolicyPackReferenceInputArgs>[]>;
     /**
      * List of stack references that belong to this policy group.
      */

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -395,9 +395,9 @@ export interface OperationContextOptionsArgs {
 }
 
 /**
- * A reference to a policy pack within a policy group.
+ * A reference to a policy pack within a policy group (input).
  */
-export interface PolicyGroupPolicyPackReferenceArgs {
+export interface PolicyGroupPolicyPackReferenceInputArgs {
     /**
      * Optional configuration for the policy pack.
      */
@@ -410,10 +410,6 @@ export interface PolicyGroupPolicyPackReferenceArgs {
      * The name of the policy pack.
      */
     name: pulumi.Input<string>;
-    /**
-     * The version of the policy pack.
-     */
-    version?: pulumi.Input<number>;
     /**
      * The version tag of the policy pack.
      */

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -459,7 +459,7 @@ export interface PolicyGroupPolicyPackReference {
      */
     name: string;
     /**
-     * The version of the policy pack.
+     * The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
      */
     version?: number;
     /**

--- a/sdk/python/pulumi_pulumiservice/_inputs.py
+++ b/sdk/python/pulumi_pulumiservice/_inputs.py
@@ -54,8 +54,8 @@ __all__ = [
     'OperationContextOIDCArgsDict',
     'OperationContextOptionsArgs',
     'OperationContextOptionsArgsDict',
-    'PolicyGroupPolicyPackReferenceArgs',
-    'PolicyGroupPolicyPackReferenceArgsDict',
+    'PolicyGroupPolicyPackReferenceInputArgs',
+    'PolicyGroupPolicyPackReferenceInputArgsDict',
     'PolicyGroupStackReferenceArgs',
     'PolicyGroupStackReferenceArgsDict',
     'TemplateSourceDestinationArgs',
@@ -1663,9 +1663,9 @@ class OperationContextOptionsArgs:
 
 
 if not MYPY:
-    class PolicyGroupPolicyPackReferenceArgsDict(TypedDict):
+    class PolicyGroupPolicyPackReferenceInputArgsDict(TypedDict):
         """
-        A reference to a policy pack within a policy group.
+        A reference to a policy pack within a policy group (input).
         """
         name: pulumi.Input[_builtins.str]
         """
@@ -1679,31 +1679,25 @@ if not MYPY:
         """
         The display name of the policy pack.
         """
-        version: NotRequired[pulumi.Input[_builtins.float]]
-        """
-        The version of the policy pack.
-        """
         version_tag: NotRequired[pulumi.Input[_builtins.str]]
         """
         The version tag of the policy pack.
         """
 elif False:
-    PolicyGroupPolicyPackReferenceArgsDict: TypeAlias = Mapping[str, Any]
+    PolicyGroupPolicyPackReferenceInputArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
-class PolicyGroupPolicyPackReferenceArgs:
+class PolicyGroupPolicyPackReferenceInputArgs:
     def __init__(__self__, *,
                  name: pulumi.Input[_builtins.str],
                  config: Optional[pulumi.Input[Mapping[str, Any]]] = None,
                  display_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 version: Optional[pulumi.Input[_builtins.float]] = None,
                  version_tag: Optional[pulumi.Input[_builtins.str]] = None):
         """
-        A reference to a policy pack within a policy group.
+        A reference to a policy pack within a policy group (input).
         :param pulumi.Input[_builtins.str] name: The name of the policy pack.
         :param pulumi.Input[Mapping[str, Any]] config: Optional configuration for the policy pack.
         :param pulumi.Input[_builtins.str] display_name: The display name of the policy pack.
-        :param pulumi.Input[_builtins.float] version: The version of the policy pack.
         :param pulumi.Input[_builtins.str] version_tag: The version tag of the policy pack.
         """
         pulumi.set(__self__, "name", name)
@@ -1711,8 +1705,6 @@ class PolicyGroupPolicyPackReferenceArgs:
             pulumi.set(__self__, "config", config)
         if display_name is not None:
             pulumi.set(__self__, "display_name", display_name)
-        if version is not None:
-            pulumi.set(__self__, "version", version)
         if version_tag is not None:
             pulumi.set(__self__, "version_tag", version_tag)
 
@@ -1751,18 +1743,6 @@ class PolicyGroupPolicyPackReferenceArgs:
     @display_name.setter
     def display_name(self, value: Optional[pulumi.Input[_builtins.str]]):
         pulumi.set(self, "display_name", value)
-
-    @_builtins.property
-    @pulumi.getter
-    def version(self) -> Optional[pulumi.Input[_builtins.float]]:
-        """
-        The version of the policy pack.
-        """
-        return pulumi.get(self, "version")
-
-    @version.setter
-    def version(self, value: Optional[pulumi.Input[_builtins.float]]):
-        pulumi.set(self, "version", value)
 
     @_builtins.property
     @pulumi.getter(name="versionTag")

--- a/sdk/python/pulumi_pulumiservice/outputs.py
+++ b/sdk/python/pulumi_pulumiservice/outputs.py
@@ -1446,7 +1446,7 @@ class PolicyGroupPolicyPackReference(dict):
         :param _builtins.str name: The name of the policy pack.
         :param Mapping[str, Any] config: Optional configuration for the policy pack.
         :param _builtins.str display_name: The display name of the policy pack.
-        :param _builtins.float version: The version of the policy pack.
+        :param _builtins.float version: The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
         :param _builtins.str version_tag: The version tag of the policy pack.
         """
         pulumi.set(__self__, "name", name)
@@ -1487,7 +1487,7 @@ class PolicyGroupPolicyPackReference(dict):
     @pulumi.getter
     def version(self) -> Optional[_builtins.float]:
         """
-        The version of the policy pack.
+        The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
         """
         return pulumi.get(self, "version")
 

--- a/sdk/python/pulumi_pulumiservice/policy_group.py
+++ b/sdk/python/pulumi_pulumiservice/policy_group.py
@@ -26,7 +26,7 @@ class PolicyGroupArgs:
                  accounts: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  entity_type: Optional[pulumi.Input[_builtins.str]] = None,
                  mode: Optional[pulumi.Input[_builtins.str]] = None,
-                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceArgs']]]] = None,
+                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceInputArgs']]]] = None,
                  stacks: Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupStackReferenceArgs']]]] = None):
         """
         The set of arguments for constructing a PolicyGroup resource.
@@ -35,7 +35,7 @@ class PolicyGroupArgs:
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] accounts: List of accounts that belong to this policy group.
         :param pulumi.Input[_builtins.str] entity_type: The entity type for the policy group. Valid values are 'stacks' or 'accounts'. Defaults to 'stacks'.
         :param pulumi.Input[_builtins.str] mode: The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
-        :param pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceArgs']]] policy_packs: List of policy packs applied to this policy group.
+        :param pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceInputArgs']]] policy_packs: List of policy packs applied to this policy group.
         :param pulumi.Input[Sequence[pulumi.Input['PolicyGroupStackReferenceArgs']]] stacks: List of stack references that belong to this policy group.
         """
         pulumi.set(__self__, "name", name)
@@ -117,14 +117,14 @@ class PolicyGroupArgs:
 
     @_builtins.property
     @pulumi.getter(name="policyPacks")
-    def policy_packs(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceArgs']]]]:
+    def policy_packs(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceInputArgs']]]]:
         """
         List of policy packs applied to this policy group.
         """
         return pulumi.get(self, "policy_packs")
 
     @policy_packs.setter
-    def policy_packs(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceArgs']]]]):
+    def policy_packs(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PolicyGroupPolicyPackReferenceInputArgs']]]]):
         pulumi.set(self, "policy_packs", value)
 
     @_builtins.property
@@ -151,7 +151,7 @@ class PolicyGroup(pulumi.CustomResource):
                  mode: Optional[pulumi.Input[_builtins.str]] = None,
                  name: Optional[pulumi.Input[_builtins.str]] = None,
                  organization_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceArgs', 'PolicyGroupPolicyPackReferenceArgsDict']]]]] = None,
+                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceInputArgs', 'PolicyGroupPolicyPackReferenceInputArgsDict']]]]] = None,
                  stacks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupStackReferenceArgs', 'PolicyGroupStackReferenceArgsDict']]]]] = None,
                  __props__=None):
         """
@@ -164,7 +164,7 @@ class PolicyGroup(pulumi.CustomResource):
         :param pulumi.Input[_builtins.str] mode: The mode for the policy group. Valid values are 'audit' (reports violations) or 'preventative' (blocks operations). Defaults to 'audit'.
         :param pulumi.Input[_builtins.str] name: The name of the policy group.
         :param pulumi.Input[_builtins.str] organization_name: The name of the Pulumi organization the policy group belongs to.
-        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceArgs', 'PolicyGroupPolicyPackReferenceArgsDict']]]] policy_packs: List of policy packs applied to this policy group.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceInputArgs', 'PolicyGroupPolicyPackReferenceInputArgsDict']]]] policy_packs: List of policy packs applied to this policy group.
         :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupStackReferenceArgs', 'PolicyGroupStackReferenceArgsDict']]]] stacks: List of stack references that belong to this policy group.
         """
         ...
@@ -196,7 +196,7 @@ class PolicyGroup(pulumi.CustomResource):
                  mode: Optional[pulumi.Input[_builtins.str]] = None,
                  name: Optional[pulumi.Input[_builtins.str]] = None,
                  organization_name: Optional[pulumi.Input[_builtins.str]] = None,
-                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceArgs', 'PolicyGroupPolicyPackReferenceArgsDict']]]]] = None,
+                 policy_packs: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupPolicyPackReferenceInputArgs', 'PolicyGroupPolicyPackReferenceInputArgsDict']]]]] = None,
                  stacks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyGroupStackReferenceArgs', 'PolicyGroupStackReferenceArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)


### PR DESCRIPTION
## Summary
- Split `PolicyGroupPolicyPackReference` into an input type (no `version`) and output type (keeps `version`), making the server-derived numeric `version` output-only.
- `Check()` strips `version` from legacy inputs so existing stacks upgrade cleanly without spurious diffs.
- Pack identity comparisons (`containsPolicyPack`, `comparePolicyPacks`, `policyPacksEq`) switch from `Name+Version` to `Name+VersionTag`, which is user-controlled.

Fixes #737. Supersedes the non-breaking workaround that was tracked in #727.

## Test plan
- [x] `go test -short ./...` in `provider/pkg` passes, including new `TestPolicyGroup_Check_StripsPolicyPackVersion`
- [x] `make lint` passes
- [x] `make provider && make build_sdks` regenerates all SDKs cleanly
- [ ] `cd examples && go test -v -run TestYamlPolicyGroups -tags yaml -timeout 10m` (CI)
- [ ] Manual upgrade check: existing stack with `version` in state, program without `version` → no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)