### PR TITLE
Document `all` enforcement-level wildcard on PolicyGroupPolicyPackReference.config

### DIFF
--- a/examples/yaml-policy-groups/Pulumi.yaml
+++ b/examples/yaml-policy-groups/Pulumi.yaml
@@ -47,6 +47,11 @@ resources:
           displayName: ""
           versionTag: 2.4.1
           config:
+            # Default every policy in the pack to `mandatory`.
+            # Per-policy entries below override individual properties while
+            # inheriting the enforcement level set here.
+            all:
+              enforcementLevel: mandatory
             hardened-os-image:
               approvedAmiIds:
                 - ami-0abcdef1234567890

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -728,7 +728,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Optional configuration for the policy pack."
+          "description": "Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it."
         },
         "displayName": {
           "type": "string",

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -696,7 +696,7 @@
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"
           },
-          "description": "Optional configuration for the policy pack."
+          "description": "Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it."
         },
         "displayName": {
           "type": "string",

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -883,7 +883,7 @@
           "type": "string"
         },
         "config": {
-          "description": "Optional configuration for the policy pack.",
+          "description": "Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.",
           "type": "object",
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -855,7 +855,7 @@
           "type": "string"
         },
         "config": {
-          "description": "Optional configuration for the policy pack.",
+          "description": "Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.",
           "type": "object",
           "additionalProperties": {
             "$ref": "pulumi.json#/Any"

--- a/sdk/dotnet/Inputs/PolicyGroupPolicyPackReferenceInputArgs.cs
+++ b/sdk/dotnet/Inputs/PolicyGroupPolicyPackReferenceInputArgs.cs
@@ -19,7 +19,7 @@ namespace Pulumi.PulumiService.Inputs
         private InputMap<object>? _config;
 
         /// <summary>
-        /// Optional configuration for the policy pack.
+        /// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         /// </summary>
         public InputMap<object> Config
         {

--- a/sdk/dotnet/Outputs/PolicyGroupPolicyPackReference.cs
+++ b/sdk/dotnet/Outputs/PolicyGroupPolicyPackReference.cs
@@ -17,7 +17,7 @@ namespace Pulumi.PulumiService.Outputs
     public sealed class PolicyGroupPolicyPackReference
     {
         /// <summary>
-        /// Optional configuration for the policy pack.
+        /// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         /// </summary>
         public readonly ImmutableDictionary<string, object>? Config;
         /// <summary>

--- a/sdk/go/pulumiservice/pulumiTypes.go
+++ b/sdk/go/pulumiservice/pulumiTypes.go
@@ -3392,7 +3392,7 @@ func (o OperationContextOptionsPtrOutput) SkipIntermediateDeployments() pulumi.B
 
 // A reference to a policy pack within a policy group.
 type PolicyGroupPolicyPackReference struct {
-	// Optional configuration for the policy pack.
+	// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
 	Config map[string]interface{} `pulumi:"config"`
 	// The display name of the policy pack.
 	DisplayName *string `pulumi:"displayName"`
@@ -3419,7 +3419,7 @@ func (o PolicyGroupPolicyPackReferenceOutput) ToPolicyGroupPolicyPackReferenceOu
 	return o
 }
 
-// Optional configuration for the policy pack.
+// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
 func (o PolicyGroupPolicyPackReferenceOutput) Config() pulumi.MapOutput {
 	return o.ApplyT(func(v PolicyGroupPolicyPackReference) map[string]interface{} { return v.Config }).(pulumi.MapOutput)
 }
@@ -3466,7 +3466,7 @@ func (o PolicyGroupPolicyPackReferenceArrayOutput) Index(i pulumi.IntInput) Poli
 
 // A reference to a policy pack within a policy group (input).
 type PolicyGroupPolicyPackReferenceInputType struct {
-	// Optional configuration for the policy pack.
+	// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
 	Config map[string]interface{} `pulumi:"config"`
 	// The display name of the policy pack.
 	DisplayName *string `pulumi:"displayName"`
@@ -3489,7 +3489,7 @@ type PolicyGroupPolicyPackReferenceInputTypeInput interface {
 
 // A reference to a policy pack within a policy group (input).
 type PolicyGroupPolicyPackReferenceInputTypeArgs struct {
-	// Optional configuration for the policy pack.
+	// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
 	Config pulumi.MapInput `pulumi:"config"`
 	// The display name of the policy pack.
 	DisplayName pulumi.StringPtrInput `pulumi:"displayName"`
@@ -3551,7 +3551,7 @@ func (o PolicyGroupPolicyPackReferenceInputTypeOutput) ToPolicyGroupPolicyPackRe
 	return o
 }
 
-// Optional configuration for the policy pack.
+// Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
 func (o PolicyGroupPolicyPackReferenceInputTypeOutput) Config() pulumi.MapOutput {
 	return o.ApplyT(func(v PolicyGroupPolicyPackReferenceInputType) map[string]interface{} { return v.Config }).(pulumi.MapOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/PolicyGroupPolicyPackReferenceInputArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/inputs/PolicyGroupPolicyPackReferenceInputArgs.java
@@ -23,14 +23,14 @@ public final class PolicyGroupPolicyPackReferenceInputArgs extends com.pulumi.re
     public static final PolicyGroupPolicyPackReferenceInputArgs Empty = new PolicyGroupPolicyPackReferenceInputArgs();
 
     /**
-     * Optional configuration for the policy pack.
+     * Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      * 
      */
     @Import(name="config")
     private @Nullable Output<Map<String,Object>> config;
 
     /**
-     * @return Optional configuration for the policy pack.
+     * @return Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      * 
      */
     public Optional<Output<Map<String,Object>>> config() {
@@ -110,7 +110,7 @@ public final class PolicyGroupPolicyPackReferenceInputArgs extends com.pulumi.re
         }
 
         /**
-         * @param config Optional configuration for the policy pack.
+         * @param config Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
          * 
          * @return builder
          * 
@@ -121,7 +121,7 @@ public final class PolicyGroupPolicyPackReferenceInputArgs extends com.pulumi.re
         }
 
         /**
-         * @param config Optional configuration for the policy pack.
+         * @param config Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/outputs/PolicyGroupPolicyPackReference.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/outputs/PolicyGroupPolicyPackReference.java
@@ -16,7 +16,7 @@ import javax.annotation.Nullable;
 @CustomType
 public final class PolicyGroupPolicyPackReference {
     /**
-     * @return Optional configuration for the policy pack.
+     * @return Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      * 
      */
     private @Nullable Map<String,Object> config;
@@ -43,7 +43,7 @@ public final class PolicyGroupPolicyPackReference {
 
     private PolicyGroupPolicyPackReference() {}
     /**
-     * @return Optional configuration for the policy pack.
+     * @return Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      * 
      */
     public Map<String,Object> config() {

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -399,7 +399,7 @@ export interface OperationContextOptionsArgs {
  */
 export interface PolicyGroupPolicyPackReferenceInputArgs {
     /**
-     * Optional configuration for the policy pack.
+     * Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      */
     config?: pulumi.Input<{[key: string]: any}>;
     /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -447,7 +447,7 @@ export interface OperationContextOptions {
  */
 export interface PolicyGroupPolicyPackReference {
     /**
-     * Optional configuration for the policy pack.
+     * Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
      */
     config?: {[key: string]: any};
     /**

--- a/sdk/python/pulumi_pulumiservice/_inputs.py
+++ b/sdk/python/pulumi_pulumiservice/_inputs.py
@@ -1673,7 +1673,7 @@ if not MYPY:
         """
         config: NotRequired[pulumi.Input[Mapping[str, Any]]]
         """
-        Optional configuration for the policy pack.
+        Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         """
         display_name: NotRequired[pulumi.Input[_builtins.str]]
         """
@@ -1696,7 +1696,7 @@ class PolicyGroupPolicyPackReferenceInputArgs:
         """
         A reference to a policy pack within a policy group (input).
         :param pulumi.Input[_builtins.str] name: The name of the policy pack.
-        :param pulumi.Input[Mapping[str, Any]] config: Optional configuration for the policy pack.
+        :param pulumi.Input[Mapping[str, Any]] config: Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         :param pulumi.Input[_builtins.str] display_name: The display name of the policy pack.
         :param pulumi.Input[_builtins.str] version_tag: The version tag of the policy pack.
         """
@@ -1724,7 +1724,7 @@ class PolicyGroupPolicyPackReferenceInputArgs:
     @pulumi.getter
     def config(self) -> Optional[pulumi.Input[Mapping[str, Any]]]:
         """
-        Optional configuration for the policy pack.
+        Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         """
         return pulumi.get(self, "config")
 

--- a/sdk/python/pulumi_pulumiservice/outputs.py
+++ b/sdk/python/pulumi_pulumiservice/outputs.py
@@ -1444,7 +1444,7 @@ class PolicyGroupPolicyPackReference(dict):
         """
         A reference to a policy pack within a policy group.
         :param _builtins.str name: The name of the policy pack.
-        :param Mapping[str, Any] config: Optional configuration for the policy pack.
+        :param Mapping[str, Any] config: Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         :param _builtins.str display_name: The display name of the policy pack.
         :param _builtins.float version: The server-derived numeric version of the policy pack. This is output-only; use `versionTag` to pin a specific version.
         :param _builtins.str version_tag: The version tag of the policy pack.
@@ -1471,7 +1471,7 @@ class PolicyGroupPolicyPackReference(dict):
     @pulumi.getter
     def config(self) -> Optional[Mapping[str, Any]]:
         """
-        Optional configuration for the policy pack.
+        Optional configuration for the policy pack. The special key `all` sets the default enforcement level for every policy in the pack; per-policy entries override it.
         """
         return pulumi.get(self, "config")
 


### PR DESCRIPTION
## Summary

- Documents the Pulumi policy engine's `all` wildcard key on `PolicyGroupPolicyPackReference.config` — it sets the default enforcement level for every policy in the pack, and per-policy entries override it.
- Demonstrates the `all` + per-policy override pattern in the existing `yaml-policy-groups` example so users have a working reference for the HITRUST-style use case (blanket `mandatory` with per-policy property tuning).
- Regenerates all five language SDKs to propagate the new description into docstrings / IDE hover / registry docs.

No provider behavior change — PSP already passed `config` through verbatim; the wildcard is implemented in `pulumi/pulumi` at `pkg/resource/analyzer/config.go:302-313`. This change just surfaces the convention to users.

Follow-up for a typed `defaultEnforcementLevel` field tracked in #755.

## Test plan

- [x] `make provider_no_deps` + `make schema` — schema regenerates with new description.
- [x] `make generate_{nodejs,python,go,java,dotnet}` — all five SDKs pick up the description (verified via `grep "sets the default enforcement level" sdk/`).
- [x] `TestYamlPolicyGroupsExample` preview — provider correctly plumbs `config.all.enforcementLevel: mandatory` into the service call (verified locally up to the unrelated `getPolicyPacks` data source call which needs `service-provider-test-org` access).
- [ ] Full integration test roundtrip in CI against `service-provider-test-org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)