### PR TITLE
Fix TeamEnvironmentPermission replacement on upgrade from 0.29.3-0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed TeamEnvironmentPermission refresh returning wrong permission when the same environment name exists in multiple projects [#674](https://github.com/pulumi/pulumi-pulumiservice/issues/674)
 - Fixed TeamEnvironmentPermission spurious replacement on upgrade from 0.29.2 caused by the optional `maxOpenDuration` field being serialized as an empty string in Check and Read [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
 - Fixed TeamEnvironmentPermission panic when `maxOpenDuration` was supplied as a non-string value; `Check` now returns a `CheckFailure` at preview instead of crashing during apply [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
+- Fixed TeamEnvironmentPermission spurious replacement for users upgrading from provider versions 0.29.3–0.36.0 whose state contains an empty-string `maxOpenDuration`; `Diff` now treats an empty-string `maxOpenDuration` as equivalent to an absent field [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
 
 ## 0.35.0
 

--- a/provider/pkg/resources/team_environment_perm.go
+++ b/provider/pkg/resources/team_environment_perm.go
@@ -223,9 +223,33 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Delete(req *pulumirpc.
 func (tp *PulumiServiceTeamEnvironmentPermissionResource) Diff(
 	req *pulumirpc.DiffRequest,
 ) (*pulumirpc.DiffResponse, error) {
-	changedKeys, err := util.DiffOldsAndNews(req)
+	olds, err := plugin.UnmarshalProperties(
+		req.GetOldInputs(),
+		plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true},
+	)
 	if err != nil {
 		return nil, err
+	}
+	news, err := plugin.UnmarshalProperties(
+		req.GetNews(),
+		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: false},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Provider versions 0.29.3–0.36.0 wrote `maxOpenDuration: ""` into state
+	// whenever the user did not set the field. #752 fixed the Check/Read
+	// paths, but state saved by those versions still carries the empty
+	// string. Without this normalization, the first preview after upgrading
+	// from that window would observe the key as deleted and force one more
+	// spurious replacement — the exact failure mode #751 set out to remove.
+	normalizeEmptyMaxOpenDuration(olds)
+	normalizeEmptyMaxOpenDuration(news)
+
+	var changedKeys []string
+	for _, k := range olds.Diff(news).ChangedKeys() {
+		changedKeys = append(changedKeys, string(k))
 	}
 
 	changes := pulumirpc.DiffResponse_DIFF_NONE
@@ -237,6 +261,14 @@ func (tp *PulumiServiceTeamEnvironmentPermissionResource) Diff(
 		Replaces:            changedKeys,
 		DeleteBeforeReplace: true,
 	}, nil
+}
+
+// normalizeEmptyMaxOpenDuration removes a zero-value `maxOpenDuration` so it
+// compares equal to an absent field. See Diff() for the history.
+func normalizeEmptyMaxOpenDuration(m resource.PropertyMap) {
+	if v, ok := m["maxOpenDuration"]; ok && v.IsString() && v.StringValue() == "" {
+		delete(m, "maxOpenDuration")
+	}
 }
 
 // Update does nothing because we always replace on changes, never an update

--- a/provider/pkg/resources/team_environment_perm_test.go
+++ b/provider/pkg/resources/team_environment_perm_test.go
@@ -255,6 +255,82 @@ func TestTeamEnvironmentPermission_Diff_UpgradeFromPreMaxOpenDuration(t *testing
 	assert.Empty(t, diffResp.Replaces, "maxOpenDuration should not drive a spurious replacement on upgrade")
 }
 
+func TestTeamEnvironmentPermission_Diff_UpgradeFromEmptyStringMaxOpenDuration(t *testing.T) {
+	// Regression for the residual 0.29.3–0.36.0 upgrade path that #752 did
+	// not cover: those provider versions wrote `maxOpenDuration: ""` into
+	// state whenever the user did not set the field. After #752, Check no
+	// longer emits the empty string, but state written by the old versions
+	// still carries it. Without Diff-side normalization, the first preview
+	// after upgrading would see the key as deleted and force one more
+	// spurious replacement.
+	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
+
+	// State on disk from a buggy 0.29.3–0.36.0 run: contains the empty string.
+	oldInputs := resource.PropertyMap{
+		"organization":    resource.NewStringProperty("org"),
+		"team":            resource.NewStringProperty("team"),
+		"project":         resource.NewStringProperty("proj"),
+		"environment":     resource.NewStringProperty("env"),
+		"permission":      resource.NewStringProperty("open"),
+		"maxOpenDuration": resource.NewStringProperty(""),
+	}
+
+	// User program (unchanged): never sets maxOpenDuration.
+	news := resource.PropertyMap{
+		"organization": resource.NewStringProperty("org"),
+		"team":         resource.NewStringProperty("team"),
+		"project":      resource.NewStringProperty("proj"),
+		"environment":  resource.NewStringProperty("env"),
+		"permission":   resource.NewStringProperty("open"),
+	}
+
+	checkResp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
+	require.NoError(t, err)
+	require.Empty(t, checkResp.Failures)
+
+	diffResp, err := r.Diff(&pulumirpc.DiffRequest{
+		OldInputs: toStruct(t, oldInputs),
+		News:      checkResp.Inputs,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pulumirpc.DiffResponse_DIFF_NONE, diffResp.Changes)
+	assert.Empty(
+		t, diffResp.Replaces,
+		"an empty-string maxOpenDuration in old state must compare equal to an absent field",
+	)
+}
+
+func TestTeamEnvironmentPermission_Diff_DetectsRealMaxOpenDurationChange(t *testing.T) {
+	// Guard against over-aggressive normalization: a real value change must
+	// still be reported as a change (and, for this resource, a replace).
+	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
+
+	oldInputs := resource.PropertyMap{
+		"organization":    resource.NewStringProperty("org"),
+		"team":            resource.NewStringProperty("team"),
+		"project":         resource.NewStringProperty("proj"),
+		"environment":     resource.NewStringProperty("env"),
+		"permission":      resource.NewStringProperty("open"),
+		"maxOpenDuration": resource.NewStringProperty("30m0s"),
+	}
+	news := resource.PropertyMap{
+		"organization":    resource.NewStringProperty("org"),
+		"team":            resource.NewStringProperty("team"),
+		"project":         resource.NewStringProperty("proj"),
+		"environment":     resource.NewStringProperty("env"),
+		"permission":      resource.NewStringProperty("open"),
+		"maxOpenDuration": resource.NewStringProperty("1h0m0s"),
+	}
+
+	diffResp, err := r.Diff(&pulumirpc.DiffRequest{
+		OldInputs: toStruct(t, oldInputs),
+		News:      toStruct(t, news),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pulumirpc.DiffResponse_DIFF_SOME, diffResp.Changes)
+	assert.Contains(t, diffResp.Replaces, "maxOpenDuration")
+}
+
 func TestTeamEnvironmentPermission_Read_OmitsMaxOpenDurationWhenUnset(t *testing.T) {
 	// When the Pulumi Cloud API does not return a maxOpenDuration for the
 	// environment, Read must not bake an empty string into state. Otherwise


### PR DESCRIPTION
## Summary

Follow-up to #752 that closes a residual upgrade path the merged fix did not cover.

#752 fixed `Check()` and `Read()` so they no longer emit `maxOpenDuration: \"\"` when the user did not set the field. However, users who ran provider versions **0.29.3 through 0.36.0** already have state on disk with `maxOpenDuration: \"\"` baked into the resource's `OldInputs` — written there by the buggy `Check` path before the fix. On the first preview after upgrading to the post-#752 provider:

- the user's program (unchanged) still does not set `maxOpenDuration`,
- the new `Check()` correctly produces inputs **without** the key,
- `Diff()` compares `OldInputs` (has `maxOpenDuration: \"\"`) against `News` (no key) and reports the key as deleted,
- `changedKeys` is passed verbatim into `Replaces`, so the resource is force-replaced once more.

That's the exact failure mode #751 set out to eliminate, just on a slightly different upgrade path (0.29.3–0.36.0 → 0.37.0) than the one covered by the regression test in #752 (pre-0.29.3 → 0.29.3+).

## Fix

Normalize an empty-string `maxOpenDuration` to absent on **both sides** of the Diff comparison. Since the resource's semantics have always treated `\"\"` and unset as the same thing — `Create()` was already sending `nil` to the API for `\"\"` — making them compare equal in Diff is consistent and non-breaking. State converges to the clean representation on the next successful create/refresh without any user action.

```go
// team_environment_perm.go, Diff()
normalizeEmptyMaxOpenDuration(olds)
normalizeEmptyMaxOpenDuration(news)
```

### Why Diff and not Check

An alternative would be re-emitting `\"\"` in `Check()` when old state had it, to keep state bit-identical. That was rejected because:

1. It would require reading `req.GetOlds()` in Check, which this resource does not currently do.
2. It would preserve the bad `\"\"` in state forever, defeating the point of the #752 cleanup.
3. Making Check's output depend on state history is harder to reason about than a localized Diff-time normalization.

## Tests

Two new unit tests in `provider/pkg/resources/team_environment_perm_test.go`:

- **`TestTeamEnvironmentPermission_Diff_UpgradeFromEmptyStringMaxOpenDuration`** — mirrors the existing `TestTeamEnvironmentPermission_Diff_UpgradeFromPreMaxOpenDuration` regression test but with `OldInputs` containing `maxOpenDuration: \"\"` (the 0.29.3–0.36.0 shape). Asserts `DIFF_NONE` and no `Replaces`.
- **`TestTeamEnvironmentPermission_Diff_DetectsRealMaxOpenDurationChange`** — guards against over-aggressive normalization. A real value change (`30m0s` → `1h0m0s`) must still surface as a change **and** appear in `Replaces`, since this resource replaces on any change.

All existing tests from #752 continue to pass.

## Test plan

- [x] `go test -short -run TeamEnvironmentPermission ./provider/pkg/resources/...` — all 10 cases pass locally
- [x] CI integration tests (`TestYamlTeamEnvironmentPermissionExample`, etc.)
- [ ] Manual validation against a stack created on 0.29.3–0.36.0 without `maxOpenDuration` set:
  - `pulumi preview` on the upgraded provider should show no changes (previously: `+-TeamEnvironmentPermission` replace with `+ maxOpenDuration: \"\"`)

## Related

- Issue: #751
- Previous fix: #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)