### PR TITLE
Update CHANGELOG for 0.36.0 and upcoming release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@
 
 ### Improvements
 - Added `StackTags` resource for managing multiple stack tags as a single resource, with a `tags` map input. [#61](https://github.com/pulumi/pulumi-pulumiservice/issues/61)
+- Added `TwelveHours` (12h) scan schedule option for `InsightsAccount` resources. [#731](https://github.com/pulumi/pulumi-pulumiservice/pull/731)
+- Documented the `all` enforcement-level wildcard on `PolicyGroupPolicyPackReference.config`, enabling a single entry to set the enforcement level for every policy in a pack with optional per-policy overrides. [#756](https://github.com/pulumi/pulumi-pulumiservice/pull/756)
 
 ### Bug Fixes
-- Fixed TeamEnvironmentPermission refresh returning wrong permission when the same environment name exists in multiple projects [#674](https://github.com/pulumi/pulumi-pulumiservice/issues/674)
 - Fixed TeamEnvironmentPermission spurious replacement on upgrade from 0.29.2 caused by the optional `maxOpenDuration` field being serialized as an empty string in Check and Read [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
 - Fixed TeamEnvironmentPermission panic when `maxOpenDuration` was supplied as a non-string value; `Check` now returns a `CheckFailure` at preview instead of crashing during apply [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
 - Fixed TeamEnvironmentPermission spurious replacement for users upgrading from provider versions 0.29.3–0.36.0 whose state contains an empty-string `maxOpenDuration`; `Diff` now treats an empty-string `maxOpenDuration` as equivalent to an absent field [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)
+
+## 0.36.0
+
+### Bug Fixes
+- Fixed TeamEnvironmentPermission refresh returning wrong permission when the same environment name exists in multiple projects [#674](https://github.com/pulumi/pulumi-pulumiservice/issues/674)
 
 ## 0.35.0
 


### PR DESCRIPTION
## Summary
- Add a `## 0.36.0` section and move the #674 TeamEnvironmentPermission refresh fix into it — it shipped in 0.36.0 but was never moved out of `Unreleased`.
- Add two post-0.36.0 improvements that were missing from `Unreleased`:
  - `TwelveHours` scan schedule for `InsightsAccount` (#731)
  - Documented `all` enforcement-level wildcard on `PolicyGroupPolicyPackReference.config` (#756)

Prep so the next release can be scheduled with an accurate CHANGELOG.

## Test plan
- [x] Verified every commit on `main` since `v0.36.0` is either user-facing and represented in `Unreleased`, or excluded per CLAUDE.md rules (test/CI/tooling-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)