### PR TITLE
Collect integration-test coverage and upload to Codecov

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -17,6 +17,7 @@ env:
   PULUMI_TEST_USE_SERVICE: true
 providerDefaultBranch: main
 template: generic
+integrationTestCoverage: true
 shards: 6
 esc:
     enabled: true

--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -9,6 +9,13 @@ on:
         required: true
         type: string
         description: Version of the provider to build
+      cover:
+        required: false
+        type: boolean
+        default: false
+        description: Build the provider with `-cover` so it emits runtime
+          coverage data files at exit. Used by the SDK integration test
+          workflow when `integrationTestCoverage` is enabled.
       matrix:
         required: false
         type: string
@@ -104,6 +111,7 @@ jobs:
       - name: Build provider
         run: make "provider-${{ matrix.platform.os }}-${{ matrix.platform.arch }}"
         env:
+          PROVIDER_BUILD_FLAGS: ${{ inputs.cover && '-cover -covermode=atomic' || '' }}
           AZURE_SIGNING_CLIENT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_ID }}
           AZURE_SIGNING_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_CLIENT_SECRET }}
           AZURE_SIGNING_TENANT_ID: ${{ steps.esc-secrets.outputs.AZURE_SIGNING_TENANT_ID }}

--- a/.github/workflows/build_provider.yml
+++ b/.github/workflows/build_provider.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           tag: v2.1.5-procursus2
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:

--- a/.github/workflows/build_sdk.yml
+++ b/.github/workflows/build_sdk.yml
@@ -67,7 +67,7 @@ jobs:
             .pulumi/examples-cache
           key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,7 +56,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
@@ -79,7 +79,7 @@ jobs:
           (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude review')) ||
           (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude review'))
         id: claude-review
-        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           anthropic_api_key: ${{ steps.esc-secrets.outputs.ANTHROPIC_API_KEY }}
           prompt: |
@@ -101,7 +101,7 @@ jobs:
           !contains(github.event.comment.body, '@claude review') &&
           !contains(github.event.review.body, '@claude review')
         id: claude-action
-        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1
+        uses: anthropics/claude-code-action@567fe954a4527e81f132d87d1bdbcc94f7737434 # v1
         with:
           anthropic_api_key: ${{ steps.esc-secrets.outputs.ANTHROPIC_API_KEY }}
           # This allows claude to read github action logs

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -47,7 +47,7 @@ jobs:
           private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:

--- a/.github/workflows/prerequisites.yml
+++ b/.github/workflows/prerequisites.yml
@@ -73,7 +73,7 @@ jobs:
           .pulumi/examples-cache
         key: ${{ runner.os }}-${{ hashFiles('provider/go.sum') }}
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
@@ -97,7 +97,7 @@ jobs:
     - name: Generate schema
       run: make schema
     - name: Build provider binary
-      run: make provider
+      run: make provider_cover
     - name: Unit-test provider code
       run: make test_provider
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
@@ -161,7 +161,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -52,6 +52,7 @@ jobs:
       id-token: write # For ESC secrets.
     with:
       version: ${{ needs.prerequisites.outputs.version }}
+      cover: true
       matrix: |
         {
           "platform": [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         repository: pulumi/examples
         path: p-examples
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
       env:
         MISE_ENV: test
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
@@ -106,6 +106,8 @@ jobs:
         pip3 install pipenv
     - name: Install prebuilt SDKs
       run: make install_sdks
+    - name: Prepare coverage directory
+      run: mkdir -p ${{ github.workspace }}/coverage
     - name: Generate test shards
       run: |-
         cd examples
@@ -119,6 +121,19 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}
+        GOCOVERDIR: ${{ github.workspace }}/coverage
+    - name: Convert coverage data
+      if: always()
+      run: go tool covdata textfmt -i=${{ github.workspace }}/coverage -o
+        ${{ github.workspace }}/coverage-integration.out
+    - name: Upload integration test coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      with:
+        files: ${{ github.workspace }}/coverage-integration.out
+        flags: integration-shard-${{ matrix.current-shard }}
+      env:
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -80,7 +80,7 @@ jobs:
         name: Fetch secrets from ESC
         uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@1c5f70fd400ce6c745085c93ea80026272f8d346
         with:
           version: 2026.3.7
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ lint.fix: upstream
 	exit $$LINT_EXIT
 
 .PHONY: lint lint.fix
-build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+build_provider_cmd = cd provider && GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build $(PULUMI_PROVIDER_BUILD_PARALLELISM) $(PROVIDER_BUILD_FLAGS) -o "$(3)" -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
 
 provider: bin/$(PROVIDER)
 
@@ -295,7 +295,7 @@ upstream: .make/upstream
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@fdf6aa0d472d334cbfe7efb9f770586438bcfce2 generate
+	go run github.com/pulumi/ci-mgmt/provider-ci@54cf635e6f393350b06b7d3ab10ba71dbfa95b4f generate
 .PHONY: ci-mgmt
 
 # Start debug server for tfgen

--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,15 @@ bin/$(PROVIDER):
 	$(call build_provider_cmd,$(shell go env GOOS),$(shell go env GOARCH),$(WORKING_DIR)/bin/$(PROVIDER))
 .PHONY: provider provider_no_deps
 
+# Build a coverage-instrumented provider binary suitable for collecting runtime
+# coverage from the SDK integration tests. The binary is written to the same
+# path as `make provider`. Set `GOCOVERDIR` when running the binary so that the
+# Go runtime writes coverage data files to that directory; convert them to a
+# coverage profile with `go tool covdata textfmt -i=$$GOCOVERDIR -o cover.out`.
+provider_cover:
+	cd provider && GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) CGO_ENABLED=0 go build -cover -covermode=atomic -o $(WORKING_DIR)/bin/$(PROVIDER) -ldflags "$(LDFLAGS)" $(PROJECT)/$(PROVIDER_PATH)/cmd/$(PROVIDER)
+.PHONY: provider_cover
+
 test: export PATH := $(WORKING_DIR)/bin:$(PATH)
 test:
 	cd examples && $(GO_TEST_EXEC) -v -tags=$(TESTTAGS) -parallel $(TESTPARALLELISM) -timeout 2h $(value GOTESTARGS)
@@ -286,7 +295,7 @@ upstream: .make/upstream
 # - Run make ci-mgmt to apply the change locally.
 #
 ci-mgmt: .ci-mgmt.yaml
-	go run github.com/pulumi/ci-mgmt/provider-ci@master generate
+	go run github.com/pulumi/ci-mgmt/provider-ci@fdf6aa0d472d334cbfe7efb9f770586438bcfce2 generate
 .PHONY: ci-mgmt
 
 # Start debug server for tfgen

--- a/provider/cmd/pulumi-resource-pulumiservice/main.go
+++ b/provider/cmd/pulumi-resource-pulumiservice/main.go
@@ -16,6 +16,10 @@ package main
 
 import (
 	_ "embed"
+	"os"
+	"os/signal"
+	"runtime/coverage"
+	"syscall"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -31,11 +35,59 @@ var providerName = "pulumiservice"
 var Version = version.Version
 
 func main() {
+	// When the binary is built with `go build -cover`, the Go runtime only writes
+	// covcounters.* files at clean process exit. The Pulumi engine signals
+	// providers with SIGINT/SIGTERM at deployment teardown, so without this
+	// hook the integration test workflow gets covmeta files but no counters
+	// and `go tool covdata textfmt` produces an empty profile. Calling
+	// flushCoverage on signal lets the counters land before we exit.
+	flushCoverage := installCoverFlushOnSignal()
+
 	// Start gRPC service for the pulumiservice provider
 	err := provider.Main(providerName, func(host *provider.HostClient) (rpc.ResourceProviderServer, error) {
 		return psp.MakeProvider(host, providerName, Version)
 	})
+	flushCoverage()
 	if err != nil {
 		cmdutil.ExitError(err.Error())
 	}
+}
+
+// installCoverFlushOnSignal returns a function that flushes coverage counters
+// (if `GOCOVERDIR` is set) and is also registered to run on SIGINT/SIGTERM.
+// The returned function is idempotent and safe to call from `main` after
+// `provider.Main` returns.
+func installCoverFlushOnSignal() func() {
+	flushed := make(chan struct{})
+	flush := func() {
+		select {
+		case <-flushed:
+			return
+		default:
+			close(flushed)
+		}
+		writeCoverage()
+	}
+
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigs
+		flush()
+		os.Exit(0)
+	}()
+
+	return flush
+}
+
+// writeCoverage flushes coverage counters to GOCOVERDIR. It is a no-op if
+// GOCOVERDIR is unset or the binary was not built with `-cover`.
+func writeCoverage() {
+	dir := os.Getenv("GOCOVERDIR")
+	if dir == "" {
+		return
+	}
+	// Errors here only mean the binary wasn't built with -cover or the dir
+	// doesn't exist; either way there's nothing useful to log to stderr.
+	_ = coverage.WriteCountersDir(dir)
 }


### PR DESCRIPTION
## Summary

- Sets `integrationTestCoverage: true` in `.ci-mgmt.yaml`, opting into [pulumi/ci-mgmt#2181](https://github.com/pulumi/ci-mgmt/pull/2181).
- Regenerated workflows now build the provider with `make provider_cover` (new target shipped by the ci-mgmt PR), set `GOCOVERDIR` on each shard's test step, and after tests run `go tool covdata textfmt` + upload to Codecov under `integration-shard-<n>` flags.
- `make ci-mgmt` is pinned to the ci-mgmt branch tip (commit `fdf6aa0d`) so the regenerated workflows match what's checked in. Once ci-mgmt#2181 merges, revert that pin to `@master`.

## Why

Today's Codecov on this repo only reflects `make test_provider` (Go unit tests). The integration matrix runs the provider binary as a subprocess driven by the Pulumi engine but contributes nothing to coverage. Patches that are exercised end-to-end (most resource CRUD work) show artificially low patch coverage.

Go 1.20+'s `go build -cover` lets us instrument the binary; `GOCOVERDIR` collects per-invocation data which `go tool covdata` merges. ci-mgmt#2181 plumbs this through both the `native` (e.g. pulumi-command) and `generic` (e.g. this repo) workflow trees.

## Caveats

- This PR depends on ci-mgmt#2181 merging. Until then, `make ci-mgmt` is pinned to the branch tip.
- The other workflow file diffs (mise-action SHA bump, etc.) are regenerate noise from running against the pinned ci-mgmt tip rather than `master`. Once the pin is reverted those will collapse.
- Sister PR for the `native` template is [pulumi/pulumi-command#1225](https://github.com/pulumi/pulumi-command/pull/1225) — useful to compare how the same opt-in renders in both template trees.

## Test plan

- [x] `make provider_cover` builds locally.
- [x] `make ci-mgmt` regenerates cleanly against the pinned ci-mgmt commit; actionlint clean (verified via the ci-mgmt repo's `make test-provider/pulumiservice`).
- [ ] Land ci-mgmt#2181, repoint pin to `@master`, regenerate, verify Codecov shows `integration-shard-<n>` flags with non-empty profiles.