### PR TITLE
Migrate `pulumiservice:index:*Token` to `infer`

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -1176,11 +1176,12 @@
   },
   "resources": {
     "pulumiservice:index:AccessToken": {
-      "description": "Access tokens allow a user to authenticate against the Pulumi Cloud",
+      "description": "Access tokens allow a user to authenticate against the Pulumi Cloud.",
       "properties": {
         "description": {
           "type": "string",
-          "description": "Description of the access token."
+          "description": "Description of the access token.",
+          "replaceOnChanges": true
         },
         "value": {
           "type": "string",
@@ -1195,7 +1196,8 @@
       "inputProperties": {
         "description": {
           "type": "string",
-          "description": "Description of the access token."
+          "description": "Description of the access token.",
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -1963,19 +1963,24 @@
       "properties": {
         "admin": {
           "type": "boolean",
-          "description": "Optional. True if this is an admin token."
+          "description": "Optional. True if this is an admin token.",
+          "default": false,
+          "replaceOnChanges": true
         },
         "description": {
           "type": "string",
-          "description": "Optional. Description for the token."
+          "description": "Optional. Description for the token.",
+          "replaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name for the token."
+          "description": "The name for the token.",
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
-          "description": "The organization's name."
+          "description": "The organization's name.",
+          "replaceOnChanges": true
         },
         "value": {
           "type": "string",
@@ -1992,21 +1997,23 @@
         "admin": {
           "type": "boolean",
           "description": "Optional. True if this is an admin token.",
-          "default": false
+          "default": false,
+          "replaceOnChanges": true
         },
         "description": {
           "type": "string",
-          "description": "Optional. Team description."
+          "description": "Optional. Description for the token.",
+          "replaceOnChanges": true
         },
         "name": {
           "type": "string",
           "description": "The name for the token.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
           "description": "The organization's name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -2529,19 +2529,23 @@
       "properties": {
         "description": {
           "type": "string",
-          "description": "Optional. Description for the token."
+          "description": "Optional. Description for the token.",
+          "replaceOnChanges": true
         },
         "name": {
           "type": "string",
-          "description": "The name for the token. This must be unique amongst all machine tokens within your organization."
+          "description": "The name for the token. This must be unique amongst all machine tokens within your organization.",
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
-          "description": "The organization's name."
+          "description": "The organization's name.",
+          "replaceOnChanges": true
         },
         "teamName": {
           "type": "string",
-          "description": "The team name."
+          "description": "The team name.",
+          "replaceOnChanges": true
         },
         "value": {
           "type": "string",
@@ -2551,35 +2555,36 @@
       },
       "required": [
         "name",
-        "teamName",
         "organizationName",
+        "teamName",
         "value"
       ],
       "inputProperties": {
         "description": {
           "type": "string",
-          "description": "Optional. Team description."
+          "description": "Optional. Description for the token.",
+          "replaceOnChanges": true
         },
         "name": {
           "type": "string",
           "description": "The name for the token. This must be unique amongst all machine tokens within your organization.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
           "description": "The organization's name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "teamName": {
           "type": "string",
           "description": "The team name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [
         "name",
-        "teamName",
-        "organizationName"
+        "organizationName",
+        "teamName"
       ]
     },
     "pulumiservice:index:TeamEnvironmentPermission": {

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -54,6 +54,7 @@ type Client interface {
 	pulumiapi.InsightsAccountClient
 	pulumiapi.MemberClient
 	pulumiapi.OidcClient
+	pulumiapi.OrgAccessTokenClient
 	pulumiapi.RoleClient
 	pulumiapi.StackTagClient
 	pulumiapi.TeamAccessTokenClient

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -56,6 +56,7 @@ type Client interface {
 	pulumiapi.OidcClient
 	pulumiapi.RoleClient
 	pulumiapi.StackTagClient
+	pulumiapi.TeamAccessTokenClient
 	pulumiapi.TeamClient
 	pulumiapi.TeamRoleClient
 	pulumiapi.UserClient

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -45,6 +45,7 @@ var (
 //
 // All client interfaces from [pulumiapi] should be added to this interface.
 type Client interface {
+	pulumiapi.AccessTokenClient
 	pulumiapi.AgentPoolClient
 	pulumiapi.ApprovalRuleClient
 	pulumiapi.DeploymentSettingsClient

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -1038,64 +1038,6 @@
         "organizationName"
       ]
     },
-    "pulumiservice:index:TeamAccessToken": {
-      "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",
-      "properties": {
-        "name": {
-          "description": "The name for the token. This must be unique amongst all machine tokens within your organization.",
-          "type": "string"
-        },
-        "teamName": {
-          "description": "The team name.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Optional. Description for the token.",
-          "type": "string"
-        },
-        "organizationName": {
-          "description": "The organization's name.",
-          "type": "string"
-        },
-        "value": {
-          "description": "The token's value.",
-          "type": "string",
-          "secret": true
-        }
-      },
-      "required": [
-        "name",
-        "teamName",
-        "organizationName",
-        "value"
-      ],
-      "inputProperties": {
-        "name": {
-          "description": "The name for the token. This must be unique amongst all machine tokens within your organization.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "teamName": {
-          "description": "The team name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "description": {
-          "description": "Optional. Team description.",
-          "type": "string"
-        },
-        "organizationName": {
-          "description": "The organization's name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        }
-      },
-      "requiredInputs": [
-        "name",
-        "teamName",
-        "organizationName"
-      ]
-    },
     "pulumiservice:index:OrgAccessToken": {
       "description": "The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org",
       "properties": {

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -1038,33 +1038,6 @@
         "organizationName"
       ]
     },
-    "pulumiservice:index:AccessToken": {
-      "description": "Access tokens allow a user to authenticate against the Pulumi Cloud",
-      "properties": {
-        "description": {
-          "description": "Description of the access token.",
-          "type": "string"
-        },
-        "value": {
-          "description": "The token's value.",
-          "type": "string",
-          "secret": true
-        }
-      },
-      "required": [
-        "description",
-        "value"
-      ],
-      "inputProperties": {
-        "description": {
-          "description": "Description of the access token.",
-          "type": "string"
-        }
-      },
-      "requiredInputs": [
-        "description"
-      ]
-    },
     "pulumiservice:index:TeamAccessToken": {
       "description": "The Pulumi Cloud allows users to create access tokens scoped to team. Team access tokens is a resource to create them and assign them to a team",
       "properties": {

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -1038,62 +1038,6 @@
         "organizationName"
       ]
     },
-    "pulumiservice:index:OrgAccessToken": {
-      "description": "The Pulumi Cloud allows users to create access tokens scoped to orgs. Org access tokens is a resource to create them and assign them to an org",
-      "properties": {
-        "name": {
-          "description": "The name for the token.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Optional. Description for the token.",
-          "type": "string"
-        },
-        "organizationName": {
-          "description": "The organization's name.",
-          "type": "string"
-        },
-        "admin": {
-          "description": "Optional. True if this is an admin token.",
-          "type": "boolean"
-        },
-        "value": {
-          "description": "The token's value.",
-          "type": "string",
-          "secret": true
-        }
-      },
-      "required": [
-        "name",
-        "organizationName",
-        "value"
-      ],
-      "inputProperties": {
-        "name": {
-          "description": "The name for the token.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "description": {
-          "description": "Optional. Team description.",
-          "type": "string"
-        },
-        "organizationName": {
-          "description": "The organization's name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "admin": {
-          "description": "Optional. True if this is an admin token.",
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "requiredInputs": [
-        "name",
-        "organizationName"
-      ]
-    },
     "pulumiservice:index:Webhook": {
       "description": "Pulumi Webhooks allow you to notify external services of events happening within your Pulumi organization or stack. For example, you can trigger a notification whenever a stack is updated. Whenever an event occurs, Pulumi will send an HTTP POST request to all registered webhooks. The webhook can then be used to emit some notification, start running integration tests, or even update additional stacks.\n\n### Import\n\nPulumi webhooks can be imported using the `id`, which for webhooks is `{org}/{project}/{stack}/{webhook-name}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:Webhook my_webhook my-org/my-project/my-stack/4b0d0671\n```\n\n",
       "properties": {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -90,6 +90,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			version: version,
 		})).
 		WithResources(
+			infer.Resource(&resources.AccessToken{}),
 			infer.Resource(&resources.InsightsAccount{}),
 			infer.Resource(&resources.OrganizationMember{}),
 			infer.Resource(&resources.OrganizationRole{}),
@@ -241,9 +242,6 @@ func (k *pulumiserviceProvider) Configure(
 	k.client = client
 
 	k.pulumiResources = []PulumiServiceResource{
-		&resources.PulumiServiceAccessTokenResource{
-			Client: client,
-		},
 		&resources.PulumiServiceWebhookResource{
 			Client: client,
 		},

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -96,6 +96,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			infer.Resource(&resources.OrganizationRole{}),
 			infer.Resource(&resources.StackTag{}),
 			infer.Resource(&resources.Team{}),
+			infer.Resource(&resources.TeamAccessToken{}),
 			infer.Resource(&resources.TeamRoleAssignment{}),
 		).
 		WithFunctions(
@@ -249,9 +250,6 @@ func (k *pulumiserviceProvider) Configure(
 			Client: client,
 		},
 		&resources.TeamStackPermissionResource{
-			Client: client,
-		},
-		&resources.PulumiServiceTeamAccessTokenResource{
 			Client: client,
 		},
 		&resources.PulumiServiceOrgAccessTokenResource{

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -92,6 +92,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 		WithResources(
 			infer.Resource(&resources.AccessToken{}),
 			infer.Resource(&resources.InsightsAccount{}),
+			infer.Resource(&resources.OrgAccessToken{}),
 			infer.Resource(&resources.OrganizationMember{}),
 			infer.Resource(&resources.OrganizationRole{}),
 			infer.Resource(&resources.StackTag{}),
@@ -250,9 +251,6 @@ func (k *pulumiserviceProvider) Configure(
 			Client: client,
 		},
 		&resources.TeamStackPermissionResource{
-			Client: client,
-		},
-		&resources.PulumiServiceOrgAccessTokenResource{
 			Client: client,
 		},
 		&resources.PulumiServiceDeploymentSettingsResource{

--- a/provider/pkg/pulumiapi/accesstokens.go
+++ b/provider/pkg/pulumiapi/accesstokens.go
@@ -21,6 +21,12 @@ import (
 	"path"
 )
 
+type AccessTokenClient interface {
+	CreateAccessToken(ctx context.Context, description string) (*AccessToken, error)
+	DeleteAccessToken(ctx context.Context, tokenID string) error
+	GetAccessToken(ctx context.Context, id string) (*AccessToken, error)
+}
+
 type AccessToken struct {
 	ID          string `json:"id"`
 	Name        string `json:"name"`

--- a/provider/pkg/pulumiapi/orgtokens.go
+++ b/provider/pkg/pulumiapi/orgtokens.go
@@ -21,6 +21,12 @@ import (
 	"path"
 )
 
+type OrgAccessTokenClient interface {
+	CreateOrgAccessToken(ctx context.Context, name, orgName, description string, admin bool) (*AccessToken, error)
+	DeleteOrgAccessToken(ctx context.Context, tokenID, orgName string) error
+	GetOrgAccessToken(ctx context.Context, tokenID, orgName string) (*AccessToken, error)
+}
+
 type createOrgTokenResponse struct {
 	ID         string `json:"id"`
 	TokenValue string `json:"tokenValue"`

--- a/provider/pkg/pulumiapi/teamtokens.go
+++ b/provider/pkg/pulumiapi/teamtokens.go
@@ -21,6 +21,12 @@ import (
 	"path"
 )
 
+type TeamAccessTokenClient interface {
+	CreateTeamAccessToken(ctx context.Context, name, orgName, teamName, description string) (*AccessToken, error)
+	DeleteTeamAccessToken(ctx context.Context, tokenID, orgName, teamName string) error
+	GetTeamAccessToken(ctx context.Context, tokenID, orgName, teamName string) (*AccessToken, error)
+}
+
 type createTeamTokenResponse struct {
 	ID         string `json:"id"`
 	TokenValue string `json:"tokenValue"`

--- a/provider/pkg/resources/access_token.go
+++ b/provider/pkg/resources/access_token.go
@@ -19,10 +19,7 @@ import (
 	"fmt"
 
 	"github.com/pulumi/pulumi-go-provider/infer"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/property"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 )
@@ -136,43 +133,4 @@ func migrateAccessTokenLegacyInputs(
 		state.Value = v.AsString()
 	}
 	return infer.MigrationResult[AccessTokenState]{Result: &state}, nil
-}
-
-// diffAccessTokenProperties is shared with the legacy gRPC-style access-token
-// resources (org_access_token.go, team_access_token.go) which still rely on the
-// "__inputs" property layout. Remove this when those resources are migrated.
-func diffAccessTokenProperties(req *pulumirpc.DiffRequest, replaceProps []string) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-	if err != nil {
-		return nil, err
-	}
-
-	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: false})
-	if err != nil {
-		return nil, err
-	}
-
-	inputs, ok := olds["__inputs"]
-	if !ok {
-		return nil, fmt.Errorf("missing __inputs property")
-	}
-	diffs := inputs.ObjectValue().Diff(news)
-	if diffs == nil {
-		return &pulumirpc.DiffResponse{
-			Changes: pulumirpc.DiffResponse_DIFF_NONE,
-		}, nil
-	}
-
-	changes, replaces := pulumirpc.DiffResponse_DIFF_NONE, []string(nil)
-	for _, k := range replaceProps {
-		if diffs.Changed(resource.PropertyKey(k)) {
-			changes = pulumirpc.DiffResponse_DIFF_SOME
-			replaces = append(replaces, k)
-		}
-	}
-
-	return &pulumirpc.DiffResponse{
-		Changes:  changes,
-		Replaces: replaces,
-	}, nil
 }

--- a/provider/pkg/resources/access_token.go
+++ b/provider/pkg/resources/access_token.go
@@ -1,178 +1,146 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
 	"context"
 	"fmt"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
-
+	"github.com/pulumi/pulumi-go-provider/infer"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 )
 
-type PulumiServiceAccessTokenResource struct {
-	Client *pulumiapi.Client
+type AccessToken struct{}
+
+var (
+	_ infer.CustomCreate[AccessTokenInput, AccessTokenState] = &AccessToken{}
+	_ infer.CustomDelete[AccessTokenState]                   = &AccessToken{}
+	_ infer.CustomRead[AccessTokenInput, AccessTokenState]   = &AccessToken{}
+	_ infer.CustomStateMigrations[AccessTokenState]          = &AccessToken{}
+)
+
+func (*AccessToken) Annotate(a infer.Annotator) {
+	a.Describe(&AccessToken{}, "Access tokens allow a user to authenticate against the Pulumi Cloud.")
 }
 
-type PulumiServiceAccessTokenInput struct {
-	Description string
+type AccessTokenInput struct {
+	Description string `pulumi:"description" provider:"replaceOnChanges"`
 }
 
-// AccessToken uses outdated way of storing input in internal __inputs property
-func GenerateAcessTokenProperties(
-	input PulumiServiceAccessTokenInput,
-	accessToken pulumiapi.AccessToken,
-) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
-	inputMap := resource.PropertyMap{}
-	inputMap["description"] = resource.NewPropertyValue(input.Description)
-	outputStore := resource.PropertyMap{}
-	outputStore["__inputs"] = resource.NewObjectProperty(inputMap)
-	outputStore["description"] = resource.NewPropertyValue(input.Description)
-	outputStore["value"] = resource.MakeSecret(resource.NewPropertyValue(accessToken.TokenValue))
-
-	inputs, err = plugin.MarshalProperties(
-		inputMap,
-		plugin.MarshalOptions{},
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	outputs, err = plugin.MarshalProperties(
-		outputStore,
-		plugin.MarshalOptions{},
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return outputs, inputs, err
+func (i *AccessTokenInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Description, "Description of the access token.")
 }
 
-func (at *PulumiServiceAccessTokenResource) ToPulumiServiceAccessTokenInput(
-	inputMap resource.PropertyMap,
-) PulumiServiceAccessTokenInput {
-	input := PulumiServiceAccessTokenInput{}
-
-	if inputMap["description"].HasValue() && inputMap["description"].IsString() {
-		input.Description = inputMap["description"].StringValue()
-	}
-
-	return input
+type AccessTokenState struct {
+	AccessTokenInput
+	Value string `pulumi:"value" provider:"secret"`
 }
 
-func (at *PulumiServiceAccessTokenResource) Name() string {
-	return "pulumiservice:index:AccessToken"
+func (s *AccessTokenState) Annotate(a infer.Annotator) {
+	a.Describe(&s.Value, "The token's value.")
 }
 
-func (at *PulumiServiceAccessTokenResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return diffAccessTokenProperties(req, []string{"description"})
-}
-
-func (at *PulumiServiceAccessTokenResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	err := at.deleteAccessToken(ctx, req.Id)
-	if err != nil {
-		return &pbempty.Empty{}, err
-	}
-
-	return &pbempty.Empty{}, nil
-}
-
-func (at *PulumiServiceAccessTokenResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	inputMap, err := plugin.UnmarshalProperties(
-		req.GetProperties(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	input := at.ToPulumiServiceAccessTokenInput(inputMap)
-	accessToken, err := at.createAccessToken(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("error creating access token '%s': %s", input.Description, err.Error())
-	}
-
-	outputProperties, _, err := GenerateAcessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         accessToken.ID,
-		Properties: outputProperties,
-	}, nil
-
-}
-
-func (at *PulumiServiceAccessTokenResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (at *PulumiServiceAccessTokenResource) Update(_ *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	// all updates are destructive, so we just call Create.
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
-}
-
-func (at *PulumiServiceAccessTokenResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-
-	// the access token is immutable; if we get nil it got deleted, otherwise all data is the same
-	accessToken, err := at.Client.GetAccessToken(ctx, req.GetId())
-	if err != nil {
-		return nil, err
-	}
-	if accessToken == nil {
-		return &pulumirpc.ReadResponse{}, nil
-	}
-
-	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if propertyMap["value"].HasValue() {
-		accessToken.TokenValue = util.GetSecretOrStringValue(propertyMap["value"])
-	}
-
-	input := PulumiServiceAccessTokenInput{
-		Description: accessToken.Description,
-	}
-	outputProperties, inputs, err := GenerateAcessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         accessToken.ID,
-		Properties: outputProperties,
-		Inputs:     inputs,
-	}, nil
-}
-
-func (at *PulumiServiceAccessTokenResource) createAccessToken(
+func (*AccessToken) Create(
 	ctx context.Context,
-	input PulumiServiceAccessTokenInput,
-) (*pulumiapi.AccessToken, error) {
-
-	accessToken, err := at.Client.CreateAccessToken(ctx, input.Description)
-	if err != nil {
-		return nil, err
+	req infer.CreateRequest[AccessTokenInput],
+) (infer.CreateResponse[AccessTokenState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[AccessTokenState]{
+			Output: AccessTokenState{AccessTokenInput: req.Inputs},
+		}, nil
 	}
-
-	return accessToken, nil
+	token, err := config.GetClient(ctx).CreateAccessToken(ctx, req.Inputs.Description)
+	if err != nil {
+		return infer.CreateResponse[AccessTokenState]{}, fmt.Errorf(
+			"error creating access token %q: %w", req.Inputs.Description, err,
+		)
+	}
+	return infer.CreateResponse[AccessTokenState]{
+		ID: token.ID,
+		Output: AccessTokenState{
+			AccessTokenInput: AccessTokenInput{Description: req.Inputs.Description},
+			Value:            token.TokenValue,
+		},
+	}, nil
 }
 
-func (at *PulumiServiceAccessTokenResource) deleteAccessToken(ctx context.Context, tokenID string) error {
-	return at.Client.DeleteAccessToken(ctx, tokenID)
+func (*AccessToken) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[AccessTokenState],
+) (infer.DeleteResponse, error) {
+	return infer.DeleteResponse{}, config.GetClient(ctx).DeleteAccessToken(ctx, req.ID)
 }
 
+func (*AccessToken) Read(
+	ctx context.Context,
+	req infer.ReadRequest[AccessTokenInput, AccessTokenState],
+) (infer.ReadResponse[AccessTokenInput, AccessTokenState], error) {
+	token, err := config.GetClient(ctx).GetAccessToken(ctx, req.ID)
+	if err != nil {
+		return infer.ReadResponse[AccessTokenInput, AccessTokenState]{}, err
+	}
+	if token == nil {
+		return infer.ReadResponse[AccessTokenInput, AccessTokenState]{}, nil
+	}
+	inputs := AccessTokenInput{Description: token.Description}
+	return infer.ReadResponse[AccessTokenInput, AccessTokenState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State: AccessTokenState{
+			AccessTokenInput: inputs,
+			// The list-tokens API does not return token values; carry the existing
+			// secret from state so refresh does not erase it.
+			Value: req.State.Value,
+		},
+	}, nil
+}
+
+// StateMigrations strips the legacy "__inputs" outputs property that the
+// pre-infer AccessToken resource embedded in state. infer rejects unknown
+// fields when decoding state, so without this migration a refresh against an
+// existing stack errors with "Unrecognized field '__inputs'".
+func (*AccessToken) StateMigrations(context.Context) []infer.StateMigrationFunc[AccessTokenState] {
+	return []infer.StateMigrationFunc[AccessTokenState]{
+		infer.StateMigration(migrateAccessTokenLegacyInputs),
+	}
+}
+
+func migrateAccessTokenLegacyInputs(
+	_ context.Context, old property.Map,
+) (infer.MigrationResult[AccessTokenState], error) {
+	if _, ok := old.GetOk("__inputs"); !ok {
+		return infer.MigrationResult[AccessTokenState]{}, nil
+	}
+	state := AccessTokenState{}
+	if v, ok := old.GetOk("description"); ok && v.IsString() {
+		state.Description = v.AsString()
+	}
+	if v, ok := old.GetOk("value"); ok && v.IsString() {
+		state.Value = v.AsString()
+	}
+	return infer.MigrationResult[AccessTokenState]{Result: &state}, nil
+}
+
+// diffAccessTokenProperties is shared with the legacy gRPC-style access-token
+// resources (org_access_token.go, team_access_token.go) which still rely on the
+// "__inputs" property layout. Remove this when those resources are migrated.
 func diffAccessTokenProperties(req *pulumirpc.DiffRequest, replaceProps []string) (*pulumirpc.DiffResponse, error) {
 	olds, err := plugin.UnmarshalProperties(req.GetOlds(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
 	if err != nil {

--- a/provider/pkg/resources/access_token_test.go
+++ b/provider/pkg/resources/access_token_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// State written by the pre-infer AccessToken implementation embedded a
+// duplicate `__inputs` map alongside the real outputs. After migrating to
+// infer, decoding such state fails with "Unrecognized field '__inputs'" unless
+// migrateAccessTokenLegacyInputs runs first.
+func TestAccessTokenLegacyInputsMigration(t *testing.T) {
+	t.Run("migrates legacy state", func(t *testing.T) {
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs": property.New(property.NewMap(map[string]property.Value{
+				"description": property.New("example token"),
+			})),
+			"description": property.New("example token"),
+			"value":       property.New("tok-secret-value"),
+		})
+
+		got, err := migrateAccessTokenLegacyInputs(t.Context(), legacy)
+		require.NoError(t, err)
+		assert.Equal(t, &AccessTokenState{
+			AccessTokenInput: AccessTokenInput{Description: "example token"},
+			Value:            "tok-secret-value",
+		}, got.Result)
+	})
+
+	t.Run("no-op for already-migrated state", func(t *testing.T) {
+		current := property.NewMap(map[string]property.Value{
+			"description": property.New("example token"),
+			"value":       property.New("tok-secret-value"),
+		})
+
+		got, err := migrateAccessTokenLegacyInputs(t.Context(), current)
+		require.NoError(t, err)
+		assert.Nil(t, got.Result, "migration must not fire when __inputs is absent")
+	})
+
+	t.Run("registered on the resource", func(t *testing.T) {
+		migrations := (&AccessToken{}).StateMigrations(t.Context())
+		assert.Len(t, migrations, 1)
+	})
+}

--- a/provider/pkg/resources/org_access_token.go
+++ b/provider/pkg/resources/org_access_token.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -5,220 +19,187 @@ import (
 	"fmt"
 	"strings"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 )
 
-type PulumiServiceOrgAccessTokenResource struct {
-	Client *pulumiapi.Client
+type OrgAccessToken struct{}
+
+var (
+	_ infer.CustomCreate[OrgAccessTokenInput, OrgAccessTokenState] = &OrgAccessToken{}
+	_ infer.CustomDelete[OrgAccessTokenState]                      = &OrgAccessToken{}
+	_ infer.CustomRead[OrgAccessTokenInput, OrgAccessTokenState]   = &OrgAccessToken{}
+	_ infer.CustomStateMigrations[OrgAccessTokenState]             = &OrgAccessToken{}
+)
+
+func (*OrgAccessToken) Annotate(a infer.Annotator) {
+	a.Describe(
+		&OrgAccessToken{},
+		"The Pulumi Cloud allows users to create access tokens scoped to orgs. "+
+			"Org access tokens is a resource to create them and assign them to an org",
+	)
 }
 
-type PulumiServiceOrgAccessTokenInput struct {
-	OrgName     string
-	Description string
-	Name        string
-	Admin       bool
+type OrgAccessTokenInput struct {
+	Name             string  `pulumi:"name"                 provider:"replaceOnChanges"`
+	OrganizationName string  `pulumi:"organizationName"     provider:"replaceOnChanges"`
+	Description      *string `pulumi:"description,optional" provider:"replaceOnChanges"`
+	Admin            *bool   `pulumi:"admin,optional"       provider:"replaceOnChanges"`
 }
 
-func GenerateOrgAccessTokenProperties(
-	input PulumiServiceOrgAccessTokenInput,
-	orgAccessToken pulumiapi.AccessToken,
-) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
-	inputMap := input.ToPropertyMap()
+func (i *OrgAccessTokenInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Name, "The name for the token.")
+	a.Describe(&i.OrganizationName, "The organization's name.")
+	a.Describe(&i.Description, "Optional. Description for the token.")
+	a.Describe(&i.Admin, "Optional. True if this is an admin token.")
+	a.SetDefault(&i.Admin, false)
+}
 
-	outputMap := inputMap.Copy()
-	outputMap["__inputs"] = resource.NewObjectProperty(inputMap)
-	outputMap["value"] = resource.MakeSecret(resource.NewPropertyValue(orgAccessToken.TokenValue))
+type OrgAccessTokenState struct {
+	OrgAccessTokenInput
+	Value string `pulumi:"value" provider:"secret"`
+}
 
-	inputs, err = plugin.MarshalProperties(inputMap, plugin.MarshalOptions{})
-	if err != nil {
-		return nil, nil, err
+func (s *OrgAccessTokenState) Annotate(a infer.Annotator) {
+	a.Describe(&s.Value, "The token's value.")
+}
+
+func (*OrgAccessToken) Create(
+	ctx context.Context,
+	req infer.CreateRequest[OrgAccessTokenInput],
+) (infer.CreateResponse[OrgAccessTokenState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[OrgAccessTokenState]{
+			Output: OrgAccessTokenState{OrgAccessTokenInput: req.Inputs},
+		}, nil
 	}
-
-	outputs, err = plugin.MarshalProperties(outputMap, plugin.MarshalOptions{})
-	if err != nil {
-		return nil, nil, err
+	desc := ""
+	if req.Inputs.Description != nil {
+		desc = *req.Inputs.Description
 	}
-
-	return outputs, inputs, err
-}
-
-func (i *PulumiServiceOrgAccessTokenInput) ToPropertyMap() resource.PropertyMap {
-	pm := resource.PropertyMap{}
-	pm["name"] = resource.NewPropertyValue(i.Name)
-	pm["description"] = resource.NewPropertyValue(i.Description)
-	pm["organizationName"] = resource.NewPropertyValue(i.OrgName)
-	pm["admin"] = resource.NewPropertyValue(i.Admin)
-	return pm
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) ToPulumiServiceOrgAccessTokenInput(
-	inputMap resource.PropertyMap,
-) PulumiServiceOrgAccessTokenInput {
-	input := PulumiServiceOrgAccessTokenInput{}
-
-	if inputMap["name"].HasValue() && inputMap["name"].IsString() {
-		input.Name = inputMap["name"].StringValue()
+	admin := false
+	if req.Inputs.Admin != nil {
+		admin = *req.Inputs.Admin
 	}
-
-	if inputMap["description"].HasValue() && inputMap["description"].IsString() {
-		input.Description = inputMap["description"].StringValue()
-	}
-
-	if inputMap["organizationName"].HasValue() && inputMap["organizationName"].IsString() {
-		input.OrgName = inputMap["organizationName"].StringValue()
-	}
-
-	if inputMap["admin"].HasValue() && inputMap["admin"].IsBool() {
-		input.Admin = inputMap["admin"].BoolValue()
-	}
-
-	return input
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Name() string {
-	return "pulumiservice:index:OrgAccessToken"
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return diffAccessTokenProperties(req, []string{"name", "organizationName", "description", "admin"})
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	err := ot.deleteOrgAccessToken(ctx, req.Id)
-
-	if err != nil {
-		return &pbempty.Empty{}, err
-	}
-
-	return &pbempty.Empty{}, nil
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	inputMap, err := plugin.UnmarshalProperties(
-		req.GetProperties(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+	token, err := config.GetClient(ctx).CreateOrgAccessToken(
+		ctx, req.Inputs.Name, req.Inputs.OrganizationName, desc, admin,
 	)
 	if err != nil {
-		return nil, err
+		return infer.CreateResponse[OrgAccessTokenState]{}, fmt.Errorf(
+			"error creating org access token %q: %w", req.Inputs.Name, err,
+		)
 	}
-
-	input := ot.ToPulumiServiceOrgAccessTokenInput(inputMap)
-
-	accessToken, err := ot.createOrgAccessToken(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("error creating access token '%s': %s", input.Name, err.Error())
-	}
-
-	outputs, _, err := GenerateOrgAccessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         fmt.Sprintf("%s/%s/%s", input.OrgName, input.Name, accessToken.ID),
-		Properties: outputs,
-	}, nil
-
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Update(_ *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	// all updates are destructive, so we just call Create.
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
-}
-
-func (ot *PulumiServiceOrgAccessTokenResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-	urn := req.GetId()
-
-	orgName, _, tokenID, err := splitOrgAccessTokenID(urn)
-	if err != nil {
-		return nil, err
-	}
-
-	// the org access token is immutable; if we get nil it got deleted, otherwise all data is the same
-	accessToken, err := ot.Client.GetOrgAccessToken(ctx, tokenID, orgName)
-	if err != nil {
-		return nil, err
-	}
-	if accessToken == nil {
-		return &pulumirpc.ReadResponse{}, nil
-	}
-
-	var input = PulumiServiceOrgAccessTokenInput{
-		Name:        accessToken.Name,
-		OrgName:     orgName,
-		Description: accessToken.Description,
-		Admin:       accessToken.Admin,
-	}
-
-	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if propertyMap["value"].HasValue() {
-		accessToken.TokenValue = util.GetSecretOrStringValue(propertyMap["value"])
-	}
-
-	outputs, inputs, err := GenerateOrgAccessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: outputs,
-		Inputs:     inputs,
+	return infer.CreateResponse[OrgAccessTokenState]{
+		ID: orgAccessTokenID(req.Inputs.OrganizationName, req.Inputs.Name, token.ID),
+		Output: OrgAccessTokenState{
+			OrgAccessTokenInput: req.Inputs,
+			Value:               token.TokenValue,
+		},
 	}, nil
 }
 
-func (ot *PulumiServiceOrgAccessTokenResource) createOrgAccessToken(
+func (*OrgAccessToken) Delete(
 	ctx context.Context,
-	input PulumiServiceOrgAccessTokenInput,
-) (*pulumiapi.AccessToken, error) {
-
-	accessToken, err := ot.Client.CreateOrgAccessToken(ctx, input.Name, input.OrgName, input.Description, input.Admin)
+	req infer.DeleteRequest[OrgAccessTokenState],
+) (infer.DeleteResponse, error) {
+	orgName, _, tokenID, err := splitOrgAccessTokenID(req.ID)
 	if err != nil {
-		return nil, err
+		return infer.DeleteResponse{}, err
 	}
-
-	return accessToken, nil
+	return infer.DeleteResponse{}, config.GetClient(ctx).DeleteOrgAccessToken(ctx, tokenID, orgName)
 }
 
-func (ot *PulumiServiceOrgAccessTokenResource) deleteOrgAccessToken(ctx context.Context, id string) error {
-	// we don't need the token name when we delete
-	orgName, _, tokenID, err := splitOrgAccessTokenID(id)
+func (*OrgAccessToken) Read(
+	ctx context.Context,
+	req infer.ReadRequest[OrgAccessTokenInput, OrgAccessTokenState],
+) (infer.ReadResponse[OrgAccessTokenInput, OrgAccessTokenState], error) {
+	orgName, _, tokenID, err := splitOrgAccessTokenID(req.ID)
 	if err != nil {
-		return err
+		return infer.ReadResponse[OrgAccessTokenInput, OrgAccessTokenState]{}, err
 	}
-	return ot.Client.DeleteOrgAccessToken(ctx, tokenID, orgName)
 
+	token, err := config.GetClient(ctx).GetOrgAccessToken(ctx, tokenID, orgName)
+	if err != nil {
+		return infer.ReadResponse[OrgAccessTokenInput, OrgAccessTokenState]{}, err
+	}
+	if token == nil {
+		return infer.ReadResponse[OrgAccessTokenInput, OrgAccessTokenState]{}, nil
+	}
+
+	admin := token.Admin
+	inputs := OrgAccessTokenInput{
+		Name:             token.Name,
+		OrganizationName: orgName,
+		Description:      stringPtrIfNonEmpty(token.Description),
+		Admin:            &admin,
+	}
+	return infer.ReadResponse[OrgAccessTokenInput, OrgAccessTokenState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State: OrgAccessTokenState{
+			OrgAccessTokenInput: inputs,
+			// Token values aren't retrievable from the API after creation; carry
+			// the existing secret from state so refresh does not erase it.
+			Value: req.State.Value,
+		},
+	}, nil
+}
+
+// StateMigrations strips the legacy "__inputs" outputs property that the
+// pre-infer OrgAccessToken resource embedded in state. infer rejects unknown
+// fields when decoding state, so without this migration a refresh against an
+// existing stack errors with "Unrecognized field '__inputs'".
+func (*OrgAccessToken) StateMigrations(context.Context) []infer.StateMigrationFunc[OrgAccessTokenState] {
+	return []infer.StateMigrationFunc[OrgAccessTokenState]{
+		infer.StateMigration(migrateOrgAccessTokenLegacyInputs),
+	}
+}
+
+func migrateOrgAccessTokenLegacyInputs(
+	_ context.Context, old property.Map,
+) (infer.MigrationResult[OrgAccessTokenState], error) {
+	if _, ok := old.GetOk("__inputs"); !ok {
+		return infer.MigrationResult[OrgAccessTokenState]{}, nil
+	}
+	state := OrgAccessTokenState{}
+	if v, ok := old.GetOk("name"); ok && v.IsString() {
+		state.Name = v.AsString()
+	}
+	if v, ok := old.GetOk("organizationName"); ok && v.IsString() {
+		state.OrganizationName = v.AsString()
+	}
+	if v, ok := old.GetOk("description"); ok && v.IsString() {
+		s := v.AsString()
+		state.Description = &s
+	}
+	if v, ok := old.GetOk("admin"); ok && v.IsBool() {
+		b := v.AsBool()
+		state.Admin = &b
+	}
+	if v, ok := old.GetOk("value"); ok && v.IsString() {
+		state.Value = v.AsString()
+	}
+	return infer.MigrationResult[OrgAccessTokenState]{Result: &state}, nil
+}
+
+func orgAccessTokenID(org, name, tokenID string) string {
+	return fmt.Sprintf("%s/%s/%s", org, name, tokenID)
 }
 
 func splitOrgAccessTokenID(id string) (string, string, string, error) {
-	// format: organization/name/tokenID
+	// format: organization/name/tokenID. Name may itself contain slashes,
+	// so org is the first segment and tokenID is the last.
 	s := strings.Split(id, "/")
 	if len(s) < 3 {
-		return "", "", "", fmt.Errorf("%q is invalid, must contain a single slash ('/')", id)
+		return "", "", "", fmt.Errorf(
+			"%q is invalid, must be of the form organization/name/tokenId",
+			id,
+		)
 	}
-
 	org := s[0]
 	tokenID := s[len(s)-1]
-	// Name can contain slashes so this joins the split parts except for first and last
 	name := strings.Join(s[1:len(s)-1], "/")
-
 	return org, name, tokenID, nil
 }

--- a/provider/pkg/resources/org_access_token_test.go
+++ b/provider/pkg/resources/org_access_token_test.go
@@ -5,7 +5,83 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 )
+
+// State written by the pre-infer OrgAccessToken implementation embedded a
+// duplicate `__inputs` map alongside the real outputs. After migrating to
+// infer, decoding such state fails with "Unrecognized field '__inputs'" unless
+// migrateOrgAccessTokenLegacyInputs runs first.
+func TestOrgAccessTokenLegacyInputsMigration(t *testing.T) {
+	t.Run("migrates legacy state", func(t *testing.T) {
+		legacyInputs := property.NewMap(map[string]property.Value{
+			"name":             property.New("admin-token"),
+			"organizationName": property.New("my-org"),
+			"description":      property.New("example org token"),
+			"admin":            property.New(true),
+		})
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs":         property.New(legacyInputs),
+			"name":             property.New("admin-token"),
+			"organizationName": property.New("my-org"),
+			"description":      property.New("example org token"),
+			"admin":            property.New(true),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateOrgAccessTokenLegacyInputs(t.Context(), legacy)
+		require.NoError(t, err)
+		desc := "example org token"
+		admin := true
+		assert.Equal(t, &OrgAccessTokenState{
+			OrgAccessTokenInput: OrgAccessTokenInput{
+				Name:             "admin-token",
+				OrganizationName: "my-org",
+				Description:      &desc,
+				Admin:            &admin,
+			},
+			Value: "tok-secret-value",
+		}, got.Result)
+	})
+
+	t.Run("migrates legacy state with optional fields omitted", func(t *testing.T) {
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs":         property.New(property.NewMap(nil)),
+			"name":             property.New("plain-token"),
+			"organizationName": property.New("my-org"),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateOrgAccessTokenLegacyInputs(t.Context(), legacy)
+		require.NoError(t, err)
+		assert.Equal(t, &OrgAccessTokenState{
+			OrgAccessTokenInput: OrgAccessTokenInput{
+				Name:             "plain-token",
+				OrganizationName: "my-org",
+			},
+			Value: "tok-secret-value",
+		}, got.Result)
+	})
+
+	t.Run("no-op for already-migrated state", func(t *testing.T) {
+		current := property.NewMap(map[string]property.Value{
+			"name":             property.New("admin-token"),
+			"organizationName": property.New("my-org"),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateOrgAccessTokenLegacyInputs(t.Context(), current)
+		require.NoError(t, err)
+		assert.Nil(t, got.Result, "migration must not fire when __inputs is absent")
+	})
+
+	t.Run("registered on the resource", func(t *testing.T) {
+		migrations := (&OrgAccessToken{}).StateMigrations(t.Context())
+		assert.Len(t, migrations, 1)
+	})
+}
 
 func TestSplitOrgAccessTokenId(t *testing.T) {
 	t.Run("Splits org access token id", func(t *testing.T) {
@@ -34,6 +110,6 @@ func TestSplitOrgAccessTokenId(t *testing.T) {
 		tokenID := "org/badname"
 
 		_, _, _, err := splitOrgAccessTokenID(tokenID)
-		assert.ErrorContains(t, err, fmt.Sprintf("%q is invalid, must contain a single slash ('/')", tokenID))
+		assert.ErrorContains(t, err, fmt.Sprintf("%q is invalid, must be of the form organization/name/tokenId", tokenID))
 	})
 }

--- a/provider/pkg/resources/team_access_token.go
+++ b/provider/pkg/resources/team_access_token.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -5,218 +19,180 @@ import (
 	"fmt"
 	"strings"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 )
 
-type PulumiServiceTeamAccessTokenResource struct {
-	Client *pulumiapi.Client
-}
+type TeamAccessToken struct{}
 
-type PulumiServiceTeamAccessTokenInput struct {
-	Name        string
-	OrgName     string
-	TeamName    string
-	Description string
-}
+var (
+	_ infer.CustomCreate[TeamAccessTokenInput, TeamAccessTokenState] = &TeamAccessToken{}
+	_ infer.CustomDelete[TeamAccessTokenState]                       = &TeamAccessToken{}
+	_ infer.CustomRead[TeamAccessTokenInput, TeamAccessTokenState]   = &TeamAccessToken{}
+	_ infer.CustomStateMigrations[TeamAccessTokenState]              = &TeamAccessToken{}
+)
 
-func GenerateTeamAccessTokenProperties(
-	input PulumiServiceTeamAccessTokenInput,
-	teamAccessToken pulumiapi.AccessToken,
-) (outputs *structpb.Struct, inputs *structpb.Struct, err error) {
-	inputMap := input.ToPropertyMap()
-
-	outputMap := inputMap.Copy()
-	outputMap["__inputs"] = resource.NewObjectProperty(inputMap)
-	outputMap["value"] = resource.MakeSecret(resource.NewPropertyValue(teamAccessToken.TokenValue))
-
-	inputs, err = plugin.MarshalProperties(inputMap, plugin.MarshalOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	outputs, err = plugin.MarshalProperties(outputMap, plugin.MarshalOptions{})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return outputs, inputs, err
-}
-
-func (i *PulumiServiceTeamAccessTokenInput) ToPropertyMap() resource.PropertyMap {
-	pm := resource.PropertyMap{}
-	pm["name"] = resource.NewPropertyValue(i.Name)
-	pm["description"] = resource.NewPropertyValue(i.Description)
-	pm["organizationName"] = resource.NewPropertyValue(i.OrgName)
-	pm["teamName"] = resource.NewPropertyValue(i.TeamName)
-	return pm
-}
-
-func (t *PulumiServiceTeamAccessTokenResource) ToPulumiServiceAccessTokenInput(
-	inputMap resource.PropertyMap,
-) PulumiServiceTeamAccessTokenInput {
-	input := PulumiServiceTeamAccessTokenInput{}
-
-	if inputMap["name"].HasValue() && inputMap["name"].IsString() {
-		input.Name = inputMap["name"].StringValue()
-	}
-
-	if inputMap["description"].HasValue() && inputMap["description"].IsString() {
-		input.Description = inputMap["description"].StringValue()
-	}
-
-	if inputMap["teamName"].HasValue() && inputMap["teamName"].IsString() {
-		input.TeamName = inputMap["teamName"].StringValue()
-	}
-
-	if inputMap["organizationName"].HasValue() && inputMap["organizationName"].IsString() {
-		input.OrgName = inputMap["organizationName"].StringValue()
-	}
-
-	return input
-}
-
-func (t *PulumiServiceTeamAccessTokenResource) Name() string {
-	return "pulumiservice:index:TeamAccessToken"
-}
-
-func (t *PulumiServiceTeamAccessTokenResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return diffAccessTokenProperties(req, []string{"name", "organizationName", "teamName", "description"})
-}
-
-func (t *PulumiServiceTeamAccessTokenResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	err := t.deleteTeamAccessToken(ctx, req.Id)
-
-	if err != nil {
-		return &pbempty.Empty{}, err
-	}
-
-	return &pbempty.Empty{}, nil
-}
-
-func (t *PulumiServiceTeamAccessTokenResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	inputMap, err := plugin.UnmarshalProperties(
-		req.GetProperties(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
+func (*TeamAccessToken) Annotate(a infer.Annotator) {
+	a.Describe(
+		&TeamAccessToken{},
+		"The Pulumi Cloud allows users to create access tokens scoped to team. "+
+			"Team access tokens is a resource to create them and assign them to a team",
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	input := t.ToPulumiServiceAccessTokenInput(inputMap)
-
-	accessToken, err := t.createTeamAccessToken(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("error creating access token '%s': %s", input.Name, err.Error())
-	}
-
-	outputs, _, err := GenerateTeamAccessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         fmt.Sprintf("%s/%s/%s/%s", input.OrgName, input.TeamName, input.Name, accessToken.ID),
-		Properties: outputs,
-	}, nil
 }
 
-func (t *PulumiServiceTeamAccessTokenResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
+type TeamAccessTokenInput struct {
+	Name             string  `pulumi:"name"             provider:"replaceOnChanges"`
+	OrganizationName string  `pulumi:"organizationName" provider:"replaceOnChanges"`
+	TeamName         string  `pulumi:"teamName"         provider:"replaceOnChanges"`
+	Description      *string `pulumi:"description,optional" provider:"replaceOnChanges"`
 }
 
-func (t *PulumiServiceTeamAccessTokenResource) Update(_ *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	// all updates are destructive, so we just call Create.
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
+func (i *TeamAccessTokenInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Name, "The name for the token. This must be unique amongst all machine tokens within your organization.")
+	a.Describe(&i.OrganizationName, "The organization's name.")
+	a.Describe(&i.TeamName, "The team name.")
+	a.Describe(&i.Description, "Optional. Description for the token.")
 }
 
-func (t *PulumiServiceTeamAccessTokenResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-	urn := req.GetId()
-
-	orgName, teamName, tokenName, tokenID, err := splitTeamAccessTokenID(urn)
-	if err != nil {
-		return nil, err
-	}
-
-	// the team access token is immutable; if we get nil it got deleted, otherwise all data is the same
-	accessToken, err := t.Client.GetTeamAccessToken(ctx, tokenID, orgName, teamName)
-	if err != nil {
-		return nil, err
-	}
-	if accessToken == nil {
-		return &pulumirpc.ReadResponse{}, nil
-	}
-
-	var input = PulumiServiceTeamAccessTokenInput{
-		Name:        tokenName,
-		OrgName:     orgName,
-		Description: accessToken.Description,
-		TeamName:    teamName,
-	}
-
-	propertyMap, err := plugin.UnmarshalProperties(req.GetProperties(), plugin.MarshalOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if propertyMap["value"].HasValue() {
-		accessToken.TokenValue = util.GetSecretOrStringValue(propertyMap["value"])
-	}
-
-	outputs, inputs, err := GenerateTeamAccessTokenProperties(input, *accessToken)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: outputs,
-		Inputs:     inputs,
-	}, nil
+type TeamAccessTokenState struct {
+	TeamAccessTokenInput
+	Value string `pulumi:"value" provider:"secret"`
 }
 
-func (t *PulumiServiceTeamAccessTokenResource) createTeamAccessToken(
+func (s *TeamAccessTokenState) Annotate(a infer.Annotator) {
+	a.Describe(&s.Value, "The token's value.")
+}
+
+func (*TeamAccessToken) Create(
 	ctx context.Context,
-	input PulumiServiceTeamAccessTokenInput,
-) (*pulumiapi.AccessToken, error) {
-
-	accessToken, err := t.Client.CreateTeamAccessToken(
-		ctx,
-		input.Name,
-		input.OrgName,
-		input.TeamName,
-		input.Description,
+	req infer.CreateRequest[TeamAccessTokenInput],
+) (infer.CreateResponse[TeamAccessTokenState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[TeamAccessTokenState]{
+			Output: TeamAccessTokenState{TeamAccessTokenInput: req.Inputs},
+		}, nil
+	}
+	desc := ""
+	if req.Inputs.Description != nil {
+		desc = *req.Inputs.Description
+	}
+	token, err := config.GetClient(ctx).CreateTeamAccessToken(
+		ctx, req.Inputs.Name, req.Inputs.OrganizationName, req.Inputs.TeamName, desc,
 	)
 	if err != nil {
-		return nil, err
+		return infer.CreateResponse[TeamAccessTokenState]{}, fmt.Errorf(
+			"error creating team access token %q: %w", req.Inputs.Name, err,
+		)
 	}
-
-	return accessToken, nil
+	return infer.CreateResponse[TeamAccessTokenState]{
+		ID: teamAccessTokenID(req.Inputs.OrganizationName, req.Inputs.TeamName, req.Inputs.Name, token.ID),
+		Output: TeamAccessTokenState{
+			TeamAccessTokenInput: req.Inputs,
+			Value:                token.TokenValue,
+		},
+	}, nil
 }
 
-func (t *PulumiServiceTeamAccessTokenResource) deleteTeamAccessToken(ctx context.Context, id string) error {
-	orgName, teamName, _, tokenID, err := splitTeamAccessTokenID(id)
+func (*TeamAccessToken) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[TeamAccessTokenState],
+) (infer.DeleteResponse, error) {
+	orgName, teamName, _, tokenID, err := splitTeamAccessTokenID(req.ID)
 	if err != nil {
-		return err
+		return infer.DeleteResponse{}, err
 	}
-	return t.Client.DeleteTeamAccessToken(ctx, tokenID, orgName, teamName)
+	return infer.DeleteResponse{}, config.GetClient(ctx).DeleteTeamAccessToken(ctx, tokenID, orgName, teamName)
+}
 
+func (*TeamAccessToken) Read(
+	ctx context.Context,
+	req infer.ReadRequest[TeamAccessTokenInput, TeamAccessTokenState],
+) (infer.ReadResponse[TeamAccessTokenInput, TeamAccessTokenState], error) {
+	orgName, teamName, tokenName, tokenID, err := splitTeamAccessTokenID(req.ID)
+	if err != nil {
+		return infer.ReadResponse[TeamAccessTokenInput, TeamAccessTokenState]{}, err
+	}
+
+	token, err := config.GetClient(ctx).GetTeamAccessToken(ctx, tokenID, orgName, teamName)
+	if err != nil {
+		return infer.ReadResponse[TeamAccessTokenInput, TeamAccessTokenState]{}, err
+	}
+	if token == nil {
+		return infer.ReadResponse[TeamAccessTokenInput, TeamAccessTokenState]{}, nil
+	}
+
+	inputs := TeamAccessTokenInput{
+		Name:             tokenName,
+		OrganizationName: orgName,
+		TeamName:         teamName,
+		Description:      stringPtrIfNonEmpty(token.Description),
+	}
+	return infer.ReadResponse[TeamAccessTokenInput, TeamAccessTokenState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State: TeamAccessTokenState{
+			TeamAccessTokenInput: inputs,
+			// Token values aren't retrievable from the API after creation; carry
+			// the existing secret from state so refresh does not erase it.
+			Value: req.State.Value,
+		},
+	}, nil
+}
+
+// StateMigrations strips the legacy "__inputs" outputs property that the
+// pre-infer TeamAccessToken resource embedded in state. infer rejects unknown
+// fields when decoding state, so without this migration a refresh against an
+// existing stack errors with "Unrecognized field '__inputs'".
+func (*TeamAccessToken) StateMigrations(context.Context) []infer.StateMigrationFunc[TeamAccessTokenState] {
+	return []infer.StateMigrationFunc[TeamAccessTokenState]{
+		infer.StateMigration(migrateTeamAccessTokenLegacyInputs),
+	}
+}
+
+func migrateTeamAccessTokenLegacyInputs(
+	_ context.Context, old property.Map,
+) (infer.MigrationResult[TeamAccessTokenState], error) {
+	if _, ok := old.GetOk("__inputs"); !ok {
+		return infer.MigrationResult[TeamAccessTokenState]{}, nil
+	}
+	state := TeamAccessTokenState{}
+	if v, ok := old.GetOk("name"); ok && v.IsString() {
+		state.Name = v.AsString()
+	}
+	if v, ok := old.GetOk("organizationName"); ok && v.IsString() {
+		state.OrganizationName = v.AsString()
+	}
+	if v, ok := old.GetOk("teamName"); ok && v.IsString() {
+		state.TeamName = v.AsString()
+	}
+	if v, ok := old.GetOk("description"); ok && v.IsString() {
+		s := v.AsString()
+		state.Description = &s
+	}
+	if v, ok := old.GetOk("value"); ok && v.IsString() {
+		state.Value = v.AsString()
+	}
+	return infer.MigrationResult[TeamAccessTokenState]{Result: &state}, nil
+}
+
+func teamAccessTokenID(org, team, name, tokenID string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", org, team, name, tokenID)
 }
 
 func splitTeamAccessTokenID(id string) (string, string, string, string, error) {
 	// format: organization/teamName/tokenName/tokenID
 	s := strings.Split(id, "/")
 	if len(s) != 4 {
-		return "", "", "", "", fmt.Errorf("%q is invalid, must contain a single slash ('/')", id)
+		return "", "", "", "", fmt.Errorf("%q is invalid, must be of the form organization/team/name/tokenId", id)
 	}
 	return s[0], s[1], s[2], s[3], nil
+}
+
+func stringPtrIfNonEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/provider/pkg/resources/team_access_token_test.go
+++ b/provider/pkg/resources/team_access_token_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+)
+
+// State written by the pre-infer TeamAccessToken implementation embedded a
+// duplicate `__inputs` map alongside the real outputs. After migrating to
+// infer, decoding such state fails with "Unrecognized field '__inputs'" unless
+// migrateTeamAccessTokenLegacyInputs runs first.
+func TestTeamAccessTokenLegacyInputsMigration(t *testing.T) {
+	t.Run("migrates legacy state", func(t *testing.T) {
+		legacyInputs := property.NewMap(map[string]property.Value{
+			"name":             property.New("test-token"),
+			"organizationName": property.New("my-org"),
+			"teamName":         property.New("my-team"),
+			"description":      property.New("example team token"),
+		})
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs":         property.New(legacyInputs),
+			"name":             property.New("test-token"),
+			"organizationName": property.New("my-org"),
+			"teamName":         property.New("my-team"),
+			"description":      property.New("example team token"),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateTeamAccessTokenLegacyInputs(t.Context(), legacy)
+		require.NoError(t, err)
+		desc := "example team token"
+		assert.Equal(t, &TeamAccessTokenState{
+			TeamAccessTokenInput: TeamAccessTokenInput{
+				Name:             "test-token",
+				OrganizationName: "my-org",
+				TeamName:         "my-team",
+				Description:      &desc,
+			},
+			Value: "tok-secret-value",
+		}, got.Result)
+	})
+
+	t.Run("migrates legacy state without description", func(t *testing.T) {
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs":         property.New(property.NewMap(nil)),
+			"name":             property.New("test-token"),
+			"organizationName": property.New("my-org"),
+			"teamName":         property.New("my-team"),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateTeamAccessTokenLegacyInputs(t.Context(), legacy)
+		require.NoError(t, err)
+		assert.Equal(t, &TeamAccessTokenState{
+			TeamAccessTokenInput: TeamAccessTokenInput{
+				Name:             "test-token",
+				OrganizationName: "my-org",
+				TeamName:         "my-team",
+			},
+			Value: "tok-secret-value",
+		}, got.Result)
+	})
+
+	t.Run("no-op for already-migrated state", func(t *testing.T) {
+		current := property.NewMap(map[string]property.Value{
+			"name":             property.New("test-token"),
+			"organizationName": property.New("my-org"),
+			"teamName":         property.New("my-team"),
+			"value":            property.New("tok-secret-value"),
+		})
+
+		got, err := migrateTeamAccessTokenLegacyInputs(t.Context(), current)
+		require.NoError(t, err)
+		assert.Nil(t, got.Result, "migration must not fire when __inputs is absent")
+	})
+
+	t.Run("registered on the resource", func(t *testing.T) {
+		migrations := (&TeamAccessToken{}).StateMigrations(t.Context())
+		assert.Len(t, migrations, 1)
+	})
+}

--- a/sdk/dotnet/AccessToken.cs
+++ b/sdk/dotnet/AccessToken.cs
@@ -10,7 +10,7 @@ using Pulumi.Serialization;
 namespace Pulumi.PulumiService
 {
     /// <summary>
-    /// Access tokens allow a user to authenticate against the Pulumi Cloud
+    /// Access tokens allow a user to authenticate against the Pulumi Cloud.
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:AccessToken")]
     public partial class AccessToken : global::Pulumi.CustomResource
@@ -53,6 +53,10 @@ namespace Pulumi.PulumiService
                 AdditionalSecretOutputs =
                 {
                     "value",
+                },
+                ReplaceOnChanges =
+                {
+                    "description",
                 },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);

--- a/sdk/dotnet/OrgAccessToken.cs
+++ b/sdk/dotnet/OrgAccessToken.cs
@@ -72,6 +72,13 @@ namespace Pulumi.PulumiService
                 {
                     "value",
                 },
+                ReplaceOnChanges =
+                {
+                    "admin",
+                    "description",
+                    "name",
+                    "organizationName",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -101,7 +108,7 @@ namespace Pulumi.PulumiService
         public Input<bool>? Admin { get; set; }
 
         /// <summary>
-        /// Optional. Team description.
+        /// Optional. Description for the token.
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }

--- a/sdk/dotnet/TeamAccessToken.cs
+++ b/sdk/dotnet/TeamAccessToken.cs
@@ -72,6 +72,13 @@ namespace Pulumi.PulumiService
                 {
                     "value",
                 },
+                ReplaceOnChanges =
+                {
+                    "description",
+                    "name",
+                    "organizationName",
+                    "teamName",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -95,7 +102,7 @@ namespace Pulumi.PulumiService
     public sealed class TeamAccessTokenArgs : global::Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Optional. Team description.
+        /// Optional. Description for the token.
         /// </summary>
         [Input("description")]
         public Input<string>? Description { get; set; }

--- a/sdk/go/pulumiservice/accessToken.go
+++ b/sdk/go/pulumiservice/accessToken.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// Access tokens allow a user to authenticate against the Pulumi Cloud
+// Access tokens allow a user to authenticate against the Pulumi Cloud.
 type AccessToken struct {
 	pulumi.CustomResourceState
 
@@ -36,6 +36,10 @@ func NewAccessToken(ctx *pulumi.Context,
 		"value",
 	})
 	opts = append(opts, secrets)
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"description",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource AccessToken
 	err := ctx.RegisterResource("pulumiservice:index:AccessToken", name, args, &resource, opts...)

--- a/sdk/go/pulumiservice/orgAccessToken.go
+++ b/sdk/go/pulumiservice/orgAccessToken.go
@@ -48,6 +48,13 @@ func NewOrgAccessToken(ctx *pulumi.Context,
 		"value",
 	})
 	opts = append(opts, secrets)
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"admin",
+		"description",
+		"name",
+		"organizationName",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource OrgAccessToken
 	err := ctx.RegisterResource("pulumiservice:index:OrgAccessToken", name, args, &resource, opts...)
@@ -83,7 +90,7 @@ func (OrgAccessTokenState) ElementType() reflect.Type {
 type orgAccessTokenArgs struct {
 	// Optional. True if this is an admin token.
 	Admin *bool `pulumi:"admin"`
-	// Optional. Team description.
+	// Optional. Description for the token.
 	Description *string `pulumi:"description"`
 	// The name for the token.
 	Name string `pulumi:"name"`
@@ -95,7 +102,7 @@ type orgAccessTokenArgs struct {
 type OrgAccessTokenArgs struct {
 	// Optional. True if this is an admin token.
 	Admin pulumi.BoolPtrInput
-	// Optional. Team description.
+	// Optional. Description for the token.
 	Description pulumi.StringPtrInput
 	// The name for the token.
 	Name pulumi.StringInput

--- a/sdk/go/pulumiservice/teamAccessToken.go
+++ b/sdk/go/pulumiservice/teamAccessToken.go
@@ -48,6 +48,13 @@ func NewTeamAccessToken(ctx *pulumi.Context,
 		"value",
 	})
 	opts = append(opts, secrets)
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"description",
+		"name",
+		"organizationName",
+		"teamName",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource TeamAccessToken
 	err := ctx.RegisterResource("pulumiservice:index:TeamAccessToken", name, args, &resource, opts...)
@@ -81,7 +88,7 @@ func (TeamAccessTokenState) ElementType() reflect.Type {
 }
 
 type teamAccessTokenArgs struct {
-	// Optional. Team description.
+	// Optional. Description for the token.
 	Description *string `pulumi:"description"`
 	// The name for the token. This must be unique amongst all machine tokens within your organization.
 	Name string `pulumi:"name"`
@@ -93,7 +100,7 @@ type teamAccessTokenArgs struct {
 
 // The set of arguments for constructing a TeamAccessToken resource.
 type TeamAccessTokenArgs struct {
-	// Optional. Team description.
+	// Optional. Description for the token.
 	Description pulumi.StringPtrInput
 	// The name for the token. This must be unique amongst all machine tokens within your organization.
 	Name pulumi.StringInput

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/AccessToken.java
@@ -14,7 +14,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 /**
- * Access tokens allow a user to authenticate against the Pulumi Cloud
+ * Access tokens allow a user to authenticate against the Pulumi Cloud.
  * 
  */
 @ResourceType(type="pulumiservice:index:AccessToken")

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrgAccessTokenArgs.java
@@ -34,14 +34,14 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
     }
 
     /**
-     * Optional. Team description.
+     * Optional. Description for the token.
      * 
      */
     @Import(name="description")
     private @Nullable Output<String> description;
 
     /**
-     * @return Optional. Team description.
+     * @return Optional. Description for the token.
      * 
      */
     public Optional<Output<String>> description() {
@@ -127,7 +127,7 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param description Optional. Team description.
+         * @param description Optional. Description for the token.
          * 
          * @return builder
          * 
@@ -138,7 +138,7 @@ public final class OrgAccessTokenArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param description Optional. Team description.
+         * @param description Optional. Description for the token.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessTokenArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamAccessTokenArgs.java
@@ -17,14 +17,14 @@ public final class TeamAccessTokenArgs extends com.pulumi.resources.ResourceArgs
     public static final TeamAccessTokenArgs Empty = new TeamAccessTokenArgs();
 
     /**
-     * Optional. Team description.
+     * Optional. Description for the token.
      * 
      */
     @Import(name="description")
     private @Nullable Output<String> description;
 
     /**
-     * @return Optional. Team description.
+     * @return Optional. Description for the token.
      * 
      */
     public Optional<Output<String>> description() {
@@ -104,7 +104,7 @@ public final class TeamAccessTokenArgs extends com.pulumi.resources.ResourceArgs
         }
 
         /**
-         * @param description Optional. Team description.
+         * @param description Optional. Description for the token.
          * 
          * @return builder
          * 
@@ -115,7 +115,7 @@ public final class TeamAccessTokenArgs extends com.pulumi.resources.ResourceArgs
         }
 
         /**
-         * @param description Optional. Team description.
+         * @param description Optional. Description for the token.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/accessToken.ts
+++ b/sdk/nodejs/accessToken.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
 /**
- * Access tokens allow a user to authenticate against the Pulumi Cloud
+ * Access tokens allow a user to authenticate against the Pulumi Cloud.
  */
 export class AccessToken extends pulumi.CustomResource {
     /**
@@ -66,6 +66,8 @@ export class AccessToken extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["value"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
+        const replaceOnChanges = { replaceOnChanges: ["description"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(AccessToken.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/orgAccessToken.ts
+++ b/sdk/nodejs/orgAccessToken.ts
@@ -87,6 +87,8 @@ export class OrgAccessToken extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["value"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
+        const replaceOnChanges = { replaceOnChanges: ["admin", "description", "name", "organizationName"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(OrgAccessToken.__pulumiType, name, resourceInputs, opts);
     }
 }
@@ -100,7 +102,7 @@ export interface OrgAccessTokenArgs {
      */
     admin?: pulumi.Input<boolean>;
     /**
-     * Optional. Team description.
+     * Optional. Description for the token.
      */
     description?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/teamAccessToken.ts
+++ b/sdk/nodejs/teamAccessToken.ts
@@ -90,6 +90,8 @@ export class TeamAccessToken extends pulumi.CustomResource {
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
         const secretOpts = { additionalSecretOutputs: ["value"] };
         opts = pulumi.mergeOptions(opts, secretOpts);
+        const replaceOnChanges = { replaceOnChanges: ["description", "name", "organizationName", "teamName"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(TeamAccessToken.__pulumiType, name, resourceInputs, opts);
     }
 }
@@ -99,7 +101,7 @@ export class TeamAccessToken extends pulumi.CustomResource {
  */
 export interface TeamAccessTokenArgs {
     /**
-     * Optional. Team description.
+     * Optional. Description for the token.
      */
     description?: pulumi.Input<string>;
     /**

--- a/sdk/python/pulumi_pulumiservice/access_token.py
+++ b/sdk/python/pulumi_pulumiservice/access_token.py
@@ -48,7 +48,7 @@ class AccessToken(pulumi.CustomResource):
                  description: Optional[pulumi.Input[_builtins.str]] = None,
                  __props__=None):
         """
-        Access tokens allow a user to authenticate against the Pulumi Cloud
+        Access tokens allow a user to authenticate against the Pulumi Cloud.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
@@ -61,7 +61,7 @@ class AccessToken(pulumi.CustomResource):
                  args: AccessTokenArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
-        Access tokens allow a user to authenticate against the Pulumi Cloud
+        Access tokens allow a user to authenticate against the Pulumi Cloud.
 
         :param str resource_name: The name of the resource.
         :param AccessTokenArgs args: The arguments to use to populate this resource's properties.
@@ -94,6 +94,8 @@ class AccessToken(pulumi.CustomResource):
             __props__.__dict__["value"] = None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["description"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(AccessToken, __self__).__init__(
             'pulumiservice:index:AccessToken',
             resource_name,

--- a/sdk/python/pulumi_pulumiservice/org_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/org_access_token.py
@@ -28,7 +28,7 @@ class OrgAccessTokenArgs:
         :param pulumi.Input[_builtins.str] name: The name for the token.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token.
-        :param pulumi.Input[_builtins.str] description: Optional. Team description.
+        :param pulumi.Input[_builtins.str] description: Optional. Description for the token.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
@@ -79,7 +79,7 @@ class OrgAccessTokenArgs:
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
         """
-        Optional. Team description.
+        Optional. Description for the token.
         """
         return pulumi.get(self, "description")
 
@@ -105,7 +105,7 @@ class OrgAccessToken(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.bool] admin: Optional. True if this is an admin token.
-        :param pulumi.Input[_builtins.str] description: Optional. Team description.
+        :param pulumi.Input[_builtins.str] description: Optional. Description for the token.
         :param pulumi.Input[_builtins.str] name: The name for the token.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         """
@@ -159,6 +159,8 @@ class OrgAccessToken(pulumi.CustomResource):
             __props__.__dict__["value"] = None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["admin", "description", "name", "organizationName"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(OrgAccessToken, __self__).__init__(
             'pulumiservice:index:OrgAccessToken',
             resource_name,

--- a/sdk/python/pulumi_pulumiservice/team_access_token.py
+++ b/sdk/python/pulumi_pulumiservice/team_access_token.py
@@ -28,7 +28,7 @@ class TeamAccessTokenArgs:
         :param pulumi.Input[_builtins.str] name: The name for the token. This must be unique amongst all machine tokens within your organization.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         :param pulumi.Input[_builtins.str] team_name: The team name.
-        :param pulumi.Input[_builtins.str] description: Optional. Team description.
+        :param pulumi.Input[_builtins.str] description: Optional. Description for the token.
         """
         pulumi.set(__self__, "name", name)
         pulumi.set(__self__, "organization_name", organization_name)
@@ -76,7 +76,7 @@ class TeamAccessTokenArgs:
     @pulumi.getter
     def description(self) -> Optional[pulumi.Input[_builtins.str]]:
         """
-        Optional. Team description.
+        Optional. Description for the token.
         """
         return pulumi.get(self, "description")
 
@@ -101,7 +101,7 @@ class TeamAccessToken(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[_builtins.str] description: Optional. Team description.
+        :param pulumi.Input[_builtins.str] description: Optional. Description for the token.
         :param pulumi.Input[_builtins.str] name: The name for the token. This must be unique amongst all machine tokens within your organization.
         :param pulumi.Input[_builtins.str] organization_name: The organization's name.
         :param pulumi.Input[_builtins.str] team_name: The team name.
@@ -156,6 +156,8 @@ class TeamAccessToken(pulumi.CustomResource):
             __props__.__dict__["value"] = None
         secret_opts = pulumi.ResourceOptions(additional_secret_outputs=["value"])
         opts = pulumi.ResourceOptions.merge(opts, secret_opts)
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["description", "name", "organizationName", "teamName"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(TeamAccessToken, __self__).__init__(
             'pulumiservice:index:TeamAccessToken',
             resource_name,


### PR DESCRIPTION
I figured it would be ideal to finish out the last migration before we move on to the next one. LLMs make this really easy to finish.