### PR TITLE
Fix CI

### DIFF
--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -70,6 +70,7 @@ func TestTeamsExample(t *testing.T) {
 		opttest.YarnLink("@pulumi/pulumiservice"),
 		opttest.StackName(randomStackName()),
 	)
+	test.SetConfig(t, "digits", generateRandomFiveDigits())
 	runPulumiTest(t, test)
 }
 

--- a/examples/ts-teams/index.ts
+++ b/examples/ts-teams/index.ts
@@ -1,9 +1,11 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as service from "@pulumi/pulumiservice";
 
+const config = new pulumi.Config();
+
 const team = new service.Team("team", {
     description: "This was created with Pulumi",
-    name: "brand-new-ts-team",
+    name: "brand-new-ts-team-" + config.require("digits"),
     displayName: "PulumiUP Team",
     organizationName: process.env.PULUMI_TEST_OWNER || "service-provider-test-org",
     members: ["pulumi-bot", "service-provider-example-user"],

--- a/infra/test-aws-oidc/Pulumi.yaml
+++ b/infra/test-aws-oidc/Pulumi.yaml
@@ -60,6 +60,10 @@ resources:
       # returns ValidationError("DurationSeconds exceeds MaxSessionDuration").
       # 43200s (12h) is the AWS-imposed maximum.
       maxSessionDuration: 43200
+      tags:
+        Owner: pulumi/pulumi-pulumiservice # Prevents automatic cleanup in this account
+        Project: ${pulumi.project}
+        Stack: ${pulumi.stack}
       # The IAM condition key prefix is the issuer host+path, so the keys
       # are dynamic. Pulumi YAML interpolates `${...}` inside map keys, so
       # we can build the policy as a structured object and hand it to


### PR DESCRIPTION
This fix addressed 2 errors:

- It gives the team generated in `examples/ts-teams/index.ts` a unique name to prevent conflicts.
- It prevents the IAM role needed for CI from being reaped (already applied locally).

Fixes #806 
Fixes #809 