### PR TITLE
Migrate `*Permission` resources to `infer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 - Removed the numeric `version` field from `PolicyGroup.policyPacks` inputs; it is now output-only, since the value is server-derived from `versionTag`. Use `versionTag` to pin pack versions. [#737](https://github.com/pulumi/pulumi-pulumiservice/issues/737)
+- `TeamStackPermission.permission` is no longer marked `plain` in the schema. The output is now an `Output<TeamStackPermissionScope>` rather than a plain value; consumers reading `myPerm.permission` need `.apply(...)` to access the underlying value. The input side is strictly more permissive — callers may now wire `permission` to another resource's output. The Go SDK type also changes from `float64` to `int` to match the wire format.
 
 ### Improvements
 - Added `installationId` to `DeploymentSettings.vcs` to disambiguate when an organization has multiple integrations of the same provider type (e.g., two GitHub Apps installed against different sets of repos). When omitted, the API resolves the integration automatically from `provider` and `repository` as before.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 - Removed the numeric `version` field from `PolicyGroup.policyPacks` inputs; it is now output-only, since the value is server-derived from `versionTag`. Use `versionTag` to pin pack versions. [#737](https://github.com/pulumi/pulumi-pulumiservice/issues/737)
 - `TeamStackPermission.permission` is no longer marked `plain` in the schema. The output is now an `Output<TeamStackPermissionScope>` rather than a plain value; consumers reading `myPerm.permission` need `.apply(...)` to access the underlying value. The input side is strictly more permissive — callers may now wire `permission` to another resource's output. The Go SDK type also changes from `float64` to `int` to match the wire format.
+- `TeamEnvironmentPermission` outputs (`organization`, `team`, `environment`, `permission`) are now typed as definitely-present (`Output<string>`, `Output<EnvironmentPermission>`) rather than optional (`Output<string | undefined>`). The values were always populated; the schema previously misrepresented them.
 
 ### Improvements
 - Added `installationId` to `DeploymentSettings.vcs` to disambiguate when an organization has multiple integrations of the same provider type (e.g., two GitHub Apps installed against different sets of repos). When omitted, the API resolves the integration automatically from `provider` and `repository` as before.

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -926,7 +926,7 @@
       ]
     },
     "pulumiservice:index:TeamStackPermissionScope": {
-      "type": "number",
+      "type": "integer",
       "enum": [
         {
           "name": "read",
@@ -2738,66 +2738,69 @@
       "properties": {
         "organization": {
           "type": "string",
-          "description": "The organization or the personal account name of the stack."
+          "description": "The organization or the personal account name of the stack.",
+          "replaceOnChanges": true
         },
         "permission": {
           "$ref": "#/types/pulumiservice:index:TeamStackPermissionScope",
-          "plain": true,
-          "description": "Sets the permission level that this team will be granted to the stack."
+          "description": "Sets the permission level that this team will be granted to the stack.",
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
-          "description": "The project name for this stack."
+          "description": "The project name for this stack.",
+          "replaceOnChanges": true
         },
         "stack": {
           "type": "string",
-          "description": "The name of the stack that the team will be granted permissions to."
+          "description": "The name of the stack that the team will be granted permissions to.",
+          "replaceOnChanges": true
         },
         "team": {
           "type": "string",
-          "description": "The name of the team to grant this stack permissions to. This is not the display name."
+          "description": "The name of the team to grant this stack permissions to. This is not the display name.",
+          "replaceOnChanges": true
         }
       },
       "required": [
-        "team",
         "organization",
         "project",
         "stack",
+        "team",
         "permission"
       ],
       "inputProperties": {
         "organization": {
           "type": "string",
           "description": "The organization or the personal account name of the stack.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "permission": {
           "$ref": "#/types/pulumiservice:index:TeamStackPermissionScope",
-          "plain": true,
           "description": "Sets the permission level that this team will be granted to the stack.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
           "description": "The project name for this stack.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "stack": {
           "type": "string",
           "description": "The name of the stack that the team will be granted permissions to.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "team": {
           "type": "string",
           "description": "The name of the team to grant this stack permissions to. This is not the display name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [
-        "team",
         "organization",
         "project",
         "stack",
+        "team",
         "permission"
       ]
     },

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -2623,55 +2623,73 @@
       "properties": {
         "environment": {
           "type": "string",
-          "description": "Environment name."
+          "description": "Environment name.",
+          "replaceOnChanges": true
         },
         "maxOpenDuration": {
           "type": "string",
-          "description": "The maximum duration for which members of this team may open the environment."
+          "description": "The maximum duration for which members of this team may open the environment.",
+          "replaceOnChanges": true
         },
         "organization": {
           "type": "string",
-          "description": "Organization name."
+          "description": "Organization name.",
+          "replaceOnChanges": true
         },
         "permission": {
           "$ref": "#/types/pulumiservice:index:EnvironmentPermission",
-          "description": "Which permission level to grant to the specified team."
+          "description": "Which permission level to grant to the specified team.",
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
           "description": "Project name.",
-          "default": "default"
+          "default": "default",
+          "replaceOnChanges": true
         },
         "team": {
           "type": "string",
-          "description": "Team name."
+          "description": "Team name.",
+          "replaceOnChanges": true
         }
       },
+      "required": [
+        "organization",
+        "team",
+        "environment",
+        "permission"
+      ],
       "inputProperties": {
         "environment": {
           "type": "string",
-          "description": "Environment name."
+          "description": "Environment name.",
+          "replaceOnChanges": true
         },
         "maxOpenDuration": {
           "type": "string",
-          "description": "The maximum duration for which members of this team may open the environment."
+          "description": "The maximum duration for which members of this team may open the environment.",
+          "replaceOnChanges": true
         },
         "organization": {
           "type": "string",
-          "description": "Organization name."
+          "description": "Organization name.",
+          "replaceOnChanges": true
         },
         "permission": {
           "$ref": "#/types/pulumiservice:index:EnvironmentPermission",
-          "description": "Which permission level to grant to the specified team."
+          "description": "Which permission level to grant to the specified team.",
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
           "description": "Project name.",
-          "default": "default"
+          "default": "default",
+          "replaceOnChanges": true
         },
         "team": {
           "type": "string",
-          "description": "Team name."
+          "description": "Team name.",
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -12,26 +12,6 @@
   "license": "Apache-2.0",
   "publisher": "Pulumi",
   "types": {
-    "pulumiservice:index:TeamStackPermissionScope": {
-      "type": "number",
-      "enum": [
-        {
-          "name": "read",
-          "description": "Grants read permissions to stack.",
-          "value": 101
-        },
-        {
-          "name": "edit",
-          "description": "Grants edit permissions to stack.",
-          "value": 102
-        },
-        {
-          "name": "admin",
-          "description": "Grants admin permissions to stack.",
-          "value": 103
-        }
-      ]
-    },
     "pulumiservice:index:WebhookFormat": {
       "type": "string",
       "enum": [
@@ -1310,74 +1290,6 @@
         "project",
         "stack",
         "tags"
-      ]
-    },
-    "pulumiservice:index:TeamStackPermission": {
-      "description": "Grants a team permissions to the specified stack.",
-      "inputProperties": {
-        "team": {
-          "description": "The name of the team to grant this stack permissions to. This is not the display name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "organization": {
-          "description": "The organization or the personal account name of the stack.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "project": {
-          "description": "The project name for this stack.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "stack": {
-          "description": "The name of the stack that the team will be granted permissions to.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "permission": {
-          "$ref": "#/types/pulumiservice:index:TeamStackPermissionScope",
-          "plain": true,
-          "description": "Sets the permission level that this team will be granted to the stack.",
-          "willReplaceOnChanges": true
-        }
-      },
-      "requiredInputs": [
-        "team",
-        "organization",
-        "project",
-        "stack",
-        "permission"
-      ],
-      "properties": {
-        "team": {
-          "description": "The name of the team to grant this stack permissions to. This is not the display name.",
-          "type": "string"
-        },
-        "organization": {
-          "description": "The organization or the personal account name of the stack.",
-          "type": "string"
-        },
-        "project": {
-          "description": "The project name for this stack.",
-          "type": "string"
-        },
-        "stack": {
-          "description": "The name of the stack that the team will be granted permissions to.",
-          "type": "string"
-        },
-        "permission": {
-          "$ref": "#/types/pulumiservice:index:TeamStackPermissionScope",
-          "plain": true,
-          "description": "Sets the permission level that this team will be granted to the stack."
-        }
-      },
-      "required": [
-        "team",
-        "organization",
-        "project",
-        "stack",
-        "permission"
       ]
     },
     "pulumiservice:index:Environment": {

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -565,31 +565,6 @@
       },
       "type": "object"
     },
-    "pulumiservice:index:EnvironmentPermission": {
-      "type": "string",
-      "enum": [
-        {
-          "description": "No permissions.",
-          "value": "none"
-        },
-        {
-          "description": "Permission to read environment definition only.",
-          "value": "read"
-        },
-        {
-          "description": "Permission to open and read the environment.",
-          "value": "open"
-        },
-        {
-          "description": "Permission to open, read and update the environment.",
-          "value": "write"
-        },
-        {
-          "description": "Permission for all operations on the environment.",
-          "value": "admin"
-        }
-      ]
-    },
     "pulumiservice:index:TemplateSourceDestination": {
       "type": "object",
       "properties": {
@@ -1350,69 +1325,6 @@
         "organization",
         "name",
         "yaml"
-      ]
-    },
-    "pulumiservice:index:TeamEnvironmentPermission": {
-      "description": "A permission for a team to use an environment.",
-      "properties": {
-        "organization": {
-          "description": "Organization name.",
-          "type": "string"
-        },
-        "team": {
-          "description": "Team name.",
-          "type": "string"
-        },
-        "project": {
-          "description": "Project name.",
-          "default": "default",
-          "type": "string"
-        },
-        "environment": {
-          "description": "Environment name.",
-          "type": "string"
-        },
-        "permission": {
-          "description": "Which permission level to grant to the specified team.",
-          "$ref": "#/types/pulumiservice:index:EnvironmentPermission"
-        },
-        "maxOpenDuration": {
-          "description": "The maximum duration for which members of this team may open the environment.",
-          "type": "string"
-        }
-      },
-      "inputProperties": {
-        "organization": {
-          "description": "Organization name.",
-          "type": "string"
-        },
-        "team": {
-          "description": "Team name.",
-          "type": "string"
-        },
-        "project": {
-          "description": "Project name.",
-          "default": "default",
-          "type": "string"
-        },
-        "environment": {
-          "description": "Environment name.",
-          "type": "string"
-        },
-        "permission": {
-          "description": "Which permission level to grant to the specified team.",
-          "$ref": "#/types/pulumiservice:index:EnvironmentPermission"
-        },
-        "maxOpenDuration": {
-          "description": "The maximum duration for which members of this team may open the environment.",
-          "type": "string"
-        }
-      },
-      "requiredInputs": [
-        "organization",
-        "team",
-        "environment",
-        "permission"
       ]
     },
     "pulumiservice:index:EnvironmentVersionTag": {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -103,6 +103,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			infer.Resource(&resources.Team{}),
 			infer.Resource(&resources.TeamAccessToken{}),
 			infer.Resource(&resources.TeamRoleAssignment{}),
+			infer.Resource(&resources.TeamStackPermission{}),
 		).
 		WithFunctions(
 			infer.Function(&functions.GetCurrentUserFunction{}),
@@ -252,9 +253,6 @@ func (k *pulumiserviceProvider) Configure(
 			Client: client,
 		},
 		&resources.PulumiServiceStackTagsResource{
-			Client: client,
-		},
-		&resources.TeamStackPermissionResource{
 			Client: client,
 		},
 		&resources.PulumiServiceDeploymentSettingsResource{

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -102,6 +102,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			infer.Resource(&resources.TTLSchedule{}),
 			infer.Resource(&resources.Team{}),
 			infer.Resource(&resources.TeamAccessToken{}),
+			infer.Resource(&resources.TeamEnvironmentPermission{}),
 			infer.Resource(&resources.TeamRoleAssignment{}),
 			infer.Resource(&resources.TeamStackPermission{}),
 		).
@@ -264,9 +265,6 @@ func (k *pulumiserviceProvider) Configure(
 		&resources.PulumiServiceEnvironmentResource{
 			Client:         escClient,
 			MetadataClient: client,
-		},
-		&resources.PulumiServiceTeamEnvironmentPermissionResource{
-			Client: client,
 		},
 		&resources.PulumiServiceEnvironmentVersionTagResource{
 			Client: escClient,

--- a/provider/pkg/resources/team_environment_perm.go
+++ b/provider/pkg/resources/team_environment_perm.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -6,276 +20,254 @@ import (
 	"strings"
 	"time"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
 )
 
-type PulumiServiceTeamEnvironmentPermissionResource struct {
-	Client pulumiapi.TeamClient
+type EnvironmentPermission string
+
+const (
+	EnvironmentPermissionNone  EnvironmentPermission = "none"
+	EnvironmentPermissionRead  EnvironmentPermission = "read"
+	EnvironmentPermissionOpen  EnvironmentPermission = "open"
+	EnvironmentPermissionWrite EnvironmentPermission = "write"
+	EnvironmentPermissionAdmin EnvironmentPermission = "admin"
+)
+
+func (EnvironmentPermission) Values() []infer.EnumValue[EnvironmentPermission] {
+	return []infer.EnumValue[EnvironmentPermission]{
+		{Value: EnvironmentPermissionNone, Description: "No permissions."},
+		{Value: EnvironmentPermissionRead, Description: "Permission to read environment definition only."},
+		{Value: EnvironmentPermissionOpen, Description: "Permission to open and read the environment."},
+		{Value: EnvironmentPermissionWrite, Description: "Permission to open, read and update the environment."},
+		{Value: EnvironmentPermissionAdmin, Description: "Permission for all operations on the environment."},
+	}
+}
+
+type TeamEnvironmentPermission struct{}
+
+type (
+	tepIn  = TeamEnvironmentPermissionInput
+	tepOut = TeamEnvironmentPermissionState
+)
+
+var (
+	_ infer.CustomCheck[tepIn]          = &TeamEnvironmentPermission{}
+	_ infer.CustomDiff[tepIn, tepOut]   = &TeamEnvironmentPermission{}
+	_ infer.CustomCreate[tepIn, tepOut] = &TeamEnvironmentPermission{}
+	_ infer.CustomDelete[tepOut]        = &TeamEnvironmentPermission{}
+	_ infer.CustomRead[tepIn, tepOut]   = &TeamEnvironmentPermission{}
+)
+
+func (*TeamEnvironmentPermission) Annotate(a infer.Annotator) {
+	a.Describe(&TeamEnvironmentPermission{}, "A permission for a team to use an environment.")
+	a.SetToken("index", "TeamEnvironmentPermission")
 }
 
 type TeamEnvironmentPermissionInput struct {
-	Organization    string `pulumi:"organization"`
-	Team            string `pulumi:"team"`
-	Environment     string `pulumi:"environment"`
-	Project         string `pulumi:"project"`
-	Permission      string `pulumi:"permission"`
-	MaxOpenDuration string `pulumi:"maxOpenDuration"`
+	Organization    string                `pulumi:"organization"              provider:"replaceOnChanges"`
+	Team            string                `pulumi:"team"                      provider:"replaceOnChanges"`
+	Project         string                `pulumi:"project,optional"          provider:"replaceOnChanges"`
+	Environment     string                `pulumi:"environment"               provider:"replaceOnChanges"`
+	Permission      EnvironmentPermission `pulumi:"permission"                provider:"replaceOnChanges"`
+	MaxOpenDuration *string               `pulumi:"maxOpenDuration,optional"  provider:"replaceOnChanges"`
 }
 
-func (i *TeamEnvironmentPermissionInput) ToPropertyMap() resource.PropertyMap {
-	return util.ToPropertyMap(*i)
+func (i *TeamEnvironmentPermissionInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Organization, "Organization name.")
+	a.Describe(&i.Team, "Team name.")
+	a.Describe(&i.Project, "Project name.")
+	a.SetDefault(&i.Project, "default")
+	a.Describe(&i.Environment, "Environment name.")
+	a.Describe(&i.Permission, "Which permission level to grant to the specified team.")
+	a.Describe(
+		&i.MaxOpenDuration,
+		"The maximum duration for which members of this team may open the environment.",
+	)
 }
 
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) ToPulumiServiceTeamInput(
-	inputMap resource.PropertyMap,
-) (*TeamEnvironmentPermissionInput, error) {
-	input := TeamEnvironmentPermissionInput{}
-	return &input, util.FromPropertyMap(inputMap, &input)
+type TeamEnvironmentPermissionState struct {
+	TeamEnvironmentPermissionInput
 }
 
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Name() string {
-	return "pulumiservice:index:TeamEnvironmentPermission"
-}
-
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Check(
-	req *pulumirpc.CheckRequest,
-) (*pulumirpc.CheckResponse, error) {
-	// Work on the property map directly so we only touch fields the user
-	// actually supplied. Re-serializing the input struct would emit every
-	// tagged field (including empty strings), which introduces spurious
-	// diffs for optional fields that weren't present in state written by
-	// older provider versions.
-	news, err := plugin.UnmarshalProperties(req.GetNews(), util.StandardUnmarshal)
-	if err != nil {
-		return nil, err
+func (*TeamEnvironmentPermission) Check(
+	ctx context.Context, req infer.CheckRequest,
+) (infer.CheckResponse[TeamEnvironmentPermissionInput], error) {
+	// Strip an explicit empty-string maxOpenDuration before decoding.
+	// Provider versions 0.29.3–0.36.0 wrote `""` into state when the user
+	// did not set the field; treating that as "unset" keeps re-applies
+	// against that state from forcing a spurious replacement.
+	if v, ok := req.NewInputs.GetOk("maxOpenDuration"); ok && v.IsString() && v.AsString() == "" {
+		req.NewInputs = req.NewInputs.Delete("maxOpenDuration")
 	}
 
-	var failures []*pulumirpc.CheckFailure
-	if prop, ok := news["maxOpenDuration"]; ok {
-		if !prop.IsString() {
-			// Reject non-string values deterministically at preview; otherwise
-			// util.FromPropertyMap panics during Create when asserting a
-			// number into the string field.
-			failures = append(failures, &pulumirpc.CheckFailure{
+	i, failures, err := infer.DefaultCheck[TeamEnvironmentPermissionInput](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[TeamEnvironmentPermissionInput]{}, err
+	}
+	if i.MaxOpenDuration != nil {
+		d, perr := time.ParseDuration(*i.MaxOpenDuration)
+		if perr != nil {
+			failures = append(failures, p.CheckFailure{
 				Property: "maxOpenDuration",
-				Reason:   "maxOpenDuration property is present but can't be parsed as string",
+				Reason:   fmt.Sprintf("malformed duration: %v", perr),
 			})
-		} else {
-			raw := prop.StringValue()
-			if raw == "" {
-				// Treat an explicit empty string as "unset" to stay consistent
-				// with state saved before this field existed.
-				delete(news, "maxOpenDuration")
-			} else {
-				d, err := time.ParseDuration(raw)
-				if err != nil {
-					failures = append(failures, &pulumirpc.CheckFailure{
-						Property: "maxOpenDuration",
-						Reason:   fmt.Sprintf("malformed duration: %v", err),
-					})
-				} else if normalized := d.String(); normalized != raw {
-					// Normalize the duration to prevent spurious diffs.
-					news["maxOpenDuration"] = resource.NewStringProperty(normalized)
-				}
-			}
+		} else if normalized := d.String(); normalized != *i.MaxOpenDuration {
+			i.MaxOpenDuration = &normalized
 		}
 	}
+	return infer.CheckResponse[TeamEnvironmentPermissionInput]{Inputs: i, Failures: failures}, nil
+}
 
-	inputs, err := plugin.MarshalProperties(news, util.StandardMarshal)
-	if err != nil {
-		return nil, err
+func (*TeamEnvironmentPermission) Diff(
+	_ context.Context,
+	req infer.DiffRequest[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState],
+) (infer.DiffResponse, error) {
+	diff := map[string]p.PropertyDiff{}
+	add := func(key string) { diff[key] = p.PropertyDiff{Kind: p.UpdateReplace, InputDiff: true} }
+
+	if req.State.Organization != req.Inputs.Organization {
+		add("organization")
+	}
+	if req.State.Team != req.Inputs.Team {
+		add("team")
+	}
+	if req.State.Project != req.Inputs.Project {
+		add("project")
+	}
+	if req.State.Environment != req.Inputs.Environment {
+		add("environment")
+	}
+	if req.State.Permission != req.Inputs.Permission {
+		add("permission")
+	}
+	if normalizedDuration(req.State.MaxOpenDuration) != normalizedDuration(req.Inputs.MaxOpenDuration) {
+		add("maxOpenDuration")
 	}
 
-	return &pulumirpc.CheckResponse{
-		Inputs:   inputs,
-		Failures: failures,
+	return infer.DiffResponse{
+		HasChanges:          len(diff) > 0,
+		DetailedDiff:        diff,
+		DeleteBeforeReplace: true,
 	}, nil
 }
 
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Read(
-	req *pulumirpc.ReadRequest,
-) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-	permID, err := splitTeamEnvironmentPermissionID(req.GetId())
-	if err != nil {
-		return nil, err
+// normalizedDuration treats nil and an empty string as equivalent so a
+// pre-#752 empty-string in state does not diff against an absent field.
+func normalizedDuration(d *string) string {
+	if d == nil {
+		return ""
 	}
+	return *d
+}
 
-	request := pulumiapi.TeamEnvironmentSettingsRequest{
+func (*TeamEnvironmentPermission) Create(
+	ctx context.Context,
+	req infer.CreateRequest[TeamEnvironmentPermissionInput],
+) (infer.CreateResponse[TeamEnvironmentPermissionState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[TeamEnvironmentPermissionState]{
+			Output: TeamEnvironmentPermissionState{TeamEnvironmentPermissionInput: req.Inputs},
+		}, nil
+	}
+	apiReq, err := req.Inputs.toCreateRequest()
+	if err != nil {
+		return infer.CreateResponse[TeamEnvironmentPermissionState]{}, err
+	}
+	if err := config.GetClient(ctx).AddEnvironmentSettings(ctx, apiReq); err != nil {
+		return infer.CreateResponse[TeamEnvironmentPermissionState]{},
+			fmt.Errorf("error granting team environment permission: %w", err)
+	}
+	id := teamEnvironmentPermissionID{
+		Organization: req.Inputs.Organization,
+		Team:         req.Inputs.Team,
+		Project:      req.Inputs.Project,
+		Environment:  req.Inputs.Environment,
+	}
+	return infer.CreateResponse[TeamEnvironmentPermissionState]{
+		ID:     id.String(),
+		Output: TeamEnvironmentPermissionState{TeamEnvironmentPermissionInput: req.Inputs},
+	}, nil
+}
+
+func (*TeamEnvironmentPermission) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[TeamEnvironmentPermissionState],
+) (infer.DeleteResponse, error) {
+	apiReq := pulumiapi.TeamEnvironmentSettingsRequest{
+		Organization: req.State.Organization,
+		Team:         req.State.Team,
+		Project:      req.State.Project,
+		Environment:  req.State.Environment,
+	}
+	return infer.DeleteResponse{}, config.GetClient(ctx).RemoveEnvironmentSettings(ctx, apiReq)
+}
+
+func (*TeamEnvironmentPermission) Read(
+	ctx context.Context,
+	req infer.ReadRequest[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState],
+) (infer.ReadResponse[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState], error) {
+	permID, err := splitTeamEnvironmentPermissionID(req.ID)
+	if err != nil {
+		return infer.ReadResponse[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState]{}, err
+	}
+	apiReq := pulumiapi.TeamEnvironmentSettingsRequest{
 		Organization: permID.Organization,
 		Team:         permID.Team,
-		Environment:  permID.Environment,
 		Project:      permID.Project,
+		Environment:  permID.Environment,
 	}
-	permission, maxOpenDuration, err := tp.Client.GetTeamEnvironmentSettings(ctx, request)
+	permission, maxOpenDuration, err := config.GetClient(ctx).GetTeamEnvironmentSettings(ctx, apiReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get team environment permission: %w", err)
+		return infer.ReadResponse[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState]{},
+			fmt.Errorf("failed to get team environment permission: %w", err)
 	}
 	if permission == nil {
-		return &pulumirpc.ReadResponse{}, nil
+		return infer.ReadResponse[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState]{}, nil
 	}
-
 	inputs := TeamEnvironmentPermissionInput{
 		Organization: permID.Organization,
 		Team:         permID.Team,
 		Project:      permID.Project,
 		Environment:  permID.Environment,
-		Permission:   *permission,
+		Permission:   EnvironmentPermission(*permission),
 	}
 	if maxOpenDuration != nil {
-		inputs.MaxOpenDuration = (time.Duration)(*maxOpenDuration).String()
+		s := time.Duration(*maxOpenDuration).String()
+		inputs.MaxOpenDuration = &s
 	}
-
-	// Omit maxOpenDuration when it wasn't set on the remote resource; emitting
-	// an empty string would cause a spurious replacement on the next update
-	// against state written by providers that didn't have this field.
-	propertyMap := inputs.ToPropertyMap()
-	if inputs.MaxOpenDuration == "" {
-		delete(propertyMap, "maxOpenDuration")
-	}
-
-	properties, err := plugin.MarshalProperties(propertyMap, plugin.MarshalOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal inputs to properties: %w", err)
-	}
-	return &pulumirpc.ReadResponse{
-		Id:         req.Id,
-		Properties: properties,
-		Inputs:     properties,
+	return infer.ReadResponse[TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State:  TeamEnvironmentPermissionState{TeamEnvironmentPermissionInput: inputs},
 	}, nil
 }
 
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Create(
-	req *pulumirpc.CreateRequest,
-) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	var input TeamEnvironmentPermissionInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-
-	var maxOpenDuration *pulumiapi.Duration
-	if input.MaxOpenDuration != "" {
-		d, err := time.ParseDuration(input.MaxOpenDuration)
-		if err != nil {
-			return nil, err
-		}
-		maxOpenDuration = (*pulumiapi.Duration)(&d)
-	}
-
-	request := pulumiapi.CreateTeamEnvironmentSettingsRequest{
+func (i TeamEnvironmentPermissionInput) toCreateRequest() (
+	pulumiapi.CreateTeamEnvironmentSettingsRequest, error,
+) {
+	apiReq := pulumiapi.CreateTeamEnvironmentSettingsRequest{
 		TeamEnvironmentSettingsRequest: pulumiapi.TeamEnvironmentSettingsRequest{
-			Organization: input.Organization,
-			Team:         input.Team,
-			Project:      input.Project,
-			Environment:  input.Environment,
+			Organization: i.Organization,
+			Team:         i.Team,
+			Project:      i.Project,
+			Environment:  i.Environment,
 		},
-		Permission:      input.Permission,
-		MaxOpenDuration: maxOpenDuration,
+		Permission: string(i.Permission),
 	}
-
-	err = tp.Client.AddEnvironmentSettings(ctx, request)
-	if err != nil {
-		return nil, err
+	if i.MaxOpenDuration != nil {
+		d, err := time.ParseDuration(*i.MaxOpenDuration)
+		if err != nil {
+			return pulumiapi.CreateTeamEnvironmentSettingsRequest{},
+				fmt.Errorf("invalid maxOpenDuration %q: %w", *i.MaxOpenDuration, err)
+		}
+		mod := pulumiapi.Duration(d)
+		apiReq.MaxOpenDuration = &mod
 	}
-
-	environmentPermissionID := teamEnvironmentPermissionID{
-		Organization: input.Organization,
-		Team:         input.Team,
-		Project:      input.Project,
-		Environment:  input.Environment,
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         environmentPermissionID.String(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	var input TeamEnvironmentPermissionInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-	request := pulumiapi.TeamEnvironmentSettingsRequest{
-		Organization: input.Organization,
-		Team:         input.Team,
-		Project:      input.Project,
-		Environment:  input.Environment,
-	}
-	err = tp.Client.RemoveEnvironmentSettings(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	return &pbempty.Empty{}, nil
-}
-
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Diff(
-	req *pulumirpc.DiffRequest,
-) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(
-		req.GetOldInputs(),
-		plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true},
-	)
-	if err != nil {
-		return nil, err
-	}
-	news, err := plugin.UnmarshalProperties(
-		req.GetNews(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: false},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Provider versions 0.29.3–0.36.0 wrote `maxOpenDuration: ""` into state
-	// whenever the user did not set the field. #752 fixed the Check/Read
-	// paths, but state saved by those versions still carries the empty
-	// string. Without this normalization, the first preview after upgrading
-	// from that window would observe the key as deleted and force one more
-	// spurious replacement — the exact failure mode #751 set out to remove.
-	normalizeEmptyMaxOpenDuration(olds)
-	normalizeEmptyMaxOpenDuration(news)
-
-	var changedKeys []string
-	for _, k := range olds.Diff(news).ChangedKeys() {
-		changedKeys = append(changedKeys, string(k))
-	}
-
-	changes := pulumirpc.DiffResponse_DIFF_NONE
-	if len(changedKeys) > 0 {
-		changes = pulumirpc.DiffResponse_DIFF_SOME
-	}
-	return &pulumirpc.DiffResponse{
-		Changes:             changes,
-		Replaces:            changedKeys,
-		DeleteBeforeReplace: true,
-	}, nil
-}
-
-// normalizeEmptyMaxOpenDuration removes a zero-value `maxOpenDuration` so it
-// compares equal to an absent field. See Diff() for the history.
-func normalizeEmptyMaxOpenDuration(m resource.PropertyMap) {
-	if v, ok := m["maxOpenDuration"]; ok && v.IsString() && v.StringValue() == "" {
-		delete(m, "maxOpenDuration")
-	}
-}
-
-// Update does nothing because we always replace on changes, never an update
-func (tp *PulumiServiceTeamEnvironmentPermissionResource) Update(
-	_ *pulumirpc.UpdateRequest,
-) (*pulumirpc.UpdateResponse, error) {
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
+	return apiReq, nil
 }
 
 type teamEnvironmentPermissionID struct {
@@ -285,7 +277,7 @@ type teamEnvironmentPermissionID struct {
 	Environment  string
 }
 
-func (s *teamEnvironmentPermissionID) String() string {
+func (s teamEnvironmentPermissionID) String() string {
 	return fmt.Sprintf("%s/%s/%s+%s", s.Organization, s.Team, s.Project, s.Environment)
 }
 
@@ -294,17 +286,16 @@ func splitTeamEnvironmentPermissionID(id string) (teamEnvironmentPermissionID, e
 	if len(split) != 3 {
 		return teamEnvironmentPermissionID{}, fmt.Errorf("invalid id %q, expected 3 parts", id)
 	}
-
 	splitProjectEnv := strings.Split(split[2], "+")
-	if len(splitProjectEnv) == 1 {
+	switch len(splitProjectEnv) {
+	case 1:
 		return teamEnvironmentPermissionID{
 			Organization: split[0],
 			Team:         split[1],
 			Project:      "default",
 			Environment:  splitProjectEnv[0],
 		}, nil
-	}
-	if len(splitProjectEnv) == 2 {
+	case 2:
 		return teamEnvironmentPermissionID{
 			Organization: split[0],
 			Team:         split[1],
@@ -312,9 +303,7 @@ func splitTeamEnvironmentPermissionID(id string) (teamEnvironmentPermissionID, e
 			Environment:  splitProjectEnv[1],
 		}, nil
 	}
-
 	return teamEnvironmentPermissionID{}, fmt.Errorf(
-		"invalid id %q, expected environment name or project/environment in last part",
-		id,
+		"invalid id %q, expected environment name or project/environment in last part", id,
 	)
 }

--- a/provider/pkg/resources/team_environment_perm_test.go
+++ b/provider/pkg/resources/team_environment_perm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2026, Pulumi Corporation.
+// Copyright 2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,353 +21,211 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
 )
 
-// teamEnvPermClientMock satisfies pulumiapi.TeamClient for the handful of
-// tests below. Only the methods that TeamEnvironmentPermission actually calls
-// are wired up; the rest return zero values.
 type teamEnvPermClientMock struct {
-	getEnvSettingsFunc func() (*string, *pulumiapi.Duration, error)
-}
-
-func (*teamEnvPermClientMock) ListTeams(_ context.Context, _ string) ([]pulumiapi.Team, error) {
-	return nil, nil
-}
-
-func (*teamEnvPermClientMock) GetTeam(_ context.Context, _, _ string) (*pulumiapi.Team, error) {
-	return nil, nil
-}
-
-func (*teamEnvPermClientMock) CreateTeam(
-	_ context.Context, _, _, _, _, _ string, _ int64,
-) (*pulumiapi.Team, error) {
-	return nil, nil
-}
-
-func (*teamEnvPermClientMock) UpdateTeam(_ context.Context, _, _, _, _ string) error {
-	return nil
-}
-
-func (*teamEnvPermClientMock) DeleteTeam(_ context.Context, _, _ string) error { return nil }
-
-func (*teamEnvPermClientMock) AddMemberToTeam(_ context.Context, _, _, _ string) error { return nil }
-
-func (*teamEnvPermClientMock) DeleteMemberFromTeam(_ context.Context, _, _, _ string) error {
-	return nil
-}
-
-func (*teamEnvPermClientMock) AddStackPermission(
-	_ context.Context, _ pulumiapi.StackIdentifier, _ string, _ int,
-) error {
-	return nil
-}
-
-func (*teamEnvPermClientMock) RemoveStackPermission(
-	_ context.Context, _ pulumiapi.StackIdentifier, _ string,
-) error {
-	return nil
-}
-
-func (*teamEnvPermClientMock) GetTeamStackPermission(
-	_ context.Context, _ pulumiapi.StackIdentifier, _ string,
-) (*int, error) {
-	return nil, nil
-}
-
-func (*teamEnvPermClientMock) AddEnvironmentSettings(
-	_ context.Context, _ pulumiapi.CreateTeamEnvironmentSettingsRequest,
-) error {
-	return nil
-}
-
-func (*teamEnvPermClientMock) RemoveEnvironmentSettings(
-	_ context.Context, _ pulumiapi.TeamEnvironmentSettingsRequest,
-) error {
-	return nil
+	config.Client
+	getFunc func() (*string, *pulumiapi.Duration, error)
 }
 
 func (c *teamEnvPermClientMock) GetTeamEnvironmentSettings(
 	_ context.Context, _ pulumiapi.TeamEnvironmentSettingsRequest,
 ) (*string, *pulumiapi.Duration, error) {
-	return c.getEnvSettingsFunc()
+	return c.getFunc()
 }
 
-func newTeamEnvPermResource(client pulumiapi.TeamClient) *PulumiServiceTeamEnvironmentPermissionResource {
-	return &PulumiServiceTeamEnvironmentPermissionResource{Client: client}
-}
-
-func toStruct(t *testing.T, m resource.PropertyMap) *structpb.Struct {
+func newTeamEnvPermCheckRequest(t *testing.T, props map[string]property.Value) infer.CheckRequest {
 	t.Helper()
-	s, err := structpb.NewStruct(m.Mappable())
-	require.NoError(t, err)
-	return s
+	return infer.CheckRequest{NewInputs: property.NewMap(props)}
 }
 
-func TestTeamEnvironmentPermission_Check_OmitsUnsetMaxOpenDuration(t *testing.T) {
-	// Regression: when upgrading from a provider version that did not have
-	// maxOpenDuration, Check must not inject an empty-string maxOpenDuration
-	// into the returned inputs. Otherwise Diff sees a "new" key against the
-	// saved state and forces replacement.
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-
-	news := resource.PropertyMap{
-		"organization": resource.NewStringProperty("org"),
-		"team":         resource.NewStringProperty("team"),
-		"project":      resource.NewStringProperty("proj"),
-		"environment":  resource.NewStringProperty("env"),
-		"permission":   resource.NewStringProperty("open"),
+func TestTeamEnvironmentPermissionCheck(t *testing.T) {
+	r := &TeamEnvironmentPermission{}
+	base := func() map[string]property.Value {
+		return map[string]property.Value{
+			"organization": property.New("org"),
+			"team":         property.New("team"),
+			"project":      property.New("proj"),
+			"environment":  property.New("env"),
+			"permission":   property.New("open"),
+		}
 	}
 
-	resp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-	require.NoError(t, err)
-	assert.Empty(t, resp.Failures)
+	t.Run("omits unset maxOpenDuration", func(t *testing.T) {
+		// Regression: when upgrading from a provider version that did not have
+		// maxOpenDuration, Check must not inject a maxOpenDuration into the
+		// returned inputs.
+		resp, err := r.Check(t.Context(), newTeamEnvPermCheckRequest(t, base()))
+		require.NoError(t, err)
+		assert.Empty(t, resp.Failures)
+		assert.Nil(t, resp.Inputs.MaxOpenDuration)
+	})
 
-	out, err := plugin.UnmarshalProperties(resp.Inputs, plugin.MarshalOptions{})
-	require.NoError(t, err)
-	_, present := out["maxOpenDuration"]
-	assert.False(t, present, "maxOpenDuration must not be emitted when the user did not set it")
+	t.Run("normalizes maxOpenDuration", func(t *testing.T) {
+		props := base()
+		props["maxOpenDuration"] = property.New("60m")
+
+		resp, err := r.Check(t.Context(), newTeamEnvPermCheckRequest(t, props))
+		require.NoError(t, err)
+		assert.Empty(t, resp.Failures)
+		require.NotNil(t, resp.Inputs.MaxOpenDuration)
+		assert.Equal(t, "1h0m0s", *resp.Inputs.MaxOpenDuration)
+	})
+
+	t.Run("treats empty-string maxOpenDuration as unset", func(t *testing.T) {
+		props := base()
+		props["maxOpenDuration"] = property.New("")
+
+		resp, err := r.Check(t.Context(), newTeamEnvPermCheckRequest(t, props))
+		require.NoError(t, err)
+		assert.Empty(t, resp.Failures)
+		assert.Nil(t, resp.Inputs.MaxOpenDuration)
+	})
+
+	t.Run("rejects invalid maxOpenDuration", func(t *testing.T) {
+		props := base()
+		props["maxOpenDuration"] = property.New("not-a-duration")
+
+		resp, err := r.Check(t.Context(), newTeamEnvPermCheckRequest(t, props))
+		require.NoError(t, err)
+		require.Len(t, resp.Failures, 1)
+		assert.Equal(t, "maxOpenDuration", resp.Failures[0].Property)
+	})
 }
 
-func TestTeamEnvironmentPermission_Check_NormalizesMaxOpenDuration(t *testing.T) {
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-
-	news := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty("60m"),
+func TestTeamEnvironmentPermissionDiff(t *testing.T) {
+	r := &TeamEnvironmentPermission{}
+	state := func() TeamEnvironmentPermissionState {
+		return TeamEnvironmentPermissionState{
+			TeamEnvironmentPermissionInput: TeamEnvironmentPermissionInput{
+				Organization: "org",
+				Team:         "team",
+				Project:      "proj",
+				Environment:  "env",
+				Permission:   EnvironmentPermissionOpen,
+			},
+		}
 	}
 
-	resp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-	require.NoError(t, err)
-	assert.Empty(t, resp.Failures)
-
-	out, err := plugin.UnmarshalProperties(resp.Inputs, plugin.MarshalOptions{})
-	require.NoError(t, err)
-	require.True(t, out["maxOpenDuration"].IsString())
-	assert.Equal(t, "1h0m0s", out["maxOpenDuration"].StringValue())
-}
-
-func TestTeamEnvironmentPermission_Check_EmptyStringMaxOpenDurationTreatedAsUnset(t *testing.T) {
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-
-	news := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty(""),
-	}
-
-	resp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-	require.NoError(t, err)
-	assert.Empty(t, resp.Failures)
-
-	out, err := plugin.UnmarshalProperties(resp.Inputs, plugin.MarshalOptions{})
-	require.NoError(t, err)
-	_, present := out["maxOpenDuration"]
-	assert.False(t, present, "an explicit empty string must be stripped so it never triggers a spurious diff")
-}
-
-func TestTeamEnvironmentPermission_Check_InvalidMaxOpenDurationReportsFailure(t *testing.T) {
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-
-	news := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty("not-a-duration"),
-	}
-
-	resp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-	require.NoError(t, err)
-	require.Len(t, resp.Failures, 1)
-	assert.Equal(t, "maxOpenDuration", resp.Failures[0].Property)
-}
-
-func TestTeamEnvironmentPermission_Check_NonStringMaxOpenDurationReportsFailure(t *testing.T) {
-	cases := map[string]resource.PropertyValue{
-		"number": resource.NewNumberProperty(3600),
-		"bool":   resource.NewBoolProperty(true),
-		"array":  resource.NewArrayProperty([]resource.PropertyValue{resource.NewStringProperty("60m")}),
-		"object": resource.NewObjectProperty(resource.PropertyMap{
-			"value": resource.NewStringProperty("60m"),
-		}),
-	}
-	for name, value := range cases {
-		t.Run(name, func(t *testing.T) {
-			r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-			news := resource.PropertyMap{
-				"organization":    resource.NewStringProperty("org"),
-				"team":            resource.NewStringProperty("team"),
-				"project":         resource.NewStringProperty("proj"),
-				"environment":     resource.NewStringProperty("env"),
-				"permission":      resource.NewStringProperty("open"),
-				"maxOpenDuration": value,
-			}
-
-			resp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-			require.NoError(t, err)
-			require.Len(t, resp.Failures, 1)
-			assert.Equal(t, "maxOpenDuration", resp.Failures[0].Property)
-			assert.Contains(t, resp.Failures[0].Reason, "can't be parsed as string")
+	t.Run("no changes when nothing changed", func(t *testing.T) {
+		// Regression: 0.29.2 -> 0.29.3 upgrade path. State has no
+		// maxOpenDuration; inputs don't set it. Diff must report no changes.
+		resp, err := r.Diff(t.Context(), infer.DiffRequest[
+			TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState,
+		]{
+			State:  state(),
+			Inputs: state().TeamEnvironmentPermissionInput,
 		})
-	}
-}
-
-func TestTeamEnvironmentPermission_Diff_UpgradeFromPreMaxOpenDuration(t *testing.T) {
-	// End-to-end regression for the 0.29.2 -> 0.29.3 upgrade path:
-	//   - OldInputs has no maxOpenDuration (was saved before the field existed)
-	//   - The user's program still doesn't set maxOpenDuration
-	//   - Check + Diff together must report no changes and no replaces
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
-
-	inputs := resource.PropertyMap{
-		"organization": resource.NewStringProperty("org"),
-		"team":         resource.NewStringProperty("team"),
-		"project":      resource.NewStringProperty("proj"),
-		"environment":  resource.NewStringProperty("env"),
-		"permission":   resource.NewStringProperty("open"),
-	}
-
-	checkResp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, inputs)})
-	require.NoError(t, err)
-	require.Empty(t, checkResp.Failures)
-
-	diffResp, err := r.Diff(&pulumirpc.DiffRequest{
-		OldInputs: toStruct(t, inputs),
-		News:      checkResp.Inputs,
+		require.NoError(t, err)
+		assert.False(t, resp.HasChanges)
 	})
-	require.NoError(t, err)
-	assert.Equal(t, pulumirpc.DiffResponse_DIFF_NONE, diffResp.Changes)
-	assert.Empty(t, diffResp.Replaces, "maxOpenDuration should not drive a spurious replacement on upgrade")
-}
 
-func TestTeamEnvironmentPermission_Diff_UpgradeFromEmptyStringMaxOpenDuration(t *testing.T) {
-	// Regression for the residual 0.29.3–0.36.0 upgrade path that #752 did
-	// not cover: those provider versions wrote `maxOpenDuration: ""` into
-	// state whenever the user did not set the field. After #752, Check no
-	// longer emits the empty string, but state written by the old versions
-	// still carries it. Without Diff-side normalization, the first preview
-	// after upgrading would see the key as deleted and force one more
-	// spurious replacement.
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
+	t.Run("treats empty-string maxOpenDuration in state as unset", func(t *testing.T) {
+		// 0.29.3-0.36.0 wrote `""` into state when the user did not set the
+		// field. After the migration, refreshes against that state must not
+		// force a spurious replacement.
+		empty := ""
+		oldState := state()
+		oldState.MaxOpenDuration = &empty
 
-	// State on disk from a buggy 0.29.3–0.36.0 run: contains the empty string.
-	oldInputs := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty(""),
-	}
-
-	// User program (unchanged): never sets maxOpenDuration.
-	news := resource.PropertyMap{
-		"organization": resource.NewStringProperty("org"),
-		"team":         resource.NewStringProperty("team"),
-		"project":      resource.NewStringProperty("proj"),
-		"environment":  resource.NewStringProperty("env"),
-		"permission":   resource.NewStringProperty("open"),
-	}
-
-	checkResp, err := r.Check(&pulumirpc.CheckRequest{News: toStruct(t, news)})
-	require.NoError(t, err)
-	require.Empty(t, checkResp.Failures)
-
-	diffResp, err := r.Diff(&pulumirpc.DiffRequest{
-		OldInputs: toStruct(t, oldInputs),
-		News:      checkResp.Inputs,
+		resp, err := r.Diff(t.Context(), infer.DiffRequest[
+			TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState,
+		]{
+			State:  oldState,
+			Inputs: state().TeamEnvironmentPermissionInput,
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.HasChanges)
 	})
-	require.NoError(t, err)
-	assert.Equal(t, pulumirpc.DiffResponse_DIFF_NONE, diffResp.Changes)
-	assert.Empty(
-		t, diffResp.Replaces,
-		"an empty-string maxOpenDuration in old state must compare equal to an absent field",
-	)
-}
 
-func TestTeamEnvironmentPermission_Diff_DetectsRealMaxOpenDurationChange(t *testing.T) {
-	// Guard against over-aggressive normalization: a real value change must
-	// still be reported as a change (and, for this resource, a replace).
-	r := newTeamEnvPermResource(&teamEnvPermClientMock{})
+	t.Run("detects real maxOpenDuration change", func(t *testing.T) {
+		// Guard against over-aggressive normalization.
+		oldDur := "30m0s"
+		newDur := "1h0m0s"
+		oldState := state()
+		oldState.MaxOpenDuration = &oldDur
+		newInputs := state().TeamEnvironmentPermissionInput
+		newInputs.MaxOpenDuration = &newDur
 
-	oldInputs := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty("30m0s"),
-	}
-	news := resource.PropertyMap{
-		"organization":    resource.NewStringProperty("org"),
-		"team":            resource.NewStringProperty("team"),
-		"project":         resource.NewStringProperty("proj"),
-		"environment":     resource.NewStringProperty("env"),
-		"permission":      resource.NewStringProperty("open"),
-		"maxOpenDuration": resource.NewStringProperty("1h0m0s"),
-	}
-
-	diffResp, err := r.Diff(&pulumirpc.DiffRequest{
-		OldInputs: toStruct(t, oldInputs),
-		News:      toStruct(t, news),
+		resp, err := r.Diff(t.Context(), infer.DiffRequest[
+			TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState,
+		]{State: oldState, Inputs: newInputs})
+		require.NoError(t, err)
+		assert.True(t, resp.HasChanges)
+		assert.Contains(t, resp.DetailedDiff, "maxOpenDuration")
+		assert.True(t, resp.DeleteBeforeReplace)
 	})
-	require.NoError(t, err)
-	assert.Equal(t, pulumirpc.DiffResponse_DIFF_SOME, diffResp.Changes)
-	assert.Contains(t, diffResp.Replaces, "maxOpenDuration")
 }
 
-func TestTeamEnvironmentPermission_Read_OmitsMaxOpenDurationWhenUnset(t *testing.T) {
-	// When the Pulumi Cloud API does not return a maxOpenDuration for the
-	// environment, Read must not bake an empty string into state. Otherwise
-	// a follow-up against a program that doesn't set the field would
-	// observe a spurious diff (same root cause as the Check path).
-	permission := "open"
-	client := &teamEnvPermClientMock{
-		getEnvSettingsFunc: func() (*string, *pulumiapi.Duration, error) {
-			return &permission, nil, nil
-		},
-	}
-	r := newTeamEnvPermResource(client)
+func TestTeamEnvironmentPermissionRead(t *testing.T) {
+	r := &TeamEnvironmentPermission{}
 
-	resp, err := r.Read(&pulumirpc.ReadRequest{Id: "org/team/proj+env"})
-	require.NoError(t, err)
+	t.Run("omits maxOpenDuration when API returns none", func(t *testing.T) {
+		permission := "open"
+		mock := &teamEnvPermClientMock{
+			getFunc: func() (*string, *pulumiapi.Duration, error) {
+				return &permission, nil, nil
+			},
+		}
+		ctx := config.WithMockClient(t.Context(), mock)
 
-	out, err := plugin.UnmarshalProperties(resp.Inputs, plugin.MarshalOptions{})
-	require.NoError(t, err)
-	_, present := out["maxOpenDuration"]
-	assert.False(t, present, "Read must omit maxOpenDuration when the API did not return one")
+		resp, err := r.Read(ctx, infer.ReadRequest[
+			TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState,
+		]{ID: "org/team/proj+env"})
+		require.NoError(t, err)
+		assert.Nil(t, resp.Inputs.MaxOpenDuration)
+	})
+
+	t.Run("includes maxOpenDuration when API returns one", func(t *testing.T) {
+		permission := "open"
+		d := pulumiapi.Duration(30 * time.Minute)
+		mock := &teamEnvPermClientMock{
+			getFunc: func() (*string, *pulumiapi.Duration, error) {
+				return &permission, &d, nil
+			},
+		}
+		ctx := config.WithMockClient(t.Context(), mock)
+
+		resp, err := r.Read(ctx, infer.ReadRequest[
+			TeamEnvironmentPermissionInput, TeamEnvironmentPermissionState,
+		]{ID: "org/team/proj+env"})
+		require.NoError(t, err)
+		require.NotNil(t, resp.Inputs.MaxOpenDuration)
+		assert.Equal(t, "30m0s", *resp.Inputs.MaxOpenDuration)
+	})
 }
 
-func TestTeamEnvironmentPermission_Read_IncludesMaxOpenDurationWhenSet(t *testing.T) {
-	permission := "open"
-	d := pulumiapi.Duration(30 * time.Minute)
-	client := &teamEnvPermClientMock{
-		getEnvSettingsFunc: func() (*string, *pulumiapi.Duration, error) {
-			return &permission, &d, nil
-		},
-	}
-	r := newTeamEnvPermResource(client)
+func TestSplitTeamEnvironmentPermissionID(t *testing.T) {
+	t.Run("project+environment form", func(t *testing.T) {
+		got, err := splitTeamEnvironmentPermissionID("org/team/proj+env")
+		require.NoError(t, err)
+		assert.Equal(t, teamEnvironmentPermissionID{
+			Organization: "org",
+			Team:         "team",
+			Project:      "proj",
+			Environment:  "env",
+		}, got)
+	})
 
-	resp, err := r.Read(&pulumirpc.ReadRequest{Id: "org/team/proj+env"})
-	require.NoError(t, err)
+	t.Run("legacy environment-only form defaults project", func(t *testing.T) {
+		got, err := splitTeamEnvironmentPermissionID("org/team/env")
+		require.NoError(t, err)
+		assert.Equal(t, teamEnvironmentPermissionID{
+			Organization: "org",
+			Team:         "team",
+			Project:      "default",
+			Environment:  "env",
+		}, got)
+	})
 
-	out, err := plugin.UnmarshalProperties(resp.Inputs, plugin.MarshalOptions{})
-	require.NoError(t, err)
-	require.True(t, out["maxOpenDuration"].IsString())
-	assert.Equal(t, "30m0s", out["maxOpenDuration"].StringValue())
+	t.Run("rejects malformed id", func(t *testing.T) {
+		_, err := splitTeamEnvironmentPermissionID("org/team")
+		assert.Error(t, err)
+	})
 }

--- a/provider/pkg/resources/team_stack_perm.go
+++ b/provider/pkg/resources/team_stack_perm.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -5,75 +19,127 @@ import (
 	"fmt"
 	"strings"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
+	"github.com/pulumi/pulumi-go-provider/infer"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
 )
 
-type TeamStackPermissionResource struct {
-	Client pulumiapi.TeamClient
+type TeamStackPermissionScope int
+
+const (
+	TeamStackPermissionRead  TeamStackPermissionScope = 101
+	TeamStackPermissionEdit  TeamStackPermissionScope = 102
+	TeamStackPermissionAdmin TeamStackPermissionScope = 103
+)
+
+func (TeamStackPermissionScope) Values() []infer.EnumValue[TeamStackPermissionScope] {
+	return []infer.EnumValue[TeamStackPermissionScope]{
+		{Name: "read", Value: TeamStackPermissionRead, Description: "Grants read permissions to stack."},
+		{Name: "edit", Value: TeamStackPermissionEdit, Description: "Grants edit permissions to stack."},
+		{Name: "admin", Value: TeamStackPermissionAdmin, Description: "Grants admin permissions to stack."},
+	}
+}
+
+type TeamStackPermission struct{}
+
+var (
+	_ infer.CustomCreate[TeamStackPermissionInput, TeamStackPermissionState] = &TeamStackPermission{}
+	_ infer.CustomDelete[TeamStackPermissionState]                           = &TeamStackPermission{}
+	_ infer.CustomRead[TeamStackPermissionInput, TeamStackPermissionState]   = &TeamStackPermission{}
+)
+
+func (*TeamStackPermission) Annotate(a infer.Annotator) {
+	a.Describe(&TeamStackPermission{}, "Grants a team permissions to the specified stack.")
+	a.SetToken("index", "TeamStackPermission")
 }
 
 type TeamStackPermissionInput struct {
-	Organization string `pulumi:"organization"`
-	Project      string `pulumi:"project"`
-	Stack        string `pulumi:"stack"`
-	Team         string `pulumi:"team"`
-	Permission   int    `pulumi:"permission"`
+	Organization string                   `pulumi:"organization" provider:"replaceOnChanges"`
+	Project      string                   `pulumi:"project"      provider:"replaceOnChanges"`
+	Stack        string                   `pulumi:"stack"        provider:"replaceOnChanges"`
+	Team         string                   `pulumi:"team"         provider:"replaceOnChanges"`
+	Permission   TeamStackPermissionScope `pulumi:"permission"   provider:"replaceOnChanges"`
 }
 
-func (i *TeamStackPermissionInput) ToPropertyMap() resource.PropertyMap {
-	return util.ToPropertyMap(*i)
+func (i *TeamStackPermissionInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Organization, "The organization or the personal account name of the stack.")
+	a.Describe(&i.Project, "The project name for this stack.")
+	a.Describe(&i.Stack, "The name of the stack that the team will be granted permissions to.")
+	a.Describe(&i.Team, "The name of the team to grant this stack permissions to. This is not the display name.")
+	a.Describe(&i.Permission, "Sets the permission level that this team will be granted to the stack.")
 }
 
-func (tp *TeamStackPermissionResource) ToPulumiServiceTeamInput(
-	inputMap resource.PropertyMap,
-) (*TeamStackPermissionInput, error) {
-	input := TeamStackPermissionInput{}
-	return &input, util.FromPropertyMap(inputMap, &input)
+type TeamStackPermissionState struct {
+	TeamStackPermissionInput
 }
 
-func (tp *TeamStackPermissionResource) Name() string {
-	return "pulumiservice:index:TeamStackPermission"
-}
-
-func (tp *TeamStackPermissionResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{
-		Inputs: req.GetNews(),
+func (*TeamStackPermission) Create(
+	ctx context.Context,
+	req infer.CreateRequest[TeamStackPermissionInput],
+) (infer.CreateResponse[TeamStackPermissionState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[TeamStackPermissionState]{
+			Output: TeamStackPermissionState{TeamStackPermissionInput: req.Inputs},
+		}, nil
+	}
+	stack := pulumiapi.StackIdentifier{
+		OrgName:     req.Inputs.Organization,
+		ProjectName: req.Inputs.Project,
+		StackName:   req.Inputs.Stack,
+	}
+	err := config.GetClient(ctx).AddStackPermission(ctx, stack, req.Inputs.Team, int(req.Inputs.Permission))
+	if err != nil {
+		return infer.CreateResponse[TeamStackPermissionState]{}, fmt.Errorf(
+			"error granting team stack permission: %w", err,
+		)
+	}
+	return infer.CreateResponse[TeamStackPermissionState]{
+		ID:     teamStackPermissionResourceID(stack, req.Inputs.Team),
+		Output: TeamStackPermissionState{TeamStackPermissionInput: req.Inputs},
 	}, nil
 }
 
-func (tp *TeamStackPermissionResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-	id := req.GetId()
+func (*TeamStackPermission) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[TeamStackPermissionState],
+) (infer.DeleteResponse, error) {
+	stack := pulumiapi.StackIdentifier{
+		OrgName:     req.State.Organization,
+		ProjectName: req.State.Project,
+		StackName:   req.State.Stack,
+	}
+	return infer.DeleteResponse{}, config.GetClient(ctx).RemoveStackPermission(ctx, stack, req.State.Team)
+}
 
-	permID, err := splitTeamStackPermissionID(id)
+func (*TeamStackPermission) Read(
+	ctx context.Context,
+	req infer.ReadRequest[TeamStackPermissionInput, TeamStackPermissionState],
+) (infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState], error) {
+	permID, err := splitTeamStackPermissionID(req.ID)
 	if err != nil {
 		if strings.Contains(err.Error(), "expected 4 parts") {
-			// Return an error if attempting to refresh stack permissions created before this change.
-			// We return a warning and an empty response, which will cause the resource to be deleted on refresh,
-			// forcing the user to recreate it with the updated version.
-			return nil, fmt.Errorf("TeamStackPermission resources created before v0.17.0 do not support refresh. " +
-				"You will need to destroy and recreate this resource with >v0.17.0 to successfully refresh")
+			return infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState]{}, fmt.Errorf(
+				"TeamStackPermission resources created before v0.17.0 do not support refresh. " +
+					"You will need to destroy and recreate this resource with >v0.17.0 to successfully refresh",
+			)
 		}
-		return nil, err
+		return infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState]{}, err
 	}
 
-	permission, err := tp.Client.GetTeamStackPermission(ctx, pulumiapi.StackIdentifier{
+	stack := pulumiapi.StackIdentifier{
 		OrgName:     permID.Organization,
 		ProjectName: permID.Project,
 		StackName:   permID.Stack,
-	}, permID.Team)
+	}
+	permission, err := config.GetClient(ctx).GetTeamStackPermission(ctx, stack, permID.Team)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get team stack permission: %w", err)
+		return infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState]{}, fmt.Errorf(
+			"failed to get team stack permission: %w", err,
+		)
 	}
 	if permission == nil {
-		return &pulumirpc.ReadResponse{}, nil
+		return infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState]{}, nil
 	}
 
 	inputs := TeamStackPermissionInput{
@@ -81,83 +147,17 @@ func (tp *TeamStackPermissionResource) Read(req *pulumirpc.ReadRequest) (*pulumi
 		Project:      permID.Project,
 		Stack:        permID.Stack,
 		Team:         permID.Team,
-		Permission:   *permission,
+		Permission:   TeamStackPermissionScope(*permission),
 	}
-
-	properties, err := plugin.MarshalProperties(inputs.ToPropertyMap(), plugin.MarshalOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal inputs to properties: %w", err)
-	}
-	return &pulumirpc.ReadResponse{
-		Id:         req.Id,
-		Properties: properties,
-		Inputs:     properties,
+	return infer.ReadResponse[TeamStackPermissionInput, TeamStackPermissionState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State:  TeamStackPermissionState{TeamStackPermissionInput: inputs},
 	}, nil
 }
 
-func (tp *TeamStackPermissionResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	var input TeamStackPermissionInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     input.Organization,
-		ProjectName: input.Project,
-		StackName:   input.Stack,
-	}
-
-	err = tp.Client.AddStackPermission(ctx, stackName, input.Team, input.Permission)
-	if err != nil {
-		return nil, err
-	}
-
-	stackPermissionID := fmt.Sprintf("%s/%s", stackName.String(), input.Team)
-
-	return &pulumirpc.CreateResponse{
-		Id:         stackPermissionID,
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (tp *TeamStackPermissionResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	var input TeamStackPermissionInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     input.Organization,
-		ProjectName: input.Project,
-		StackName:   input.Stack,
-	}
-	err = tp.Client.RemoveStackPermission(ctx, stackName, input.Team)
-	if err != nil {
-		return nil, err
-	}
-	return &pbempty.Empty{}, nil
-}
-
-func (tp *TeamStackPermissionResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	changedKeys, err := util.DiffOldsAndNews(req)
-	if err != nil {
-		return nil, err
-	}
-	changes := pulumirpc.DiffResponse_DIFF_NONE
-	if len(changedKeys) > 0 {
-		changes = pulumirpc.DiffResponse_DIFF_SOME
-	}
-	return &pulumirpc.DiffResponse{
-		Changes:  changes,
-		Replaces: changedKeys,
-	}, nil
-}
-
-// Update does nothing because we always replace on changes, never an update
-func (tp *TeamStackPermissionResource) Update(_ *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
+func teamStackPermissionResourceID(stack pulumiapi.StackIdentifier, team string) string {
+	return fmt.Sprintf("%s/%s/%s/%s", stack.OrgName, stack.ProjectName, stack.StackName, team)
 }
 
 type teamStackPermissionID struct {

--- a/sdk/dotnet/Enums.cs
+++ b/sdk/dotnet/Enums.cs
@@ -373,42 +373,20 @@ namespace Pulumi.PulumiService
         public override string ToString() => _value;
     }
 
-    [EnumType]
-    public readonly struct TeamStackPermissionScope : IEquatable<TeamStackPermissionScope>
+    public enum TeamStackPermissionScope
     {
-        private readonly double _value;
-
-        private TeamStackPermissionScope(double value)
-        {
-            _value = value;
-        }
-
         /// <summary>
         /// Grants read permissions to stack.
         /// </summary>
-        public static TeamStackPermissionScope Read { get; } = new TeamStackPermissionScope(101);
+        Read = 101,
         /// <summary>
         /// Grants edit permissions to stack.
         /// </summary>
-        public static TeamStackPermissionScope Edit { get; } = new TeamStackPermissionScope(102);
+        Edit = 102,
         /// <summary>
         /// Grants admin permissions to stack.
         /// </summary>
-        public static TeamStackPermissionScope Admin { get; } = new TeamStackPermissionScope(103);
-
-        public static bool operator ==(TeamStackPermissionScope left, TeamStackPermissionScope right) => left.Equals(right);
-        public static bool operator !=(TeamStackPermissionScope left, TeamStackPermissionScope right) => !left.Equals(right);
-
-        public static explicit operator double(TeamStackPermissionScope value) => value._value;
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override bool Equals(object? obj) => obj is TeamStackPermissionScope other && Equals(other);
-        public bool Equals(TeamStackPermissionScope other) => _value == other._value;
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public override int GetHashCode() => _value.GetHashCode();
-
-        public override string ToString() => _value.ToString();
+        Admin = 103,
     }
 
     [EnumType]

--- a/sdk/dotnet/TeamEnvironmentPermission.cs
+++ b/sdk/dotnet/TeamEnvironmentPermission.cs
@@ -19,7 +19,7 @@ namespace Pulumi.PulumiService
         /// Environment name.
         /// </summary>
         [Output("environment")]
-        public Output<string?> Environment { get; private set; } = null!;
+        public Output<string> Environment { get; private set; } = null!;
 
         /// <summary>
         /// The maximum duration for which members of this team may open the environment.
@@ -31,13 +31,13 @@ namespace Pulumi.PulumiService
         /// Organization name.
         /// </summary>
         [Output("organization")]
-        public Output<string?> Organization { get; private set; } = null!;
+        public Output<string> Organization { get; private set; } = null!;
 
         /// <summary>
         /// Which permission level to grant to the specified team.
         /// </summary>
         [Output("permission")]
-        public Output<Pulumi.PulumiService.EnvironmentPermission?> Permission { get; private set; } = null!;
+        public Output<Pulumi.PulumiService.EnvironmentPermission> Permission { get; private set; } = null!;
 
         /// <summary>
         /// Project name.
@@ -49,7 +49,7 @@ namespace Pulumi.PulumiService
         /// Team name.
         /// </summary>
         [Output("team")]
-        public Output<string?> Team { get; private set; } = null!;
+        public Output<string> Team { get; private set; } = null!;
 
 
         /// <summary>
@@ -74,6 +74,15 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                ReplaceOnChanges =
+                {
+                    "environment",
+                    "maxOpenDuration",
+                    "organization",
+                    "permission",
+                    "project",
+                    "team",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/dotnet/TeamStackPermission.cs
+++ b/sdk/dotnet/TeamStackPermission.cs
@@ -68,6 +68,14 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                ReplaceOnChanges =
+                {
+                    "organization",
+                    "permission",
+                    "project",
+                    "stack",
+                    "team",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.
@@ -100,7 +108,7 @@ namespace Pulumi.PulumiService
         /// Sets the permission level that this team will be granted to the stack.
         /// </summary>
         [Input("permission", required: true)]
-        public Pulumi.PulumiService.TeamStackPermissionScope Permission { get; set; }
+        public Input<Pulumi.PulumiService.TeamStackPermissionScope> Permission { get; set; } = null!;
 
         /// <summary>
         /// The project name for this stack.

--- a/sdk/go/pulumiservice/pulumiEnums.go
+++ b/sdk/go/pulumiservice/pulumiEnums.go
@@ -1648,7 +1648,7 @@ func (o TargetActionTypeArrayOutput) Index(i pulumi.IntInput) TargetActionTypeOu
 	}).(TargetActionTypeOutput)
 }
 
-type TeamStackPermissionScope float64
+type TeamStackPermissionScope int
 
 const (
 	// Grants read permissions to stack.
@@ -1658,6 +1658,42 @@ const (
 	// Grants admin permissions to stack.
 	TeamStackPermissionScopeAdmin = TeamStackPermissionScope(103)
 )
+
+func (TeamStackPermissionScope) ElementType() reflect.Type {
+	return reflect.TypeOf((*TeamStackPermissionScope)(nil)).Elem()
+}
+
+func (e TeamStackPermissionScope) ToTeamStackPermissionScopeOutput() TeamStackPermissionScopeOutput {
+	return pulumi.ToOutput(e).(TeamStackPermissionScopeOutput)
+}
+
+func (e TeamStackPermissionScope) ToTeamStackPermissionScopeOutputWithContext(ctx context.Context) TeamStackPermissionScopeOutput {
+	return pulumi.ToOutputWithContext(ctx, e).(TeamStackPermissionScopeOutput)
+}
+
+func (e TeamStackPermissionScope) ToTeamStackPermissionScopePtrOutput() TeamStackPermissionScopePtrOutput {
+	return e.ToTeamStackPermissionScopePtrOutputWithContext(context.Background())
+}
+
+func (e TeamStackPermissionScope) ToTeamStackPermissionScopePtrOutputWithContext(ctx context.Context) TeamStackPermissionScopePtrOutput {
+	return TeamStackPermissionScope(e).ToTeamStackPermissionScopeOutputWithContext(ctx).ToTeamStackPermissionScopePtrOutputWithContext(ctx)
+}
+
+func (e TeamStackPermissionScope) ToIntOutput() pulumi.IntOutput {
+	return pulumi.ToOutput(pulumi.Int(e)).(pulumi.IntOutput)
+}
+
+func (e TeamStackPermissionScope) ToIntOutputWithContext(ctx context.Context) pulumi.IntOutput {
+	return pulumi.ToOutputWithContext(ctx, pulumi.Int(e)).(pulumi.IntOutput)
+}
+
+func (e TeamStackPermissionScope) ToIntPtrOutput() pulumi.IntPtrOutput {
+	return pulumi.Int(e).ToIntPtrOutputWithContext(context.Background())
+}
+
+func (e TeamStackPermissionScope) ToIntPtrOutputWithContext(ctx context.Context) pulumi.IntPtrOutput {
+	return pulumi.Int(e).ToIntOutputWithContext(ctx).ToIntPtrOutputWithContext(ctx)
+}
 
 type TeamStackPermissionScopeOutput struct{ *pulumi.OutputState }
 
@@ -1683,25 +1719,25 @@ func (o TeamStackPermissionScopeOutput) ToTeamStackPermissionScopePtrOutputWithC
 	}).(TeamStackPermissionScopePtrOutput)
 }
 
-func (o TeamStackPermissionScopeOutput) ToFloat64Output() pulumi.Float64Output {
-	return o.ToFloat64OutputWithContext(context.Background())
+func (o TeamStackPermissionScopeOutput) ToIntOutput() pulumi.IntOutput {
+	return o.ToIntOutputWithContext(context.Background())
 }
 
-func (o TeamStackPermissionScopeOutput) ToFloat64OutputWithContext(ctx context.Context) pulumi.Float64Output {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, e TeamStackPermissionScope) float64 {
-		return float64(e)
-	}).(pulumi.Float64Output)
+func (o TeamStackPermissionScopeOutput) ToIntOutputWithContext(ctx context.Context) pulumi.IntOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e TeamStackPermissionScope) int {
+		return int(e)
+	}).(pulumi.IntOutput)
 }
 
-func (o TeamStackPermissionScopeOutput) ToFloat64PtrOutput() pulumi.Float64PtrOutput {
-	return o.ToFloat64PtrOutputWithContext(context.Background())
+func (o TeamStackPermissionScopeOutput) ToIntPtrOutput() pulumi.IntPtrOutput {
+	return o.ToIntPtrOutputWithContext(context.Background())
 }
 
-func (o TeamStackPermissionScopeOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pulumi.Float64PtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, e TeamStackPermissionScope) *float64 {
-		v := float64(e)
+func (o TeamStackPermissionScopeOutput) ToIntPtrOutputWithContext(ctx context.Context) pulumi.IntPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e TeamStackPermissionScope) *int {
+		v := int(e)
 		return &v
-	}).(pulumi.Float64PtrOutput)
+	}).(pulumi.IntPtrOutput)
 }
 
 type TeamStackPermissionScopePtrOutput struct{ *pulumi.OutputState }
@@ -1728,18 +1764,58 @@ func (o TeamStackPermissionScopePtrOutput) Elem() TeamStackPermissionScopeOutput
 	}).(TeamStackPermissionScopeOutput)
 }
 
-func (o TeamStackPermissionScopePtrOutput) ToFloat64PtrOutput() pulumi.Float64PtrOutput {
-	return o.ToFloat64PtrOutputWithContext(context.Background())
+func (o TeamStackPermissionScopePtrOutput) ToIntPtrOutput() pulumi.IntPtrOutput {
+	return o.ToIntPtrOutputWithContext(context.Background())
 }
 
-func (o TeamStackPermissionScopePtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pulumi.Float64PtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, e *TeamStackPermissionScope) *float64 {
+func (o TeamStackPermissionScopePtrOutput) ToIntPtrOutputWithContext(ctx context.Context) pulumi.IntPtrOutput {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, e *TeamStackPermissionScope) *int {
 		if e == nil {
 			return nil
 		}
-		v := float64(*e)
+		v := int(*e)
 		return &v
-	}).(pulumi.Float64PtrOutput)
+	}).(pulumi.IntPtrOutput)
+}
+
+// TeamStackPermissionScopeInput is an input type that accepts values of the TeamStackPermissionScope enum
+// A concrete instance of `TeamStackPermissionScopeInput` can be one of the following:
+//
+//	TeamStackPermissionScopeRead
+//	TeamStackPermissionScopeEdit
+//	TeamStackPermissionScopeAdmin
+type TeamStackPermissionScopeInput interface {
+	pulumi.Input
+
+	ToTeamStackPermissionScopeOutput() TeamStackPermissionScopeOutput
+	ToTeamStackPermissionScopeOutputWithContext(context.Context) TeamStackPermissionScopeOutput
+}
+
+var teamStackPermissionScopePtrType = reflect.TypeOf((**TeamStackPermissionScope)(nil)).Elem()
+
+type TeamStackPermissionScopePtrInput interface {
+	pulumi.Input
+
+	ToTeamStackPermissionScopePtrOutput() TeamStackPermissionScopePtrOutput
+	ToTeamStackPermissionScopePtrOutputWithContext(context.Context) TeamStackPermissionScopePtrOutput
+}
+
+type teamStackPermissionScopePtr int
+
+func TeamStackPermissionScopePtr(v int) TeamStackPermissionScopePtrInput {
+	return (*teamStackPermissionScopePtr)(&v)
+}
+
+func (*teamStackPermissionScopePtr) ElementType() reflect.Type {
+	return teamStackPermissionScopePtrType
+}
+
+func (in *teamStackPermissionScopePtr) ToTeamStackPermissionScopePtrOutput() TeamStackPermissionScopePtrOutput {
+	return pulumi.ToOutput(in).(TeamStackPermissionScopePtrOutput)
+}
+
+func (in *teamStackPermissionScopePtr) ToTeamStackPermissionScopePtrOutputWithContext(ctx context.Context) TeamStackPermissionScopePtrOutput {
+	return pulumi.ToOutputWithContext(ctx, in).(TeamStackPermissionScopePtrOutput)
 }
 
 type WebhookFilters string
@@ -2447,6 +2523,8 @@ func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*TargetActionTypeInput)(nil)).Elem(), TargetActionType("update"))
 	pulumi.RegisterInputType(reflect.TypeOf((*TargetActionTypePtrInput)(nil)).Elem(), TargetActionType("update"))
 	pulumi.RegisterInputType(reflect.TypeOf((*TargetActionTypeArrayInput)(nil)).Elem(), TargetActionTypeArray{})
+	pulumi.RegisterInputType(reflect.TypeOf((*TeamStackPermissionScopeInput)(nil)).Elem(), TeamStackPermissionScope(101))
+	pulumi.RegisterInputType(reflect.TypeOf((*TeamStackPermissionScopePtrInput)(nil)).Elem(), TeamStackPermissionScope(101))
 	pulumi.RegisterInputType(reflect.TypeOf((*WebhookFiltersInput)(nil)).Elem(), WebhookFilters("stack_created"))
 	pulumi.RegisterInputType(reflect.TypeOf((*WebhookFiltersPtrInput)(nil)).Elem(), WebhookFilters("stack_created"))
 	pulumi.RegisterInputType(reflect.TypeOf((*WebhookFiltersArrayInput)(nil)).Elem(), WebhookFiltersArray{})

--- a/sdk/go/pulumiservice/teamEnvironmentPermission.go
+++ b/sdk/go/pulumiservice/teamEnvironmentPermission.go
@@ -17,17 +17,17 @@ type TeamEnvironmentPermission struct {
 	pulumi.CustomResourceState
 
 	// Environment name.
-	Environment pulumi.StringPtrOutput `pulumi:"environment"`
+	Environment pulumi.StringOutput `pulumi:"environment"`
 	// The maximum duration for which members of this team may open the environment.
 	MaxOpenDuration pulumi.StringPtrOutput `pulumi:"maxOpenDuration"`
 	// Organization name.
-	Organization pulumi.StringPtrOutput `pulumi:"organization"`
+	Organization pulumi.StringOutput `pulumi:"organization"`
 	// Which permission level to grant to the specified team.
-	Permission EnvironmentPermissionPtrOutput `pulumi:"permission"`
+	Permission EnvironmentPermissionOutput `pulumi:"permission"`
 	// Project name.
 	Project pulumi.StringPtrOutput `pulumi:"project"`
 	// Team name.
-	Team pulumi.StringPtrOutput `pulumi:"team"`
+	Team pulumi.StringOutput `pulumi:"team"`
 }
 
 // NewTeamEnvironmentPermission registers a new resource with the given unique name, arguments, and options.
@@ -52,6 +52,15 @@ func NewTeamEnvironmentPermission(ctx *pulumi.Context,
 	if args.Project == nil {
 		args.Project = pulumi.StringPtr("default")
 	}
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"environment",
+		"maxOpenDuration",
+		"organization",
+		"permission",
+		"project",
+		"team",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource TeamEnvironmentPermission
 	err := ctx.RegisterResource("pulumiservice:index:TeamEnvironmentPermission", name, args, &resource, opts...)
@@ -203,8 +212,8 @@ func (o TeamEnvironmentPermissionOutput) ToTeamEnvironmentPermissionOutputWithCo
 }
 
 // Environment name.
-func (o TeamEnvironmentPermissionOutput) Environment() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringPtrOutput { return v.Environment }).(pulumi.StringPtrOutput)
+func (o TeamEnvironmentPermissionOutput) Environment() pulumi.StringOutput {
+	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringOutput { return v.Environment }).(pulumi.StringOutput)
 }
 
 // The maximum duration for which members of this team may open the environment.
@@ -213,13 +222,13 @@ func (o TeamEnvironmentPermissionOutput) MaxOpenDuration() pulumi.StringPtrOutpu
 }
 
 // Organization name.
-func (o TeamEnvironmentPermissionOutput) Organization() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringPtrOutput { return v.Organization }).(pulumi.StringPtrOutput)
+func (o TeamEnvironmentPermissionOutput) Organization() pulumi.StringOutput {
+	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringOutput { return v.Organization }).(pulumi.StringOutput)
 }
 
 // Which permission level to grant to the specified team.
-func (o TeamEnvironmentPermissionOutput) Permission() EnvironmentPermissionPtrOutput {
-	return o.ApplyT(func(v *TeamEnvironmentPermission) EnvironmentPermissionPtrOutput { return v.Permission }).(EnvironmentPermissionPtrOutput)
+func (o TeamEnvironmentPermissionOutput) Permission() EnvironmentPermissionOutput {
+	return o.ApplyT(func(v *TeamEnvironmentPermission) EnvironmentPermissionOutput { return v.Permission }).(EnvironmentPermissionOutput)
 }
 
 // Project name.
@@ -228,8 +237,8 @@ func (o TeamEnvironmentPermissionOutput) Project() pulumi.StringPtrOutput {
 }
 
 // Team name.
-func (o TeamEnvironmentPermissionOutput) Team() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringPtrOutput { return v.Team }).(pulumi.StringPtrOutput)
+func (o TeamEnvironmentPermissionOutput) Team() pulumi.StringOutput {
+	return o.ApplyT(func(v *TeamEnvironmentPermission) pulumi.StringOutput { return v.Team }).(pulumi.StringOutput)
 }
 
 type TeamEnvironmentPermissionArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/go/pulumiservice/teamStackPermission.go
+++ b/sdk/go/pulumiservice/teamStackPermission.go
@@ -38,6 +38,9 @@ func NewTeamStackPermission(ctx *pulumi.Context,
 	if args.Organization == nil {
 		return nil, errors.New("invalid value for required argument 'Organization'")
 	}
+	if args.Permission == nil {
+		return nil, errors.New("invalid value for required argument 'Permission'")
+	}
 	if args.Project == nil {
 		return nil, errors.New("invalid value for required argument 'Project'")
 	}
@@ -47,6 +50,14 @@ func NewTeamStackPermission(ctx *pulumi.Context,
 	if args.Team == nil {
 		return nil, errors.New("invalid value for required argument 'Team'")
 	}
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"organization",
+		"permission",
+		"project",
+		"stack",
+		"team",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource TeamStackPermission
 	err := ctx.RegisterResource("pulumiservice:index:TeamStackPermission", name, args, &resource, opts...)
@@ -97,7 +108,7 @@ type TeamStackPermissionArgs struct {
 	// The organization or the personal account name of the stack.
 	Organization pulumi.StringInput
 	// Sets the permission level that this team will be granted to the stack.
-	Permission TeamStackPermissionScope
+	Permission TeamStackPermissionScopeInput
 	// The project name for this stack.
 	Project pulumi.StringInput
 	// The name of the stack that the team will be granted permissions to.

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamEnvironmentPermission.java
@@ -11,6 +11,7 @@ import com.pulumi.pulumiservice.TeamEnvironmentPermissionArgs;
 import com.pulumi.pulumiservice.Utilities;
 import com.pulumi.pulumiservice.enums.EnvironmentPermission;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -25,14 +26,14 @@ public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResour
      * 
      */
     @Export(name="environment", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> environment;
+    private Output<String> environment;
 
     /**
      * @return Environment name.
      * 
      */
-    public Output<Optional<String>> environment() {
-        return Codegen.optional(this.environment);
+    public Output<String> environment() {
+        return this.environment;
     }
     /**
      * The maximum duration for which members of this team may open the environment.
@@ -53,28 +54,28 @@ public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResour
      * 
      */
     @Export(name="organization", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> organization;
+    private Output<String> organization;
 
     /**
      * @return Organization name.
      * 
      */
-    public Output<Optional<String>> organization() {
-        return Codegen.optional(this.organization);
+    public Output<String> organization() {
+        return this.organization;
     }
     /**
      * Which permission level to grant to the specified team.
      * 
      */
     @Export(name="permission", refs={EnvironmentPermission.class}, tree="[0]")
-    private Output</* @Nullable */ EnvironmentPermission> permission;
+    private Output<EnvironmentPermission> permission;
 
     /**
      * @return Which permission level to grant to the specified team.
      * 
      */
-    public Output<Optional<EnvironmentPermission>> permission() {
-        return Codegen.optional(this.permission);
+    public Output<EnvironmentPermission> permission() {
+        return this.permission;
     }
     /**
      * Project name.
@@ -95,14 +96,14 @@ public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResour
      * 
      */
     @Export(name="team", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> team;
+    private Output<String> team;
 
     /**
      * @return Team name.
      * 
      */
-    public Output<Optional<String>> team() {
-        return Codegen.optional(this.team);
+    public Output<String> team() {
+        return this.team;
     }
 
     /**
@@ -144,6 +145,14 @@ public class TeamEnvironmentPermission extends com.pulumi.resources.CustomResour
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .replaceOnChanges(List.of(
+                "environment",
+                "maxOpenDuration",
+                "organization",
+                "permission",
+                "project",
+                "team"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermission.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermission.java
@@ -11,6 +11,7 @@ import com.pulumi.pulumiservice.TeamStackPermissionArgs;
 import com.pulumi.pulumiservice.Utilities;
 import com.pulumi.pulumiservice.enums.TeamStackPermissionScope;
 import java.lang.String;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -129,6 +130,13 @@ public class TeamStackPermission extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .replaceOnChanges(List.of(
+                "organization",
+                "permission",
+                "project",
+                "stack",
+                "team"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermissionArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/TeamStackPermissionArgs.java
@@ -35,13 +35,13 @@ public final class TeamStackPermissionArgs extends com.pulumi.resources.Resource
      * 
      */
     @Import(name="permission", required=true)
-    private TeamStackPermissionScope permission;
+    private Output<TeamStackPermissionScope> permission;
 
     /**
      * @return Sets the permission level that this team will be granted to the stack.
      * 
      */
-    public TeamStackPermissionScope permission() {
+    public Output<TeamStackPermissionScope> permission() {
         return this.permission;
     }
 
@@ -145,9 +145,19 @@ public final class TeamStackPermissionArgs extends com.pulumi.resources.Resource
          * @return builder
          * 
          */
-        public Builder permission(TeamStackPermissionScope permission) {
+        public Builder permission(Output<TeamStackPermissionScope> permission) {
             $.permission = permission;
             return this;
+        }
+
+        /**
+         * @param permission Sets the permission level that this team will be granted to the stack.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder permission(TeamStackPermissionScope permission) {
+            return permission(Output.of(permission));
         }
 
         /**

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/enums/TeamStackPermissionScope.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/enums/TeamStackPermissionScope.java
@@ -4,7 +4,7 @@
 package com.pulumi.pulumiservice.enums;
 
 import com.pulumi.core.annotations.EnumType;
-import java.lang.Double;
+import java.lang.Integer;
 import java.util.StringJoiner;
 
     @EnumType
@@ -13,26 +13,26 @@ import java.util.StringJoiner;
          * Grants read permissions to stack.
          * 
          */
-        Read(101.000000),
+        Read(101),
         /**
          * Grants edit permissions to stack.
          * 
          */
-        Edit(102.000000),
+        Edit(102),
         /**
          * Grants admin permissions to stack.
          * 
          */
-        Admin(103.000000);
+        Admin(103);
 
-        private final Double value;
+        private final Integer value;
 
-        TeamStackPermissionScope(Double value) {
+        TeamStackPermissionScope(Integer value) {
             this.value = value;
         }
 
         @EnumType.Converter
-        public Double getValue() {
+        public Integer getValue() {
             return this.value;
         }
 

--- a/sdk/nodejs/teamEnvironmentPermission.ts
+++ b/sdk/nodejs/teamEnvironmentPermission.ts
@@ -40,7 +40,7 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
     /**
      * Environment name.
      */
-    declare public readonly environment: pulumi.Output<string | undefined>;
+    declare public readonly environment: pulumi.Output<string>;
     /**
      * The maximum duration for which members of this team may open the environment.
      */
@@ -48,11 +48,11 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
     /**
      * Organization name.
      */
-    declare public readonly organization: pulumi.Output<string | undefined>;
+    declare public readonly organization: pulumi.Output<string>;
     /**
      * Which permission level to grant to the specified team.
      */
-    declare public readonly permission: pulumi.Output<enums.EnvironmentPermission | undefined>;
+    declare public readonly permission: pulumi.Output<enums.EnvironmentPermission>;
     /**
      * Project name.
      */
@@ -60,7 +60,7 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
     /**
      * Team name.
      */
-    declare public readonly team: pulumi.Output<string | undefined>;
+    declare public readonly team: pulumi.Output<string>;
 
     /**
      * Create a TeamEnvironmentPermission resource with the given unique name, arguments, and options.
@@ -100,6 +100,8 @@ export class TeamEnvironmentPermission extends pulumi.CustomResource {
             resourceInputs["team"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const replaceOnChanges = { replaceOnChanges: ["environment", "maxOpenDuration", "organization", "permission", "project", "team"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(TeamEnvironmentPermission.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/teamStackPermission.ts
+++ b/sdk/nodejs/teamStackPermission.ts
@@ -97,6 +97,8 @@ export class TeamStackPermission extends pulumi.CustomResource {
             resourceInputs["team"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const replaceOnChanges = { replaceOnChanges: ["organization", "permission", "project", "stack", "team"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(TeamStackPermission.__pulumiType, name, resourceInputs, opts);
     }
 }
@@ -112,7 +114,7 @@ export interface TeamStackPermissionArgs {
     /**
      * Sets the permission level that this team will be granted to the stack.
      */
-    permission: enums.TeamStackPermissionScope;
+    permission: pulumi.Input<enums.TeamStackPermissionScope>;
     /**
      * The project name for this stack.
      */

--- a/sdk/python/pulumi_pulumiservice/_enums.py
+++ b/sdk/python/pulumi_pulumiservice/_enums.py
@@ -192,7 +192,7 @@ class TargetActionType(_builtins.str, Enum):
 
 
 @pulumi.type_token("pulumiservice:index:TeamStackPermissionScope")
-class TeamStackPermissionScope(_builtins.float, Enum):
+class TeamStackPermissionScope(_builtins.int, Enum):
     READ = 101
     """
     Grants read permissions to stack.

--- a/sdk/python/pulumi_pulumiservice/team_environment_permission.py
+++ b/sdk/python/pulumi_pulumiservice/team_environment_permission.py
@@ -202,6 +202,8 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
             if team is None and not opts.urn:
                 raise TypeError("Missing required property 'team'")
             __props__.__dict__["team"] = team
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["environment", "maxOpenDuration", "organization", "permission", "project", "team"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(TeamEnvironmentPermission, __self__).__init__(
             'pulumiservice:index:TeamEnvironmentPermission',
             resource_name,
@@ -234,7 +236,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def environment(self) -> pulumi.Output[Optional[_builtins.str]]:
+    def environment(self) -> pulumi.Output[_builtins.str]:
         """
         Environment name.
         """
@@ -250,7 +252,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def organization(self) -> pulumi.Output[Optional[_builtins.str]]:
+    def organization(self) -> pulumi.Output[_builtins.str]:
         """
         Organization name.
         """
@@ -258,7 +260,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def permission(self) -> pulumi.Output[Optional['EnvironmentPermission']]:
+    def permission(self) -> pulumi.Output['EnvironmentPermission']:
         """
         Which permission level to grant to the specified team.
         """
@@ -274,7 +276,7 @@ class TeamEnvironmentPermission(pulumi.CustomResource):
 
     @_builtins.property
     @pulumi.getter
-    def team(self) -> pulumi.Output[Optional[_builtins.str]]:
+    def team(self) -> pulumi.Output[_builtins.str]:
         """
         Team name.
         """

--- a/sdk/python/pulumi_pulumiservice/team_stack_permission.py
+++ b/sdk/python/pulumi_pulumiservice/team_stack_permission.py
@@ -21,7 +21,7 @@ __all__ = ['TeamStackPermissionArgs', 'TeamStackPermission']
 class TeamStackPermissionArgs:
     def __init__(__self__, *,
                  organization: pulumi.Input[_builtins.str],
-                 permission: 'TeamStackPermissionScope',
+                 permission: pulumi.Input['TeamStackPermissionScope'],
                  project: pulumi.Input[_builtins.str],
                  stack: pulumi.Input[_builtins.str],
                  team: pulumi.Input[_builtins.str]):
@@ -29,7 +29,7 @@ class TeamStackPermissionArgs:
         The set of arguments for constructing a TeamStackPermission resource.
 
         :param pulumi.Input[_builtins.str] organization: The organization or the personal account name of the stack.
-        :param 'TeamStackPermissionScope' permission: Sets the permission level that this team will be granted to the stack.
+        :param pulumi.Input['TeamStackPermissionScope'] permission: Sets the permission level that this team will be granted to the stack.
         :param pulumi.Input[_builtins.str] project: The project name for this stack.
         :param pulumi.Input[_builtins.str] stack: The name of the stack that the team will be granted permissions to.
         :param pulumi.Input[_builtins.str] team: The name of the team to grant this stack permissions to. This is not the display name.
@@ -54,14 +54,14 @@ class TeamStackPermissionArgs:
 
     @_builtins.property
     @pulumi.getter
-    def permission(self) -> 'TeamStackPermissionScope':
+    def permission(self) -> pulumi.Input['TeamStackPermissionScope']:
         """
         Sets the permission level that this team will be granted to the stack.
         """
         return pulumi.get(self, "permission")
 
     @permission.setter
-    def permission(self, value: 'TeamStackPermissionScope'):
+    def permission(self, value: pulumi.Input['TeamStackPermissionScope']):
         pulumi.set(self, "permission", value)
 
     @_builtins.property
@@ -108,7 +108,7 @@ class TeamStackPermission(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  organization: pulumi.Input[Optional[_builtins.str]] = None,
-                 permission: Optional['TeamStackPermissionScope'] = None,
+                 permission: pulumi.Input[Optional['TeamStackPermissionScope']] = None,
                  project: pulumi.Input[Optional[_builtins.str]] = None,
                  stack: pulumi.Input[Optional[_builtins.str]] = None,
                  team: pulumi.Input[Optional[_builtins.str]] = None,
@@ -120,7 +120,7 @@ class TeamStackPermission(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] organization: The organization or the personal account name of the stack.
-        :param 'TeamStackPermissionScope' permission: Sets the permission level that this team will be granted to the stack.
+        :param pulumi.Input['TeamStackPermissionScope'] permission: Sets the permission level that this team will be granted to the stack.
         :param pulumi.Input[_builtins.str] project: The project name for this stack.
         :param pulumi.Input[_builtins.str] stack: The name of the stack that the team will be granted permissions to.
         :param pulumi.Input[_builtins.str] team: The name of the team to grant this stack permissions to. This is not the display name.
@@ -151,7 +151,7 @@ class TeamStackPermission(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  organization: pulumi.Input[Optional[_builtins.str]] = None,
-                 permission: Optional['TeamStackPermissionScope'] = None,
+                 permission: pulumi.Input[Optional['TeamStackPermissionScope']] = None,
                  project: pulumi.Input[Optional[_builtins.str]] = None,
                  stack: pulumi.Input[Optional[_builtins.str]] = None,
                  team: pulumi.Input[Optional[_builtins.str]] = None,
@@ -179,6 +179,8 @@ class TeamStackPermission(pulumi.CustomResource):
             if team is None and not opts.urn:
                 raise TypeError("Missing required property 'team'")
             __props__.__dict__["team"] = team
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["organization", "permission", "project", "stack", "team"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(TeamStackPermission, __self__).__init__(
             'pulumiservice:index:TeamStackPermission',
             resource_name,


### PR DESCRIPTION
Migrate the next 2 resources to `infer`. `pulumiservice:index:TeamEnvironmentPermission` is a drop-in replacement, but `pulumiservice:index:TeamStackPermission` is not.



Here, `permission` on `pulumiservice:index:TeamStackPermission` stops being plain. `infer` does not support plain inputs on custom resources, since there is generally no benefit in doing so. We should not have used `plain` here. That means this is a minor break, but in the right direction. Up to you if you think this is a good idea or not.