### PR TITLE
Drop net6.0 in favour of net8.0 for the .NET SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Breaking Changes
+- The .NET SDK (`Pulumi.PulumiService`) now targets `net8.0` and no longer supports `net6.0`. Pulumi NuGet 3.106.0 dropped `net6.0`, which made the previously-targeted framework unbuildable. Consumers must build against the .NET 8 SDK.
 - Removed the numeric `version` field from `PolicyGroup.policyPacks` inputs; it is now output-only, since the value is server-derived from `versionTag`. Use `versionTag` to pin pack versions. [#737](https://github.com/pulumi/pulumi-pulumiservice/issues/737)
 - `TeamStackPermission.permission` is no longer marked `plain` in the schema. The output is now an `Output<TeamStackPermissionScope>` rather than a plain value; consumers reading `myPerm.permission` need `.apply(...)` to access the underlying value. The input side is strictly more permissive — callers may now wire `permission` to another resource's output. The Go SDK type also changes from `float64` to `int` to match the wire format.
 - `TeamEnvironmentPermission` outputs (`organization`, `team`, `environment`, `permission`) are now typed as definitely-present (`Output<string>`, `Output<EnvironmentPermission>`) rather than optional (`Output<string | undefined>`). The values were always populated; the schema previously misrepresented them.

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,9 @@ build_dotnet: .make/build_dotnet
 .make/generate_dotnet: | mise_env
 	PULUMI_HOME=$(GEN_PULUMI_HOME) PULUMI_CONVERT_EXAMPLES_CACHE_DIR=$(GEN_PULUMI_CONVERT_EXAMPLES_CACHE_DIR) pulumi package gen-sdk provider/cmd/$(PROVIDER)/schema.json --version ${PROVIDER_VERSION} --language dotnet --out sdk/
 	printf "module fake_dotnet_module // Exclude this directory from Go tools\n\ngo 1.17\n" > sdk/dotnet/go.mod
+	# Bump TargetFramework: pulumi codegen still emits net6.0, but Pulumi NuGet
+	# 3.106.0+ dropped net6.0 support. Drop this once pulumi codegen ships net8.0.
+	perl -i -pe 's|<TargetFramework>net6\.0</TargetFramework>|<TargetFramework>net8.0</TargetFramework>|' sdk/dotnet/Pulumi.PulumiService.csproj
 	@touch $@
 .make/build_dotnet: .make/generate_dotnet
 	cd sdk/dotnet/ && dotnet build

--- a/sdk/dotnet/Pulumi.PulumiService.csproj
+++ b/sdk/dotnet/Pulumi.PulumiService.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>1.0.0-alpha.0+dev</Version>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

- Pulumi NuGet 3.106.0 was published at 2026-05-08T10:31 UTC and dropped \`net6.0\` support.
- Pulumi codegen still emits \`<TargetFramework>net6.0</TargetFramework>\` into the generated \`Pulumi.PulumiService.csproj\`, so every regenerated dotnet SDK fails with NU1202 (\"Package Pulumi 3.106.0 is not compatible with net6.0\").
- This bumps the SDK to \`net8.0\` and adds a Makefile post-process step so future regenerations stay on \`net8.0\` until pulumi codegen catches up. Example projects already target \`net8.0\`, so no other source changes are required.

## Test plan

- [x] \`make generate_dotnet\` produces a csproj with \`net8.0\` (verified locally)
- [x] \`make build_dotnet\` succeeds locally against \`Pulumi 3.106.0\`
- [ ] CI \`build_sdk (dotnet)\` passes (this PR)

## Notes

The Makefile is autogenerated by ci-mgmt. The \`perl -i -pe\` step added here will be wiped out the next time ci-mgmt regenerates the file unless ci-mgmt is updated in parallel. ci-mgmt already has an \`update_to_dotnet8\` migration but only runs it for \`bridged-provider\` / \`external-bridged-provider\` templates; this provider uses the \`generic\` template. A follow-up to widen that migration (or to bump the codegen template itself) is the proper long-term fix.