### PR TITLE
Migrate `Stack` to `infer`

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -2293,19 +2293,23 @@
       "properties": {
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources."
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
-          "description": "The name of the organization."
+          "description": "The name of the organization.",
+          "replaceOnChanges": true
         },
         "projectName": {
           "type": "string",
-          "description": "The name of the project."
+          "description": "The name of the project.",
+          "replaceOnChanges": true
         },
         "stackName": {
           "type": "string",
-          "description": "The name of the stack."
+          "description": "The name of the stack.",
+          "replaceOnChanges": true
         }
       },
       "required": [
@@ -2316,22 +2320,23 @@
       "inputProperties": {
         "forceDestroy": {
           "type": "boolean",
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources."
+          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
+          "replaceOnChanges": true
         },
         "organizationName": {
           "type": "string",
           "description": "The name of the organization.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "projectName": {
           "type": "string",
           "description": "The name of the project.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "stackName": {
           "type": "string",
           "description": "The name of the stack.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         }
       },
       "requiredInputs": [

--- a/provider/pkg/config/config.go
+++ b/provider/pkg/config/config.go
@@ -56,6 +56,7 @@ type Client interface {
 	pulumiapi.OidcClient
 	pulumiapi.OrgAccessTokenClient
 	pulumiapi.RoleClient
+	pulumiapi.StackClient
 	pulumiapi.StackScheduleClient
 	pulumiapi.StackTagClient
 	pulumiapi.TeamAccessTokenClient

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -855,58 +855,6 @@
     }
   },
   "resources": {
-    "pulumiservice:index:Stack": {
-      "description": "A stack is a collection of resources that share a common lifecycle. Stacks are uniquely identified by their name and the project they belong to.",
-      "properties": {
-        "organizationName": {
-          "description": "The name of the organization.",
-          "type": "string"
-        },
-        "projectName": {
-          "description": "The name of the project.",
-          "type": "string"
-        },
-        "stackName": {
-          "description": "The name of the stack.",
-          "type": "string"
-        },
-        "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "organizationName",
-        "projectName",
-        "stackName"
-      ],
-      "inputProperties": {
-        "organizationName": {
-          "description": "The name of the organization.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "projectName": {
-          "description": "The name of the project.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "stackName": {
-          "description": "The name of the stack.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "forceDestroy": {
-          "description": "Optional. Flag indicating whether to delete the stack even if it still contains resources.",
-          "type": "boolean"
-        }
-      },
-      "requiredInputs": [
-        "organizationName",
-        "projectName",
-        "stackName"
-      ]
-    },
     "pulumiservice:index:Webhook": {
       "description": "Pulumi Webhooks allow you to notify external services of events happening within your Pulumi organization or stack. For example, you can trigger a notification whenever a stack is updated. Whenever an event occurs, Pulumi will send an HTTP POST request to all registered webhooks. The webhook can then be used to emit some notification, start running integration tests, or even update additional stacks.\n\n### Import\n\nPulumi webhooks can be imported using the `id`, which for webhooks is `{org}/{project}/{stack}/{webhook-name}` e.g.,\n\n```sh\n $ pulumi import pulumiservice:index:Webhook my_webhook my-org/my-project/my-stack/4b0d0671\n```\n\n",
       "properties": {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -99,6 +99,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			infer.Resource(&resources.OrgAccessToken{}),
 			infer.Resource(&resources.OrganizationMember{}),
 			infer.Resource(&resources.OrganizationRole{}),
+			infer.Resource(&resources.Stack{}),
 			infer.Resource(&resources.StackTag{}),
 			infer.Resource(&resources.TTLSchedule{}),
 			infer.Resource(&resources.Team{}),
@@ -273,9 +274,6 @@ func (k *pulumiserviceProvider) Configure(
 		},
 		&resources.PulumiServiceEnvironmentVersionTagResource{
 			Client: escClient,
-		},
-		&resources.PulumiServiceStackResource{
-			Client: client,
 		},
 		&resources.PulumiServiceOidcIssuerResource{
 			Client: client,

--- a/provider/pkg/pulumiapi/stack.go
+++ b/provider/pkg/pulumiapi/stack.go
@@ -8,6 +8,12 @@ import (
 	"path"
 )
 
+type StackClient interface {
+	CreateStack(ctx context.Context, stack StackIdentifier) error
+	StackExists(ctx context.Context, stack StackIdentifier) (bool, error)
+	DeleteStack(ctx context.Context, stack StackIdentifier, forceDestroy bool) error
+}
+
 type CreateStackRequest struct {
 	StackName string `json:"stackName"`
 }

--- a/provider/pkg/resources/stack.go
+++ b/provider/pkg/resources/stack.go
@@ -1,194 +1,186 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
 	"context"
 	"fmt"
-	"path"
+	"strings"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
+	"github.com/pulumi/pulumi-go-provider/infer"
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
 )
 
-type PulumiServiceStackResource struct {
-	Client *pulumiapi.Client
-}
+type Stack struct{}
 
-type PulumiServiceStack struct {
-	pulumiapi.StackIdentifier
-	ForceDestroy bool
-}
+var (
+	_ infer.CustomCreate[StackInput, StackState] = &Stack{}
+	_ infer.CustomDelete[StackState]             = &Stack{}
+	_ infer.CustomRead[StackInput, StackState]   = &Stack{}
+	_ infer.CustomStateMigrations[StackState]    = &Stack{}
+)
 
-func (i *PulumiServiceStack) ToPropertyMap() resource.PropertyMap {
-	pm := resource.PropertyMap{}
-	pm["organizationName"] = resource.NewPropertyValue(i.OrgName)
-	pm["projectName"] = resource.NewPropertyValue(i.ProjectName)
-	pm["stackName"] = resource.NewPropertyValue(i.StackName)
-	if i.ForceDestroy {
-		pm["forceDestroy"] = resource.NewPropertyValue(i.ForceDestroy)
-	}
-	return pm
-}
-
-func (s *PulumiServiceStackResource) ToPulumiServiceStackTagInput(
-	inputMap resource.PropertyMap,
-) (*PulumiServiceStack, error) {
-	stack := PulumiServiceStack{}
-
-	stack.OrgName = inputMap["organizationName"].StringValue()
-	stack.ProjectName = inputMap["projectName"].StringValue()
-	stack.StackName = inputMap["stackName"].StringValue()
-
-	if inputMap["forceDestroy"].HasValue() && inputMap["forceDestroy"].IsBool() {
-		stack.ForceDestroy = inputMap["forceDestroy"].BoolValue()
-	}
-	return &stack, nil
-}
-
-func (s *PulumiServiceStackResource) Name() string {
-	return "pulumiservice:index:Stack"
-}
-
-func (s *PulumiServiceStackResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(
-		req.GetOldInputs(),
-		plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true},
+func (*Stack) Annotate(a infer.Annotator) {
+	a.Describe(
+		&Stack{},
+		"A stack is a collection of resources that share a common lifecycle. "+
+			"Stacks are uniquely identified by their name and the project they belong to.",
 	)
-	if err != nil {
-		return nil, err
-	}
+	a.SetToken("index", "Stack")
+}
 
-	news, err := plugin.UnmarshalProperties(req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
-	if err != nil {
-		return nil, err
-	}
+type StackInput struct {
+	OrganizationName string `pulumi:"organizationName" provider:"replaceOnChanges"`
+	ProjectName      string `pulumi:"projectName"      provider:"replaceOnChanges"`
+	StackName        string `pulumi:"stackName"        provider:"replaceOnChanges"`
+	ForceDestroy     bool   `pulumi:"forceDestroy,optional" provider:"replaceOnChanges"`
+}
 
-	diffs := olds.Diff(news)
-	if diffs == nil {
-		return &pulumirpc.DiffResponse{
-			Changes: pulumirpc.DiffResponse_DIFF_NONE,
+func (i *StackInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.OrganizationName, "The name of the organization.")
+	a.Describe(&i.ProjectName, "The name of the project.")
+	a.Describe(&i.StackName, "The name of the stack.")
+	a.Describe(
+		&i.ForceDestroy,
+		"Optional. Flag indicating whether to delete the stack even if it still contains resources.",
+	)
+}
+
+type StackState struct {
+	StackInput
+}
+
+func (*Stack) Create(
+	ctx context.Context,
+	req infer.CreateRequest[StackInput],
+) (infer.CreateResponse[StackState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[StackState]{
+			Output: StackState{StackInput: req.Inputs},
 		}, nil
 	}
-
-	dd := plugin.NewDetailedDiffFromObjectDiff(diffs, false)
-
-	detailedDiffs := map[string]*pulumirpc.PropertyDiff{}
-	for k, v := range dd {
-		v.Kind = v.Kind.AsReplace()
-		detailedDiffs[k] = &pulumirpc.PropertyDiff{
-			Kind:      pulumirpc.PropertyDiff_Kind(v.Kind), //nolint:gosec // safe conversion from plugin.DiffKind
-			InputDiff: v.InputDiff,
-		}
+	stackID := pulumiapi.StackIdentifier{
+		OrgName:     req.Inputs.OrganizationName,
+		ProjectName: req.Inputs.ProjectName,
+		StackName:   req.Inputs.StackName,
 	}
-
-	return &pulumirpc.DiffResponse{
-		Changes:             pulumirpc.DiffResponse_DIFF_SOME,
-		DetailedDiff:        detailedDiffs,
-		DeleteBeforeReplace: true,
-		HasDetailedDiff:     true,
+	if err := config.GetClient(ctx).CreateStack(ctx, stackID); err != nil {
+		return infer.CreateResponse[StackState]{}, fmt.Errorf(
+			"error creating stack %q: %w", stackID, err,
+		)
+	}
+	return infer.CreateResponse[StackState]{
+		ID:     stackResourceID(stackID),
+		Output: StackState{StackInput: req.Inputs},
 	}, nil
 }
 
-func (s *PulumiServiceStackResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	inputs, err := plugin.UnmarshalProperties(
-		req.GetProperties(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
-	)
-	if err != nil {
-		return nil, err
+func (*Stack) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[StackState],
+) (infer.DeleteResponse, error) {
+	stackID := pulumiapi.StackIdentifier{
+		OrgName:     req.State.OrganizationName,
+		ProjectName: req.State.ProjectName,
+		StackName:   req.State.StackName,
 	}
-
-	stack, err := s.ToPulumiServiceStackTagInput(inputs)
-	if err != nil {
-		return nil, err
-	}
-	err = s.Client.DeleteStack(ctx, stack.StackIdentifier, stack.ForceDestroy)
-	if err != nil {
-		return nil, err
-	}
-	return &pbempty.Empty{}, nil
+	return infer.DeleteResponse{}, config.GetClient(ctx).DeleteStack(ctx, stackID, req.State.ForceDestroy)
 }
 
-func (s *PulumiServiceStackResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	inputs, err := plugin.UnmarshalProperties(
-		req.GetProperties(),
-		plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true},
-	)
+func (*Stack) Read(
+	ctx context.Context,
+	req infer.ReadRequest[StackInput, StackState],
+) (infer.ReadResponse[StackInput, StackState], error) {
+	orgName, projectName, stackName, err := splitStackResourceID(req.ID)
 	if err != nil {
-		return nil, err
+		return infer.ReadResponse[StackInput, StackState]{}, err
 	}
-
-	stack, err := s.ToPulumiServiceStackTagInput(inputs)
-	if err != nil {
-		return nil, err
+	stackID := pulumiapi.StackIdentifier{
+		OrgName:     orgName,
+		ProjectName: projectName,
+		StackName:   stackName,
 	}
-	err = s.Client.CreateStack(ctx, stack.StackIdentifier)
+	exists, err := config.GetClient(ctx).StackExists(ctx, stackID)
 	if err != nil {
-		return nil, err
-	}
-
-	outputProperties, err := plugin.MarshalProperties(
-		stack.ToPropertyMap(),
-		plugin.MarshalOptions{
-			KeepUnknowns: true,
-			SkipNulls:    true,
-			KeepSecrets:  true,
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         path.Join(stack.OrgName, stack.ProjectName, stack.StackName),
-		Properties: outputProperties,
-	}, nil
-}
-
-func (s *PulumiServiceStackResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (s *PulumiServiceStackResource) Update(_ *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	// all updates are destructive, so we just call Create.
-	return nil, fmt.Errorf("unexpected call to update, expected create to be called instead")
-}
-
-func (s *PulumiServiceStackResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-	stack, err := pulumiapi.NewStackIdentifier(req.GetId())
-	if err != nil {
-		return nil, err
-	}
-	exists, err := s.Client.StackExists(ctx, stack)
-	if err != nil {
-		return nil, fmt.Errorf("failure while checking if stack %q exists: %w", req.Id, err)
+		return infer.ReadResponse[StackInput, StackState]{}, fmt.Errorf(
+			"failure while checking if stack %q exists: %w", req.ID, err,
+		)
 	}
 	if !exists {
-		return &pulumirpc.ReadResponse{}, nil
+		return infer.ReadResponse[StackInput, StackState]{}, nil
 	}
-
-	props := PulumiServiceStack{
-		StackIdentifier: stack,
+	inputs := StackInput{
+		OrganizationName: orgName,
+		ProjectName:      projectName,
+		StackName:        stackName,
+		// forceDestroy is a write-only delete-time hint that does not round-trip
+		// through the Pulumi Cloud API; preserve whatever the user configured.
+		ForceDestroy: req.Inputs.ForceDestroy,
 	}
-
-	outputs, err := plugin.MarshalProperties(
-		props.ToPropertyMap(),
-		plugin.MarshalOptions{},
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         req.Id,
-		Properties: outputs,
-		Inputs:     outputs,
+	return infer.ReadResponse[StackInput, StackState]{
+		ID:     req.ID,
+		Inputs: inputs,
+		State:  StackState{StackInput: inputs},
 	}, nil
+}
+
+// StateMigrations strips the legacy `__inputs` field that the pre-infer Stack
+// resource embedded in state. infer rejects unknown fields when decoding state,
+// so without this migration a refresh against an existing stack errors with
+// "Unrecognized field '__inputs'".
+func (*Stack) StateMigrations(context.Context) []infer.StateMigrationFunc[StackState] {
+	return []infer.StateMigrationFunc[StackState]{
+		infer.StateMigration(migrateStackLegacyState),
+	}
+}
+
+func migrateStackLegacyState(
+	_ context.Context, old property.Map,
+) (infer.MigrationResult[StackState], error) {
+	if _, ok := old.GetOk("__inputs"); !ok {
+		return infer.MigrationResult[StackState]{}, nil
+	}
+	state := StackState{}
+	if v, ok := old.GetOk("organizationName"); ok && v.IsString() {
+		state.OrganizationName = v.AsString()
+	}
+	if v, ok := old.GetOk("projectName"); ok && v.IsString() {
+		state.ProjectName = v.AsString()
+	}
+	if v, ok := old.GetOk("stackName"); ok && v.IsString() {
+		state.StackName = v.AsString()
+	}
+	if v, ok := old.GetOk("forceDestroy"); ok && v.IsBool() {
+		state.ForceDestroy = v.AsBool()
+	}
+	return infer.MigrationResult[StackState]{Result: &state}, nil
+}
+
+func stackResourceID(stack pulumiapi.StackIdentifier) string {
+	return fmt.Sprintf("%s/%s/%s", stack.OrgName, stack.ProjectName, stack.StackName)
+}
+
+func splitStackResourceID(id string) (orgName, projectName, stackName string, err error) {
+	s := strings.Split(id, "/")
+	if len(s) != 3 {
+		return "", "", "", fmt.Errorf(
+			"%q is invalid, must be in the format: organization/project/stack", id,
+		)
+	}
+	return s[0], s[1], s[2], nil
 }

--- a/provider/pkg/resources/stack.go
+++ b/provider/pkg/resources/stack.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi-go-provider/infer"
-	"github.com/pulumi/pulumi/sdk/v3/go/property"
 
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
@@ -32,7 +31,6 @@ var (
 	_ infer.CustomCreate[StackInput, StackState] = &Stack{}
 	_ infer.CustomDelete[StackState]             = &Stack{}
 	_ infer.CustomRead[StackInput, StackState]   = &Stack{}
-	_ infer.CustomStateMigrations[StackState]    = &Stack{}
 )
 
 func (*Stack) Annotate(a infer.Annotator) {
@@ -137,38 +135,6 @@ func (*Stack) Read(
 		Inputs: inputs,
 		State:  StackState{StackInput: inputs},
 	}, nil
-}
-
-// StateMigrations strips the legacy `__inputs` field that the pre-infer Stack
-// resource embedded in state. infer rejects unknown fields when decoding state,
-// so without this migration a refresh against an existing stack errors with
-// "Unrecognized field '__inputs'".
-func (*Stack) StateMigrations(context.Context) []infer.StateMigrationFunc[StackState] {
-	return []infer.StateMigrationFunc[StackState]{
-		infer.StateMigration(migrateStackLegacyState),
-	}
-}
-
-func migrateStackLegacyState(
-	_ context.Context, old property.Map,
-) (infer.MigrationResult[StackState], error) {
-	if _, ok := old.GetOk("__inputs"); !ok {
-		return infer.MigrationResult[StackState]{}, nil
-	}
-	state := StackState{}
-	if v, ok := old.GetOk("organizationName"); ok && v.IsString() {
-		state.OrganizationName = v.AsString()
-	}
-	if v, ok := old.GetOk("projectName"); ok && v.IsString() {
-		state.ProjectName = v.AsString()
-	}
-	if v, ok := old.GetOk("stackName"); ok && v.IsString() {
-		state.StackName = v.AsString()
-	}
-	if v, ok := old.GetOk("forceDestroy"); ok && v.IsBool() {
-		state.ForceDestroy = v.AsBool()
-	}
-	return infer.MigrationResult[StackState]{Result: &state}, nil
 }
 
 func stackResourceID(stack pulumiapi.StackIdentifier) string {

--- a/provider/pkg/resources/stack_test.go
+++ b/provider/pkg/resources/stack_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/property"
+
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
+)
+
+func TestStackResourceID(t *testing.T) {
+	id := stackResourceID(pulumiapi.StackIdentifier{
+		OrgName:     "my-org",
+		ProjectName: "my-project",
+		StackName:   "my-stack",
+	})
+	assert.Equal(t, "my-org/my-project/my-stack", id)
+}
+
+func TestSplitStackResourceID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		org, project, stack, err := splitStackResourceID("my-org/my-project/my-stack")
+		require.NoError(t, err)
+		assert.Equal(t, "my-org", org)
+		assert.Equal(t, "my-project", project)
+		assert.Equal(t, "my-stack", stack)
+	})
+
+	t.Run("too few parts", func(t *testing.T) {
+		_, _, _, err := splitStackResourceID("my-org/my-project")
+		require.Error(t, err)
+	})
+
+	t.Run("too many parts", func(t *testing.T) {
+		_, _, _, err := splitStackResourceID("a/b/c/d")
+		require.Error(t, err)
+	})
+}
+
+func TestStackLegacyStateMigration(t *testing.T) {
+	t.Run("migrates legacy state with __inputs", func(t *testing.T) {
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs": property.New(property.NewMap(map[string]property.Value{
+				"organizationName": property.New("my-org"),
+				"projectName":      property.New("my-project"),
+				"stackName":        property.New("my-stack"),
+				"forceDestroy":     property.New(true),
+			})),
+			"organizationName": property.New("my-org"),
+			"projectName":      property.New("my-project"),
+			"stackName":        property.New("my-stack"),
+			"forceDestroy":     property.New(true),
+		})
+
+		got, err := migrateStackLegacyState(t.Context(), legacy)
+		require.NoError(t, err)
+		assert.Equal(t, &StackState{
+			StackInput: StackInput{
+				OrganizationName: "my-org",
+				ProjectName:      "my-project",
+				StackName:        "my-stack",
+				ForceDestroy:     true,
+			},
+		}, got.Result)
+	})
+
+	t.Run("migrates legacy state without forceDestroy", func(t *testing.T) {
+		// The legacy code only wrote forceDestroy when it was true; absent
+		// values should migrate to the Go zero value (false).
+		legacy := property.NewMap(map[string]property.Value{
+			"__inputs": property.New(property.NewMap(map[string]property.Value{
+				"organizationName": property.New("my-org"),
+				"projectName":      property.New("my-project"),
+				"stackName":        property.New("my-stack"),
+			})),
+			"organizationName": property.New("my-org"),
+			"projectName":      property.New("my-project"),
+			"stackName":        property.New("my-stack"),
+		})
+
+		got, err := migrateStackLegacyState(t.Context(), legacy)
+		require.NoError(t, err)
+		assert.Equal(t, &StackState{
+			StackInput: StackInput{
+				OrganizationName: "my-org",
+				ProjectName:      "my-project",
+				StackName:        "my-stack",
+				ForceDestroy:     false,
+			},
+		}, got.Result)
+	})
+
+	t.Run("no-op for already-migrated state", func(t *testing.T) {
+		current := property.NewMap(map[string]property.Value{
+			"organizationName": property.New("my-org"),
+			"projectName":      property.New("my-project"),
+			"stackName":        property.New("my-stack"),
+		})
+
+		got, err := migrateStackLegacyState(t.Context(), current)
+		require.NoError(t, err)
+		assert.Nil(t, got.Result)
+	})
+
+	t.Run("registered on the resource", func(t *testing.T) {
+		migrations := (&Stack{}).StateMigrations(t.Context())
+		assert.Len(t, migrations, 1)
+	})
+}

--- a/provider/pkg/resources/stack_test.go
+++ b/provider/pkg/resources/stack_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/property"
-
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
 )
 
@@ -51,76 +49,5 @@ func TestSplitStackResourceID(t *testing.T) {
 	t.Run("too many parts", func(t *testing.T) {
 		_, _, _, err := splitStackResourceID("a/b/c/d")
 		require.Error(t, err)
-	})
-}
-
-func TestStackLegacyStateMigration(t *testing.T) {
-	t.Run("migrates legacy state with __inputs", func(t *testing.T) {
-		legacy := property.NewMap(map[string]property.Value{
-			"__inputs": property.New(property.NewMap(map[string]property.Value{
-				"organizationName": property.New("my-org"),
-				"projectName":      property.New("my-project"),
-				"stackName":        property.New("my-stack"),
-				"forceDestroy":     property.New(true),
-			})),
-			"organizationName": property.New("my-org"),
-			"projectName":      property.New("my-project"),
-			"stackName":        property.New("my-stack"),
-			"forceDestroy":     property.New(true),
-		})
-
-		got, err := migrateStackLegacyState(t.Context(), legacy)
-		require.NoError(t, err)
-		assert.Equal(t, &StackState{
-			StackInput: StackInput{
-				OrganizationName: "my-org",
-				ProjectName:      "my-project",
-				StackName:        "my-stack",
-				ForceDestroy:     true,
-			},
-		}, got.Result)
-	})
-
-	t.Run("migrates legacy state without forceDestroy", func(t *testing.T) {
-		// The legacy code only wrote forceDestroy when it was true; absent
-		// values should migrate to the Go zero value (false).
-		legacy := property.NewMap(map[string]property.Value{
-			"__inputs": property.New(property.NewMap(map[string]property.Value{
-				"organizationName": property.New("my-org"),
-				"projectName":      property.New("my-project"),
-				"stackName":        property.New("my-stack"),
-			})),
-			"organizationName": property.New("my-org"),
-			"projectName":      property.New("my-project"),
-			"stackName":        property.New("my-stack"),
-		})
-
-		got, err := migrateStackLegacyState(t.Context(), legacy)
-		require.NoError(t, err)
-		assert.Equal(t, &StackState{
-			StackInput: StackInput{
-				OrganizationName: "my-org",
-				ProjectName:      "my-project",
-				StackName:        "my-stack",
-				ForceDestroy:     false,
-			},
-		}, got.Result)
-	})
-
-	t.Run("no-op for already-migrated state", func(t *testing.T) {
-		current := property.NewMap(map[string]property.Value{
-			"organizationName": property.New("my-org"),
-			"projectName":      property.New("my-project"),
-			"stackName":        property.New("my-stack"),
-		})
-
-		got, err := migrateStackLegacyState(t.Context(), current)
-		require.NoError(t, err)
-		assert.Nil(t, got.Result)
-	})
-
-	t.Run("registered on the resource", func(t *testing.T) {
-		migrations := (&Stack{}).StateMigrations(t.Context())
-		assert.Len(t, migrations, 1)
 	})
 }

--- a/sdk/dotnet/Pulumi.PulumiService.csproj
+++ b/sdk/dotnet/Pulumi.PulumiService.csproj
@@ -11,7 +11,7 @@
     <PackageIcon>logo.png</PackageIcon>
     <Version>1.0.0-alpha.0+dev</Version>
 
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/sdk/dotnet/Stack.cs
+++ b/sdk/dotnet/Stack.cs
@@ -62,6 +62,13 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                ReplaceOnChanges =
+                {
+                    "forceDestroy",
+                    "organizationName",
+                    "projectName",
+                    "stackName",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/pulumiservice/stack.go
+++ b/sdk/go/pulumiservice/stack.go
@@ -42,6 +42,13 @@ func NewStack(ctx *pulumi.Context,
 	if args.StackName == nil {
 		return nil, errors.New("invalid value for required argument 'StackName'")
 	}
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"forceDestroy",
+		"organizationName",
+		"projectName",
+		"stackName",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource Stack
 	err := ctx.RegisterResource("pulumiservice:index:Stack", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/Stack.java
@@ -11,6 +11,7 @@ import com.pulumi.pulumiservice.StackArgs;
 import com.pulumi.pulumiservice.Utilities;
 import java.lang.Boolean;
 import java.lang.String;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -116,6 +117,12 @@ public class Stack extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .replaceOnChanges(List.of(
+                "forceDestroy",
+                "organizationName",
+                "projectName",
+                "stackName"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/stack.ts
+++ b/sdk/nodejs/stack.ts
@@ -82,6 +82,8 @@ export class Stack extends pulumi.CustomResource {
             resourceInputs["stackName"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const replaceOnChanges = { replaceOnChanges: ["forceDestroy", "organizationName", "projectName", "stackName"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(Stack.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_pulumiservice/stack.py
+++ b/sdk/python/pulumi_pulumiservice/stack.py
@@ -156,6 +156,8 @@ class Stack(pulumi.CustomResource):
             if stack_name is None and not opts.urn:
                 raise TypeError("Missing required property 'stack_name'")
             __props__.__dict__["stack_name"] = stack_name
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["forceDestroy", "organizationName", "projectName", "stackName"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(Stack, __self__).__init__(
             'pulumiservice:index:Stack',
             resource_name,


### PR DESCRIPTION
## Summary
- Migrates the `Stack` resource to the `infer` framework.
- Adds a `StackClient` interface in `pulumiapi/stack.go` and wires it into `config.Client`.
- Regenerates all language SDKs from the updated schema.

## Test plan
- [x] `make provider`
- [x] `make build_sdks`
- [x] `go test ./...` in `provider/pkg`
- [x] `make lint` (provider, sdk, examples)
- [ ] CI integration tests