### PR TITLE
Migrate `ApprovalRule` to `infer`

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -523,15 +523,18 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "The environment name."
+          "description": "The environment name.",
+          "replaceOnChanges": true
         },
         "organization": {
           "type": "string",
-          "description": "The organization name."
+          "description": "The organization name.",
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
-          "description": "The project name."
+          "description": "The project name.",
+          "replaceOnChanges": true
         }
       },
       "type": "object",

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -4924,7 +4924,8 @@
         },
         "name": {
           "type": "string",
-          "description": "Name of the approval rule."
+          "description": "The name of the approval rule.",
+          "replaceOnChanges": true
         },
         "targetActionTypes": {
           "type": "array",
@@ -4957,7 +4958,7 @@
         "name": {
           "type": "string",
           "description": "The name of the approval rule.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "targetActionTypes": {
           "type": "array",

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -565,95 +565,6 @@
       },
       "type": "object"
     },
-    "pulumiservice:index:TargetActionType": {
-      "type": "string",
-      "enum": [
-        {
-          "description": "Update action type for approval rules.",
-          "value": "update",
-          "name": "Update"
-        }
-      ]
-    },
-    "pulumiservice:index:RbacPermission": {
-      "type": "string",
-      "enum": [
-        {
-          "description": "Read permission.",
-          "value": "environment:read",
-          "name": "Read"
-        },
-        {
-          "description": "Read and decrypt permission.",
-          "value": "environment:read_decrypt",
-          "name": "ReadDecrypt"
-        },
-        {
-          "description": "Open permission.",
-          "value": "environment:open",
-          "name": "Open"
-        },
-        {
-          "description": "Write permission.",
-          "value": "environment:write",
-          "name": "Write"
-        },
-        {
-          "description": "Delete permission.",
-          "value": "environment:delete",
-          "name": "Delete"
-        },
-        {
-          "description": "Clone permission.",
-          "value": "environment:clone",
-          "name": "Clone"
-        },
-        {
-          "description": "Rotate permission.",
-          "value": "environment:rotate",
-          "name": "Rotate"
-        }
-      ]
-    },
-    "pulumiservice:index:EnvironmentIdentifier": {
-      "type": "object",
-      "properties": {
-        "organization": {
-          "type": "string",
-          "description": "The organization name."
-        },
-        "project": {
-          "type": "string",
-          "description": "The project name."
-        },
-        "name": {
-          "type": "string",
-          "description": "The environment name."
-        }
-      },
-      "required": [
-        "organization",
-        "project",
-        "name"
-      ]
-    },
-    "pulumiservice:index:EligibleApprover": {
-      "type": "object",
-      "properties": {
-        "teamName": {
-          "type": "string",
-          "description": "Name of the team that can approve."
-        },
-        "user": {
-          "type": "string",
-          "description": "Login of the user that can approve."
-        },
-        "rbacPermission": {
-          "$ref": "#/types/pulumiservice:index:RbacPermission",
-          "description": "RBAC permission that gives right to approve."
-        }
-      }
-    },
     "pulumiservice:index:PolicyGroupStackReference": {
       "type": "object",
       "description": "A reference to a stack within a policy group.",
@@ -730,36 +641,6 @@
       },
       "required": [
         "name"
-      ]
-    },
-    "pulumiservice:index:ApprovalRuleConfig": {
-      "type": "object",
-      "properties": {
-        "numApprovalsRequired": {
-          "type": "integer",
-          "description": "Number of approvals required."
-        },
-        "allowSelfApproval": {
-          "type": "boolean",
-          "description": "Whether self-approval is allowed."
-        },
-        "requireReapprovalOnChange": {
-          "type": "boolean",
-          "description": "Whether reapproval is required on changes."
-        },
-        "eligibleApprovers": {
-          "type": "array",
-          "items": {
-            "$ref": "#/types/pulumiservice:index:EligibleApprover"
-          },
-          "description": "List of eligible approvers."
-        }
-      },
-      "required": [
-        "numApprovalsRequired",
-        "allowSelfApproval",
-        "requireReapprovalOnChange",
-        "eligibleApprovers"
       ]
     }
   },
@@ -1113,74 +994,6 @@
         "organization",
         "name",
         "yaml"
-      ]
-    },
-    "pulumiservice:index:ApprovalRule": {
-      "description": "An approval rule for environment deployments.",
-      "properties": {
-        "name": {
-          "description": "Name of the approval rule.",
-          "type": "string"
-        },
-        "enabled": {
-          "description": "Whether the approval rule is enabled.",
-          "type": "boolean"
-        },
-        "targetActionTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/types/pulumiservice:index:TargetActionType"
-          },
-          "description": "The type of action this rule applies to."
-        },
-        "environmentIdentifier": {
-          "$ref": "#/types/pulumiservice:index:EnvironmentIdentifier",
-          "description": "The environment this rule applies to."
-        },
-        "approvalRuleConfig": {
-          "$ref": "#/types/pulumiservice:index:ApprovalRuleConfig",
-          "description": "The approval rule configuration."
-        }
-      },
-      "required": [
-        "name",
-        "enabled",
-        "targetActionTypes",
-        "environmentIdentifier",
-        "approvalRuleConfig"
-      ],
-      "inputProperties": {
-        "name": {
-          "description": "The name of the approval rule.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "enabled": {
-          "description": "Whether the approval rule is enabled.",
-          "type": "boolean"
-        },
-        "targetActionTypes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/types/pulumiservice:index:TargetActionType"
-          },
-          "description": "The type of action this rule applies to."
-        },
-        "environmentIdentifier": {
-          "$ref": "#/types/pulumiservice:index:EnvironmentIdentifier",
-          "description": "The environment this rule applies to."
-        },
-        "approvalRuleConfig": {
-          "$ref": "#/types/pulumiservice:index:ApprovalRuleConfig",
-          "description": "The approval rule configuration."
-        }
-      },
-      "requiredInputs": [
-        "name",
-        "enabled",
-        "targetActionTypes",
-        "environmentIdentifier",
-        "approvalRuleConfig"
       ]
     },
     "pulumiservice:index:PolicyGroup": {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -138,6 +138,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 		WithResources(
 			infer.Resource(&resources.AccessToken{}),
 			infer.Resource(&resources.AgentPool{}),
+			infer.Resource(&resources.ApprovalRule{}),
 			infer.Resource(&resources.DeploymentSchedule{}),
 			infer.Resource(&resources.DriftSchedule{}),
 			infer.Resource(&resources.EnvironmentRotationSchedule{}),
@@ -417,9 +418,6 @@ func (k *pulumiserviceProvider) Configure(
 		&resources.PulumiServiceEnvironmentResource{
 			Client:         escClient,
 			MetadataClient: client,
-		},
-		&resources.PulumiServiceApprovalRuleResource{
-			Client: client,
 		},
 		&resources.PulumiServicePolicyGroupResource{
 			Client: client,

--- a/provider/pkg/resources/approvalRule.go
+++ b/provider/pkg/resources/approvalRule.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -5,388 +19,362 @@ import (
 	"fmt"
 	"strings"
 
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
+	p "github.com/pulumi/pulumi-go-provider"
+	"github.com/pulumi/pulumi-go-provider/infer"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
 )
 
-type PulumiServiceApprovalRuleResource struct {
-	Client pulumiapi.ApprovalRuleClient
+type ApprovalRule struct{}
+
+var (
+	_ infer.CustomCheck[ApprovalRuleInput]                     = &ApprovalRule{}
+	_ infer.CustomCreate[ApprovalRuleInput, ApprovalRuleState] = &ApprovalRule{}
+	_ infer.CustomUpdate[ApprovalRuleInput, ApprovalRuleState] = &ApprovalRule{}
+	_ infer.CustomDelete[ApprovalRuleState]                    = &ApprovalRule{}
+	_ infer.CustomRead[ApprovalRuleInput, ApprovalRuleState]   = &ApprovalRule{}
+)
+
+func (*ApprovalRule) Annotate(a infer.Annotator) {
+	a.Describe(&ApprovalRule{}, "An approval rule for environment deployments.")
+	a.SetToken("index", "ApprovalRule")
 }
 
-type PulumiServiceApprovalRule struct {
-	Name                  string                          `json:"name"`
-	Enabled               bool                            `json:"enabled"`
-	TargetActionTypes     []string                        `json:"targetActionTypes"`
-	EnvironmentIdentifier pulumiapi.EnvironmentIdentifier `json:"environmentIdentifier"`
-	ApprovalRuleConfig    pulumiapi.ApprovalRuleInput     `json:"approvalRuleConfig"`
-}
+// TargetActionType enumerates the action types an approval rule applies to.
+type TargetActionType string
 
-func (i *PulumiServiceApprovalRule) ToPropertyMap() resource.PropertyMap {
-	pm := resource.PropertyMap{}
-	pm["name"] = resource.NewPropertyValue(i.Name)
-	pm["enabled"] = resource.NewPropertyValue(i.Enabled)
-	pm["targetActionTypes"] = resource.NewPropertyValue(i.TargetActionTypes)
+const (
+	TargetActionTypeUpdate TargetActionType = "update"
+)
 
-	// Environment identifier
-	envMap := resource.PropertyMap{}
-	envMap["organization"] = resource.NewPropertyValue(i.EnvironmentIdentifier.OrgName)
-	envMap["project"] = resource.NewPropertyValue(i.EnvironmentIdentifier.ProjectName)
-	envMap["name"] = resource.NewPropertyValue(i.EnvironmentIdentifier.EnvName)
-	pm["environmentIdentifier"] = resource.NewPropertyValue(envMap)
-
-	// Approval rule config
-	ruleMap := resource.PropertyMap{}
-	ruleMap["numApprovalsRequired"] = resource.NewPropertyValue(i.ApprovalRuleConfig.NumApprovalsRequired)
-	ruleMap["allowSelfApproval"] = resource.NewPropertyValue(i.ApprovalRuleConfig.AllowSelfApproval)
-	ruleMap["requireReapprovalOnChange"] = resource.NewPropertyValue(i.ApprovalRuleConfig.RequireReapprovalOnChange)
-
-	// Eligible approvers
-	approvers := []resource.PropertyValue{}
-	for _, approver := range i.ApprovalRuleConfig.EligibleApprovers {
-		approverMap := resource.PropertyMap{}
-		if approver.TeamName != "" {
-			approverMap["teamName"] = resource.NewPropertyValue(approver.TeamName)
-		}
-		if approver.User != "" {
-			approverMap["user"] = resource.NewPropertyValue(approver.User)
-		}
-		if approver.RbacPermission != "" {
-			approverMap["rbacPermission"] = resource.NewPropertyValue(approver.RbacPermission)
-		}
-		approvers = append(approvers, resource.NewPropertyValue(approverMap))
+func (TargetActionType) Values() []infer.EnumValue[TargetActionType] {
+	return []infer.EnumValue[TargetActionType]{
+		{Name: "Update", Value: TargetActionTypeUpdate, Description: "Update action type for approval rules."},
 	}
-	ruleMap["eligibleApprovers"] = resource.NewPropertyValue(approvers)
-	pm["approvalRuleConfig"] = resource.NewPropertyValue(ruleMap)
-
-	return pm
 }
 
-func (s *PulumiServiceApprovalRuleResource) ToPulumiServiceApprovalRuleInput(
-	inputMap resource.PropertyMap,
-) (*PulumiServiceApprovalRule, error) {
-	rule := PulumiServiceApprovalRule{}
+// RbacPermission enumerates the RBAC permissions that may be required for approval.
+type RbacPermission string
 
-	rule.Name = inputMap["name"].StringValue()
-	rule.Enabled = inputMap["enabled"].BoolValue()
+const (
+	RbacPermissionRead        RbacPermission = "environment:read"
+	RbacPermissionReadDecrypt RbacPermission = "environment:read_decrypt"
+	RbacPermissionOpen        RbacPermission = "environment:open"
+	RbacPermissionWrite       RbacPermission = "environment:write"
+	RbacPermissionDelete      RbacPermission = "environment:delete"
+	RbacPermissionClone       RbacPermission = "environment:clone"
+	RbacPermissionRotate      RbacPermission = "environment:rotate"
+)
 
-	targetActionTypes := []string{}
-	for _, actionType := range inputMap["targetActionTypes"].ArrayValue() {
-		targetActionTypes = append(targetActionTypes, actionType.StringValue())
+func (RbacPermission) Values() []infer.EnumValue[RbacPermission] {
+	return []infer.EnumValue[RbacPermission]{
+		{Name: "Read", Value: RbacPermissionRead, Description: "Read permission."},
+		{Name: "ReadDecrypt", Value: RbacPermissionReadDecrypt, Description: "Read and decrypt permission."},
+		{Name: "Open", Value: RbacPermissionOpen, Description: "Open permission."},
+		{Name: "Write", Value: RbacPermissionWrite, Description: "Write permission."},
+		{Name: "Delete", Value: RbacPermissionDelete, Description: "Delete permission."},
+		{Name: "Clone", Value: RbacPermissionClone, Description: "Clone permission."},
+		{Name: "Rotate", Value: RbacPermissionRotate, Description: "Rotate permission."},
 	}
-	rule.TargetActionTypes = targetActionTypes
+}
 
-	// Parse environment identifier
-	if inputMap["environmentIdentifier"].HasValue() && inputMap["environmentIdentifier"].IsObject() {
-		envMap := inputMap["environmentIdentifier"].ObjectValue()
-		rule.EnvironmentIdentifier = pulumiapi.EnvironmentIdentifier{
-			OrgName:     envMap["organization"].StringValue(),
-			ProjectName: envMap["project"].StringValue(),
-			EnvName:     envMap["name"].StringValue(),
+// EnvironmentIdentifier identifies the environment an approval rule applies to.
+type EnvironmentIdentifier struct {
+	Organization string `pulumi:"organization"`
+	Project      string `pulumi:"project"`
+	Name         string `pulumi:"name"`
+}
+
+func (e *EnvironmentIdentifier) Annotate(a infer.Annotator) {
+	a.Describe(&e.Organization, "The organization name.")
+	a.Describe(&e.Project, "The project name.")
+	a.Describe(&e.Name, "The environment name.")
+}
+
+// EligibleApprover describes a single entity that can approve a change gated by an
+// approval rule. Exactly one of `teamName`, `user`, or `rbacPermission` must be set.
+type EligibleApprover struct {
+	TeamName       *string         `pulumi:"teamName,optional"`
+	User           *string         `pulumi:"user,optional"`
+	RbacPermission *RbacPermission `pulumi:"rbacPermission,optional"`
+}
+
+func (e *EligibleApprover) Annotate(a infer.Annotator) {
+	a.Describe(&e.TeamName, "Name of the team that can approve.")
+	a.Describe(&e.User, "Login of the user that can approve.")
+	a.Describe(&e.RbacPermission, "RBAC permission that gives right to approve.")
+}
+
+// ApprovalRuleConfig captures the approval gate's enforcement configuration.
+type ApprovalRuleConfig struct {
+	NumApprovalsRequired      int                `pulumi:"numApprovalsRequired"`
+	AllowSelfApproval         bool               `pulumi:"allowSelfApproval"`
+	RequireReapprovalOnChange bool               `pulumi:"requireReapprovalOnChange"`
+	EligibleApprovers         []EligibleApprover `pulumi:"eligibleApprovers"`
+}
+
+func (c *ApprovalRuleConfig) Annotate(a infer.Annotator) {
+	a.Describe(&c.NumApprovalsRequired, "Number of approvals required.")
+	a.Describe(&c.AllowSelfApproval, "Whether self-approval is allowed.")
+	a.Describe(&c.RequireReapprovalOnChange, "Whether reapproval is required on changes.")
+	a.Describe(&c.EligibleApprovers, "List of eligible approvers.")
+}
+
+type ApprovalRuleInput struct {
+	Name                  string                `pulumi:"name"                  provider:"replaceOnChanges"`
+	Enabled               bool                  `pulumi:"enabled"`
+	TargetActionTypes     []TargetActionType    `pulumi:"targetActionTypes"`
+	EnvironmentIdentifier EnvironmentIdentifier `pulumi:"environmentIdentifier"`
+	ApprovalRuleConfig    ApprovalRuleConfig    `pulumi:"approvalRuleConfig"`
+}
+
+func (i *ApprovalRuleInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Name, "The name of the approval rule.")
+	a.Describe(&i.Enabled, "Whether the approval rule is enabled.")
+	a.Describe(&i.TargetActionTypes, "The type of action this rule applies to.")
+	a.Describe(&i.EnvironmentIdentifier, "The environment this rule applies to.")
+	a.Describe(&i.ApprovalRuleConfig, "The approval rule configuration.")
+}
+
+type ApprovalRuleState struct {
+	ApprovalRuleInput
+}
+
+func (*ApprovalRule) Check(
+	ctx context.Context, req infer.CheckRequest,
+) (infer.CheckResponse[ApprovalRuleInput], error) {
+	in, failures, err := infer.DefaultCheck[ApprovalRuleInput](ctx, req.NewInputs)
+	if err != nil {
+		return infer.CheckResponse[ApprovalRuleInput]{}, err
+	}
+	for i, approver := range in.ApprovalRuleConfig.EligibleApprovers {
+		set := 0
+		if approver.TeamName != nil && *approver.TeamName != "" {
+			set++
+		}
+		if approver.User != nil && *approver.User != "" {
+			set++
+		}
+		if approver.RbacPermission != nil && *approver.RbacPermission != "" {
+			set++
+		}
+		switch {
+		case set == 0:
+			failures = append(failures, p.CheckFailure{
+				Property: fmt.Sprintf("approvalRuleConfig.eligibleApprovers[%d]", i),
+				Reason:   "eligible approver must have exactly one of teamName, user, or rbacPermission set",
+			})
+		case set > 1:
+			failures = append(failures, p.CheckFailure{
+				Property: fmt.Sprintf("approvalRuleConfig.eligibleApprovers[%d]", i),
+				Reason: "eligible approver must have exactly one of teamName, user, or rbacPermission set, " +
+					"but multiple were provided",
+			})
 		}
 	}
+	return infer.CheckResponse[ApprovalRuleInput]{Inputs: in, Failures: failures}, nil
+}
 
-	// Parse approval rule config
-	if inputMap["approvalRuleConfig"].HasValue() && inputMap["approvalRuleConfig"].IsObject() {
-		ruleInputMap := inputMap["approvalRuleConfig"].ObjectValue()
-		rule.ApprovalRuleConfig = pulumiapi.ApprovalRuleInput{
-			NumApprovalsRequired:      int(ruleInputMap["numApprovalsRequired"].NumberValue()),
-			AllowSelfApproval:         ruleInputMap["allowSelfApproval"].BoolValue(),
-			RequireReapprovalOnChange: ruleInputMap["requireReapprovalOnChange"].BoolValue(),
+func (*ApprovalRule) Create(
+	ctx context.Context, req infer.CreateRequest[ApprovalRuleInput],
+) (infer.CreateResponse[ApprovalRuleState], error) {
+	if req.DryRun {
+		return infer.CreateResponse[ApprovalRuleState]{
+			Output: ApprovalRuleState{ApprovalRuleInput: req.Inputs},
+		}, nil
+	}
+	createReq := pulumiapi.CreateApprovalRuleRequest{
+		Name:    req.Inputs.Name,
+		Enabled: req.Inputs.Enabled,
+		Rule:    approvalRuleConfigToAPI(req.Inputs.ApprovalRuleConfig),
+		Target:  approvalRuleTargetToAPI(req.Inputs.EnvironmentIdentifier, req.Inputs.TargetActionTypes),
+	}
+	created, err := config.GetClient(ctx).CreateEnvironmentApprovalRule(
+		ctx, req.Inputs.EnvironmentIdentifier.Organization, createReq,
+	)
+	if err != nil {
+		return infer.CreateResponse[ApprovalRuleState]{}, fmt.Errorf(
+			"creating approval rule %q: %w", req.Inputs.Name, err,
+		)
+	}
+	return infer.CreateResponse[ApprovalRuleState]{
+		ID:     buildApprovalRuleID(req.Inputs.EnvironmentIdentifier, created.ID),
+		Output: ApprovalRuleState{ApprovalRuleInput: req.Inputs},
+	}, nil
+}
+
+func (*ApprovalRule) Update(
+	ctx context.Context, req infer.UpdateRequest[ApprovalRuleInput, ApprovalRuleState],
+) (infer.UpdateResponse[ApprovalRuleState], error) {
+	if req.DryRun {
+		return infer.UpdateResponse[ApprovalRuleState]{
+			Output: ApprovalRuleState{ApprovalRuleInput: req.Inputs},
+		}, nil
+	}
+	_, ruleID, err := parseApprovalRuleID(req.ID)
+	if err != nil {
+		return infer.UpdateResponse[ApprovalRuleState]{}, err
+	}
+	updateReq := pulumiapi.UpdateApprovalRuleRequest{
+		Name:    req.Inputs.Name,
+		Enabled: req.Inputs.Enabled,
+		Rule:    approvalRuleConfigToAPI(req.Inputs.ApprovalRuleConfig),
+		Target:  approvalRuleTargetToAPI(req.Inputs.EnvironmentIdentifier, req.Inputs.TargetActionTypes),
+	}
+	if _, err = config.GetClient(ctx).UpdateEnvironmentApprovalRule(
+		ctx, req.Inputs.EnvironmentIdentifier.Organization, ruleID, updateReq,
+	); err != nil {
+		return infer.UpdateResponse[ApprovalRuleState]{}, fmt.Errorf(
+			"updating approval rule %q: %w", req.Inputs.Name, err,
+		)
+	}
+	return infer.UpdateResponse[ApprovalRuleState]{
+		Output: ApprovalRuleState{ApprovalRuleInput: req.Inputs},
+	}, nil
+}
+
+func (*ApprovalRule) Delete(
+	ctx context.Context, req infer.DeleteRequest[ApprovalRuleState],
+) (infer.DeleteResponse, error) {
+	envID, ruleID, err := parseApprovalRuleID(req.ID)
+	if err != nil {
+		return infer.DeleteResponse{}, err
+	}
+	return infer.DeleteResponse{}, config.GetClient(ctx).DeleteEnvironmentApprovalRule(
+		ctx, envID.Organization, ruleID,
+	)
+}
+
+func (*ApprovalRule) Read(
+	ctx context.Context, req infer.ReadRequest[ApprovalRuleInput, ApprovalRuleState],
+) (infer.ReadResponse[ApprovalRuleInput, ApprovalRuleState], error) {
+	envID, ruleID, err := parseApprovalRuleID(req.ID)
+	if err != nil {
+		return infer.ReadResponse[ApprovalRuleInput, ApprovalRuleState]{}, err
+	}
+	apiRule, err := config.GetClient(ctx).GetEnvironmentApprovalRule(ctx, envID.Organization, ruleID)
+	if err != nil {
+		return infer.ReadResponse[ApprovalRuleInput, ApprovalRuleState]{}, fmt.Errorf(
+			"reading approval rule %q: %w", req.ID, err,
+		)
+	}
+	if apiRule == nil {
+		return infer.ReadResponse[ApprovalRuleInput, ApprovalRuleState]{}, nil
+	}
+	inputs := approvalRuleInputFromAPI(envID, *apiRule)
+	return infer.ReadResponse[ApprovalRuleInput, ApprovalRuleState]{
+		ID:     buildApprovalRuleID(envID, apiRule.ID),
+		Inputs: inputs,
+		State:  ApprovalRuleState{ApprovalRuleInput: inputs},
+	}, nil
+}
+
+func approvalRuleConfigToAPI(c ApprovalRuleConfig) pulumiapi.ChangeGateRuleInput {
+	return pulumiapi.ChangeGateRuleInput{
+		RuleType:                  pulumiapi.ChangeGateRuleTypeApproval,
+		NumApprovalsRequired:      c.NumApprovalsRequired,
+		AllowSelfApproval:         c.AllowSelfApproval,
+		RequireReapprovalOnChange: c.RequireReapprovalOnChange,
+		EligibleApprovers:         eligibleApproversToAPI(c.EligibleApprovers),
+	}
+}
+
+func approvalRuleTargetToAPI(
+	env EnvironmentIdentifier, actionTypes []TargetActionType,
+) pulumiapi.ChangeGateTargetInput {
+	actions := make([]string, len(actionTypes))
+	for i, t := range actionTypes {
+		actions[i] = string(t)
+	}
+	return pulumiapi.ChangeGateTargetInput{
+		ActionTypes:   actions,
+		EntityType:    "environment",
+		QualifiedName: fmt.Sprintf("%s/%s", env.Project, env.Name),
+	}
+}
+
+func eligibleApproversToAPI(approvers []EligibleApprover) []pulumiapi.EligibleApprover {
+	out := make([]pulumiapi.EligibleApprover, 0, len(approvers))
+	for _, a := range approvers {
+		api := pulumiapi.EligibleApprover{}
+		switch {
+		case a.TeamName != nil && *a.TeamName != "":
+			api.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypeTeam
+			api.TeamName = *a.TeamName
+		case a.User != nil && *a.User != "":
+			api.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypeUser
+			api.User = *a.User
+		case a.RbacPermission != nil && *a.RbacPermission != "":
+			api.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypePermission
+			api.RbacPermission = string(*a.RbacPermission)
 		}
+		out = append(out, api)
+	}
+	return out
+}
 
-		// Parse eligible approvers
-		if ruleInputMap["eligibleApprovers"].HasValue() && ruleInputMap["eligibleApprovers"].IsArray() {
-			for _, approverValue := range ruleInputMap["eligibleApprovers"].ArrayValue() {
-				if approverValue.IsObject() {
-					approverMap := approverValue.ObjectValue()
-					approver := pulumiapi.EligibleApprover{}
-
-					if approverMap["teamName"].HasValue() && approverMap["teamName"].IsString() {
-						approver.TeamName = approverMap["teamName"].StringValue()
-						approver.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypeTeam
-					}
-					if approverMap["user"].HasValue() && approverMap["user"].IsString() {
-						approver.User = approverMap["user"].StringValue()
-						approver.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypeUser
-					}
-					if approverMap["rbacPermission"].HasValue() && approverMap["rbacPermission"].IsString() {
-						approver.RbacPermission = approverMap["rbacPermission"].StringValue()
-						approver.EligibilityType = pulumiapi.ApprovalRuleEligibilityTypePermission
-					}
-
-					rule.ApprovalRuleConfig.EligibleApprovers = append(
-						rule.ApprovalRuleConfig.EligibleApprovers,
-						approver,
-					)
-				}
-			}
+func approvalRuleInputFromAPI(env EnvironmentIdentifier, apiRule pulumiapi.ApprovalRule) ApprovalRuleInput {
+	actionTypes := []TargetActionType{}
+	if apiRule.Target != nil {
+		actionTypes = make([]TargetActionType, len(apiRule.Target.ActionTypes))
+		for i, t := range apiRule.Target.ActionTypes {
+			actionTypes[i] = TargetActionType(t)
 		}
 	}
-
-	return &rule, nil
+	approvers := make([]EligibleApprover, 0, len(apiRule.Rule.EligibleApproverOutputs))
+	for _, a := range apiRule.Rule.EligibleApproverOutputs {
+		approvers = append(approvers, eligibleApproverFromAPIOutput(a))
+	}
+	return ApprovalRuleInput{
+		Name:                  apiRule.Name,
+		Enabled:               apiRule.Enabled,
+		TargetActionTypes:     actionTypes,
+		EnvironmentIdentifier: env,
+		ApprovalRuleConfig: ApprovalRuleConfig{
+			NumApprovalsRequired:      apiRule.Rule.NumApprovalsRequired,
+			AllowSelfApproval:         apiRule.Rule.AllowSelfApproval,
+			RequireReapprovalOnChange: apiRule.Rule.RequireReapprovalOnChange,
+			EligibleApprovers:         approvers,
+		},
+	}
 }
 
-func (s *PulumiServiceApprovalRuleResource) Name() string {
-	return "pulumiservice:index:ApprovalRule"
+func eligibleApproverFromAPIOutput(out pulumiapi.EligibleApproverOutput) EligibleApprover {
+	approver := EligibleApprover{}
+	switch out.EligibilityType {
+	case pulumiapi.ApprovalRuleEligibilityTypeTeam:
+		t := out.TeamName
+		approver.TeamName = &t
+	case pulumiapi.ApprovalRuleEligibilityTypeUser:
+		u := out.User.GithubLogin
+		approver.User = &u
+	case pulumiapi.ApprovalRuleEligibilityTypePermission:
+		perm := RbacPermission(out.RbacPermission)
+		approver.RbacPermission = &perm
+	}
+	return approver
 }
 
-func buildApprovalRuleID(envID pulumiapi.EnvironmentIdentifier, ruleID string) string {
-	return fmt.Sprintf("environment/%s/%s/%s/%s", envID.OrgName, envID.ProjectName, envID.EnvName, ruleID)
+// buildApprovalRuleID encodes the composite resource ID using the legacy format so
+// existing stacks continue to resolve. The format is:
+//
+//	environment/{org}/{project}/{env}/{ruleID}
+func buildApprovalRuleID(env EnvironmentIdentifier, ruleID string) string {
+	return fmt.Sprintf("environment/%s/%s/%s/%s", env.Organization, env.Project, env.Name, ruleID)
 }
 
-func parseApprovalRuleID(compositeID string) (pulumiapi.EnvironmentIdentifier, string, error) {
+func parseApprovalRuleID(compositeID string) (EnvironmentIdentifier, string, error) {
 	parts := strings.Split(compositeID, "/")
 	if len(parts) != 5 || parts[0] != "environment" {
-		// For now, this is the only type, but we expect to have more types of approvals later on
-		return pulumiapi.EnvironmentIdentifier{}, "", fmt.Errorf(
+		return EnvironmentIdentifier{}, "", fmt.Errorf(
 			"invalid approval rule ID format: expected 'environment/{orgName}/{projectName}/{envName}/{ruleID}', got %q",
 			compositeID,
 		)
 	}
-
-	envID := pulumiapi.EnvironmentIdentifier{
-		OrgName:     parts[1],
-		ProjectName: parts[2],
-		EnvName:     parts[3],
-	}
-	ruleID := parts[4]
-
-	return envID, ruleID, nil
-}
-
-func (s *PulumiServiceApprovalRuleResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	replaceProperties := map[string]bool{
-		"environmentIdentifier.organization": true,
-		"environmentIdentifier.project":      true,
-		"environmentIdentifier.name":         true,
-	}
-	return util.StandardDiff(req, replaceProperties)
-}
-
-func (s *PulumiServiceApprovalRuleResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-
-	envID, ruleID, err := parseApprovalRuleID(req.GetId())
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.Client.DeleteEnvironmentApprovalRule(ctx, envID.OrgName, ruleID)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pbempty.Empty{}, nil
-}
-
-func (s *PulumiServiceApprovalRuleResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	inputs, err := plugin.UnmarshalProperties(req.GetProperties(), util.StandardUnmarshal)
-	if err != nil {
-		return nil, err
-	}
-
-	rule, err := s.ToPulumiServiceApprovalRuleInput(inputs)
-	if err != nil {
-		return nil, err
-	}
-
-	createReq := pulumiapi.CreateApprovalRuleRequest{
-		Name:    rule.Name,
-		Enabled: rule.Enabled,
-		Rule: pulumiapi.ChangeGateRuleInput{
-			NumApprovalsRequired:      rule.ApprovalRuleConfig.NumApprovalsRequired,
-			AllowSelfApproval:         rule.ApprovalRuleConfig.AllowSelfApproval,
-			RequireReapprovalOnChange: rule.ApprovalRuleConfig.RequireReapprovalOnChange,
-			EligibleApprovers:         rule.ApprovalRuleConfig.EligibleApprovers,
-			RuleType:                  pulumiapi.ChangeGateRuleTypeApproval,
-		},
-		Target: pulumiapi.ChangeGateTargetInput{
-			ActionTypes: rule.TargetActionTypes,
-			EntityType:  "environment",
-			QualifiedName: fmt.Sprintf(
-				"%s/%s",
-				rule.EnvironmentIdentifier.ProjectName,
-				rule.EnvironmentIdentifier.EnvName,
-			),
-		},
-	}
-
-	createdRule, err := s.Client.CreateEnvironmentApprovalRule(ctx, rule.EnvironmentIdentifier.OrgName, createReq)
-	if err != nil {
-		return nil, err
-	}
-
-	outputProperties, err := plugin.MarshalProperties(
-		rule.ToPropertyMap(),
-		util.StandardMarshal,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         buildApprovalRuleID(rule.EnvironmentIdentifier, createdRule.ID),
-		Properties: outputProperties,
-	}, nil
-}
-
-func (s *PulumiServiceApprovalRuleResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	inputs, err := plugin.UnmarshalProperties(req.GetNews(), util.StandardUnmarshal)
-	if err != nil {
-		return nil, err
-	}
-
-	var failures []*pulumirpc.CheckFailure
-
-	// Validate eligible approvers if approvalRuleConfig is present
-	if inputs["approvalRuleConfig"].HasValue() && inputs["approvalRuleConfig"].IsObject() {
-		ruleInputMap := inputs["approvalRuleConfig"].ObjectValue()
-		if ruleInputMap["eligibleApprovers"].HasValue() && ruleInputMap["eligibleApprovers"].IsArray() {
-			approvers := ruleInputMap["eligibleApprovers"].ArrayValue()
-			for i, approverValue := range approvers {
-				if approverValue.IsObject() {
-					approverMap := approverValue.ObjectValue()
-
-					// Count how many fields are set
-					fieldsSet := 0
-					if approverMap["teamName"].HasValue() && approverMap["teamName"].IsString() &&
-						approverMap["teamName"].StringValue() != "" {
-						fieldsSet++
-					}
-					if approverMap["user"].HasValue() && approverMap["user"].IsString() &&
-						approverMap["user"].StringValue() != "" {
-						fieldsSet++
-					}
-					if approverMap["rbacPermission"].HasValue() && approverMap["rbacPermission"].IsString() &&
-						approverMap["rbacPermission"].StringValue() != "" {
-						fieldsSet++
-					}
-
-					// Validate exactly one field is set
-					if fieldsSet == 0 {
-						failures = append(failures, &pulumirpc.CheckFailure{
-							Property: fmt.Sprintf("approvalRuleConfig.eligibleApprovers[%d]", i),
-							Reason:   "eligible approver must have exactly one of teamName, user, or rbacPermission set",
-						})
-					} else if fieldsSet > 1 {
-						failures = append(failures, &pulumirpc.CheckFailure{
-							Property: fmt.Sprintf("approvalRuleConfig.eligibleApprovers[%d]", i),
-							Reason: "eligible approver must have exactly one of teamName, user, or rbacPermission set, " +
-								"but multiple were provided",
-						})
-					}
-				}
-			}
-		}
-	}
-
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: failures}, nil
-}
-
-func (s *PulumiServiceApprovalRuleResource) Update(req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	ctx := context.Background()
-	inputs, err := plugin.UnmarshalProperties(req.GetNews(), util.StandardUnmarshal)
-	if err != nil {
-		return nil, err
-	}
-
-	rule, err := s.ToPulumiServiceApprovalRuleInput(inputs)
-	if err != nil {
-		return nil, err
-	}
-
-	envID, ruleID, err := parseApprovalRuleID(req.GetId())
-	if err != nil {
-		return nil, err
-	}
-
-	updateReq := pulumiapi.UpdateApprovalRuleRequest{
-		Name:    rule.Name,
-		Enabled: rule.Enabled,
-		Rule: pulumiapi.ChangeGateRuleInput{
-			NumApprovalsRequired:      rule.ApprovalRuleConfig.NumApprovalsRequired,
-			AllowSelfApproval:         rule.ApprovalRuleConfig.AllowSelfApproval,
-			RequireReapprovalOnChange: rule.ApprovalRuleConfig.RequireReapprovalOnChange,
-			EligibleApprovers:         rule.ApprovalRuleConfig.EligibleApprovers,
-			RuleType:                  pulumiapi.ChangeGateRuleTypeApproval,
-		},
-		Target: pulumiapi.ChangeGateTargetInput{
-			ActionTypes: rule.TargetActionTypes,
-			EntityType:  "environment",
-			QualifiedName: fmt.Sprintf(
-				"%s/%s",
-				rule.EnvironmentIdentifier.ProjectName,
-				rule.EnvironmentIdentifier.EnvName,
-			),
-		},
-	}
-
-	_, err = s.Client.UpdateEnvironmentApprovalRule(ctx, envID.OrgName, ruleID, updateReq)
-	if err != nil {
-		return nil, err
-	}
-
-	outputProperties, err := plugin.MarshalProperties(
-		rule.ToPropertyMap(),
-		util.StandardMarshal,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.UpdateResponse{
-		Properties: outputProperties,
-	}, nil
-}
-
-func (s *PulumiServiceApprovalRuleResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-
-	envID, ruleID, err := parseApprovalRuleID(req.GetId())
-	if err != nil {
-		return nil, err
-	}
-
-	apiRule, err := s.Client.GetEnvironmentApprovalRule(ctx, envID.OrgName, ruleID)
-	if err != nil {
-		return nil, fmt.Errorf("failure while reading approval rule %q: %w", req.Id, err)
-	}
-	if apiRule == nil {
-		return &pulumirpc.ReadResponse{}, nil
-	}
-
-	// Convert API response back to our input format
-	readRule := PulumiServiceApprovalRule{
-		Name:                  apiRule.Name,
-		Enabled:               apiRule.Enabled,
-		TargetActionTypes:     apiRule.Target.ActionTypes,
-		EnvironmentIdentifier: envID,
-		ApprovalRuleConfig: pulumiapi.ApprovalRuleInput{
-			NumApprovalsRequired:      apiRule.Rule.NumApprovalsRequired,
-			AllowSelfApproval:         apiRule.Rule.AllowSelfApproval,
-			RequireReapprovalOnChange: apiRule.Rule.RequireReapprovalOnChange,
-			EligibleApprovers:         pulumiapi.ToApprovers(apiRule.Rule.EligibleApproverOutputs),
-		},
-	}
-
-	outputs, err := plugin.MarshalProperties(
-		readRule.ToPropertyMap(),
-		util.StandardMarshal,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         buildApprovalRuleID(envID, apiRule.ID),
-		Properties: outputs,
-		Inputs:     outputs,
-	}, nil
+	return EnvironmentIdentifier{
+		Organization: parts[1],
+		Project:      parts[2],
+		Name:         parts[3],
+	}, parts[4], nil
 }

--- a/provider/pkg/resources/approvalRule.go
+++ b/provider/pkg/resources/approvalRule.go
@@ -81,9 +81,9 @@ func (RbacPermission) Values() []infer.EnumValue[RbacPermission] {
 
 // EnvironmentIdentifier identifies the environment an approval rule applies to.
 type EnvironmentIdentifier struct {
-	Organization string `pulumi:"organization"`
-	Project      string `pulumi:"project"`
-	Name         string `pulumi:"name"`
+	Organization string `pulumi:"organization" provider:"replaceOnChanges"`
+	Project      string `pulumi:"project"      provider:"replaceOnChanges"`
+	Name         string `pulumi:"name"         provider:"replaceOnChanges"`
 }
 
 func (e *EnvironmentIdentifier) Annotate(a infer.Annotator) {

--- a/provider/pkg/resources/approvalRule_test.go
+++ b/provider/pkg/resources/approvalRule_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildApprovalRuleID(t *testing.T) {
+	got := buildApprovalRuleID(EnvironmentIdentifier{
+		Organization: "my-org",
+		Project:      "my-project",
+		Name:         "my-env",
+	}, "rule-abc")
+	assert.Equal(t, "environment/my-org/my-project/my-env/rule-abc", got)
+}
+
+func TestParseApprovalRuleID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		env, ruleID, err := parseApprovalRuleID("environment/my-org/my-project/my-env/rule-abc")
+		require.NoError(t, err)
+		assert.Equal(t, EnvironmentIdentifier{
+			Organization: "my-org",
+			Project:      "my-project",
+			Name:         "my-env",
+		}, env)
+		assert.Equal(t, "rule-abc", ruleID)
+	})
+
+	t.Run("wrong prefix", func(t *testing.T) {
+		_, _, err := parseApprovalRuleID("stack/my-org/my-project/my-env/rule-abc")
+		require.Error(t, err)
+	})
+
+	t.Run("too few parts", func(t *testing.T) {
+		_, _, err := parseApprovalRuleID("environment/my-org/my-project/my-env")
+		require.Error(t, err)
+	})
+
+	t.Run("too many parts", func(t *testing.T) {
+		_, _, err := parseApprovalRuleID("environment/my-org/my-project/my-env/rule-abc/extra")
+		require.Error(t, err)
+	})
+}

--- a/sdk/dotnet/ApprovalRule.cs
+++ b/sdk/dotnet/ApprovalRule.cs
@@ -70,6 +70,9 @@ namespace Pulumi.PulumiService
                 Version = Utilities.Version,
                 ReplaceOnChanges =
                 {
+                    "environmentIdentifier.name",
+                    "environmentIdentifier.organization",
+                    "environmentIdentifier.project",
                     "name",
                 },
             };

--- a/sdk/dotnet/ApprovalRule.cs
+++ b/sdk/dotnet/ApprovalRule.cs
@@ -34,7 +34,7 @@ namespace Pulumi.PulumiService
         public Output<Outputs.EnvironmentIdentifier> EnvironmentIdentifier { get; private set; } = null!;
 
         /// <summary>
-        /// Name of the approval rule.
+        /// The name of the approval rule.
         /// </summary>
         [Output("name")]
         public Output<string> Name { get; private set; } = null!;
@@ -68,6 +68,10 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                ReplaceOnChanges =
+                {
+                    "name",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/pulumiservice/approvalRule.go
+++ b/sdk/go/pulumiservice/approvalRule.go
@@ -51,6 +51,9 @@ func NewApprovalRule(ctx *pulumi.Context,
 		return nil, errors.New("invalid value for required argument 'TargetActionTypes'")
 	}
 	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"environmentIdentifier.name",
+		"environmentIdentifier.organization",
+		"environmentIdentifier.project",
 		"name",
 	})
 	opts = append(opts, replaceOnChanges)

--- a/sdk/go/pulumiservice/approvalRule.go
+++ b/sdk/go/pulumiservice/approvalRule.go
@@ -22,7 +22,7 @@ type ApprovalRule struct {
 	Enabled pulumi.BoolOutput `pulumi:"enabled"`
 	// The environment this rule applies to.
 	EnvironmentIdentifier EnvironmentIdentifierOutput `pulumi:"environmentIdentifier"`
-	// Name of the approval rule.
+	// The name of the approval rule.
 	Name pulumi.StringOutput `pulumi:"name"`
 	// The type of action this rule applies to.
 	TargetActionTypes TargetActionTypeArrayOutput `pulumi:"targetActionTypes"`
@@ -50,6 +50,10 @@ func NewApprovalRule(ctx *pulumi.Context,
 	if args.TargetActionTypes == nil {
 		return nil, errors.New("invalid value for required argument 'TargetActionTypes'")
 	}
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"name",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource ApprovalRule
 	err := ctx.RegisterResource("pulumiservice:index:ApprovalRule", name, args, &resource, opts...)
@@ -211,7 +215,7 @@ func (o ApprovalRuleOutput) EnvironmentIdentifier() EnvironmentIdentifierOutput 
 	return o.ApplyT(func(v *ApprovalRule) EnvironmentIdentifierOutput { return v.EnvironmentIdentifier }).(EnvironmentIdentifierOutput)
 }
 
-// Name of the approval rule.
+// The name of the approval rule.
 func (o ApprovalRuleOutput) Name() pulumi.StringOutput {
 	return o.ApplyT(func(v *ApprovalRule) pulumi.StringOutput { return v.Name }).(pulumi.StringOutput)
 }

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/ApprovalRule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/ApprovalRule.java
@@ -134,6 +134,9 @@ public class ApprovalRule extends com.pulumi.resources.CustomResource {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
             .replaceOnChanges(List.of(
+                "environmentIdentifier.name",
+                "environmentIdentifier.organization",
+                "environmentIdentifier.project",
                 "name"
             ))
             .build();

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/ApprovalRule.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/ApprovalRule.java
@@ -66,14 +66,14 @@ public class ApprovalRule extends com.pulumi.resources.CustomResource {
         return this.environmentIdentifier;
     }
     /**
-     * Name of the approval rule.
+     * The name of the approval rule.
      * 
      */
     @Export(name="name", refs={String.class}, tree="[0]")
     private Output<String> name;
 
     /**
-     * @return Name of the approval rule.
+     * @return The name of the approval rule.
      * 
      */
     public Output<String> name() {
@@ -133,6 +133,9 @@ public class ApprovalRule extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .replaceOnChanges(List.of(
+                "name"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/approvalRule.ts
+++ b/sdk/nodejs/approvalRule.ts
@@ -50,7 +50,7 @@ export class ApprovalRule extends pulumi.CustomResource {
      */
     declare public readonly environmentIdentifier: pulumi.Output<outputs.EnvironmentIdentifier>;
     /**
-     * Name of the approval rule.
+     * The name of the approval rule.
      */
     declare public readonly name: pulumi.Output<string>;
     /**
@@ -97,6 +97,8 @@ export class ApprovalRule extends pulumi.CustomResource {
             resourceInputs["targetActionTypes"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const replaceOnChanges = { replaceOnChanges: ["name"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(ApprovalRule.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/nodejs/approvalRule.ts
+++ b/sdk/nodejs/approvalRule.ts
@@ -97,7 +97,7 @@ export class ApprovalRule extends pulumi.CustomResource {
             resourceInputs["targetActionTypes"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
-        const replaceOnChanges = { replaceOnChanges: ["name"] };
+        const replaceOnChanges = { replaceOnChanges: ["environmentIdentifier.name", "environmentIdentifier.organization", "environmentIdentifier.project", "name"] };
         opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(ApprovalRule.__pulumiType, name, resourceInputs, opts);
     }

--- a/sdk/python/pulumi_pulumiservice/approval_rule.py
+++ b/sdk/python/pulumi_pulumiservice/approval_rule.py
@@ -181,6 +181,8 @@ class ApprovalRule(pulumi.CustomResource):
             if target_action_types is None and not opts.urn:
                 raise TypeError("Missing required property 'target_action_types'")
             __props__.__dict__["target_action_types"] = target_action_types
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["name"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(ApprovalRule, __self__).__init__(
             'pulumiservice:index:ApprovalRule',
             resource_name,
@@ -238,7 +240,7 @@ class ApprovalRule(pulumi.CustomResource):
     @pulumi.getter
     def name(self) -> pulumi.Output[_builtins.str]:
         """
-        Name of the approval rule.
+        The name of the approval rule.
         """
         return pulumi.get(self, "name")
 

--- a/sdk/python/pulumi_pulumiservice/approval_rule.py
+++ b/sdk/python/pulumi_pulumiservice/approval_rule.py
@@ -181,7 +181,7 @@ class ApprovalRule(pulumi.CustomResource):
             if target_action_types is None and not opts.urn:
                 raise TypeError("Missing required property 'target_action_types'")
             __props__.__dict__["target_action_types"] = target_action_types
-        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["name"])
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["environmentIdentifier.name", "environmentIdentifier.organization", "environmentIdentifier.project", "name"])
         opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(ApprovalRule, __self__).__init__(
             'pulumiservice:index:ApprovalRule',


### PR DESCRIPTION
## Summary
- Migrates the `ApprovalRule` resource to the `infer` framework.
- Preserves the legacy `environment/{org}/{project}/{env}/{ruleID}` composite ID so existing stacks resolve.
- Removes the `ApprovalRule` resource and its exclusively-used companion types (`TargetActionType`, `RbacPermission`, `EnvironmentIdentifier`, `EligibleApprover`, `ApprovalRuleConfig`) from `manual-schema.json`; infer regenerates them from the Go types.
- Regenerates SDKs.

## Test plan
- [x] `make provider`
- [x] `make build_sdks`
- [x] `go test ./...` in `provider/pkg`
- [x] `make lint`
- [ ] CI integration tests