### PR TITLE
Migrate `StackTags` to `infer`

### DIFF
--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -6138,15 +6138,18 @@
       "properties": {
         "organization": {
           "type": "string",
-          "description": "Organization name."
+          "description": "Organization name.",
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
-          "description": "Project name."
+          "description": "Project name.",
+          "replaceOnChanges": true
         },
         "stack": {
           "type": "string",
-          "description": "Stack name."
+          "description": "Stack name.",
+          "replaceOnChanges": true
         },
         "tags": {
           "type": "object",
@@ -6166,17 +6169,17 @@
         "organization": {
           "type": "string",
           "description": "Organization name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "project": {
           "type": "string",
           "description": "Project name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "stack": {
           "type": "string",
           "description": "Stack name.",
-          "willReplaceOnChanges": true
+          "replaceOnChanges": true
         },
         "tags": {
           "type": "object",

--- a/provider/pkg/provider/manual-schema.json
+++ b/provider/pkg/provider/manual-schema.json
@@ -995,66 +995,6 @@
         "stack"
       ]
     },
-    "pulumiservice:index:StackTags": {
-      "description": "Manages a set of stack tags as a single resource via a `tags` map, instead of one `StackTag` per key — useful for YAML programs.\n\nOnly tags declared in `tags` are managed; tags added out-of-band (CLI, pulumibot, a singular `StackTag` resource) are left alone. Tag values are immutable in Pulumi Cloud, so a value change is implemented as delete-and-recreate.\n\nImporting with ID `{organization}/{project}/{stack}/tags` adopts every tag currently on the stack; declare `tags` explicitly after import so subsequent updates match your intent. See the [registry docs](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/stacktags/) for full usage and examples.\n",
-      "properties": {
-        "organization": {
-          "description": "Organization name.",
-          "type": "string"
-        },
-        "project": {
-          "description": "Project name.",
-          "type": "string"
-        },
-        "stack": {
-          "description": "Stack name.",
-          "type": "string"
-        },
-        "tags": {
-          "description": "Map of tag names to values. Each entry represents a stack tag.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "required": [
-        "organization",
-        "project",
-        "stack",
-        "tags"
-      ],
-      "inputProperties": {
-        "organization": {
-          "description": "Organization name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "project": {
-          "description": "Project name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "stack": {
-          "description": "Stack name.",
-          "type": "string",
-          "willReplaceOnChanges": true
-        },
-        "tags": {
-          "description": "Map of tag names to values. Each entry represents a stack tag.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "requiredInputs": [
-        "organization",
-        "project",
-        "stack",
-        "tags"
-      ]
-    },
     "pulumiservice:index:Environment": {
       "description": "An ESC Environment.",
       "properties": {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -150,6 +150,7 @@ func MakeProvider(host *provider.HostClient, name, version string) (pulumirpc.Re
 			infer.Resource(&resources.PolicyPack{}),
 			infer.Resource(&resources.Stack{}),
 			infer.Resource(&resources.StackTag{}),
+			infer.Resource(&resources.StackTags{}),
 			infer.Resource(&resources.TTLSchedule{}),
 			infer.Resource(&resources.Team{}),
 			infer.Resource(&resources.TeamAccessToken{}),
@@ -406,9 +407,6 @@ func (k *pulumiserviceProvider) Configure(
 
 	k.pulumiResources = []PulumiServiceResource{
 		&resources.PulumiServiceWebhookResource{
-			Client: client,
-		},
-		&resources.PulumiServiceStackTagsResource{
 			Client: client,
 		},
 		&resources.PulumiServiceDeploymentSettingsResource{

--- a/provider/pkg/pulumiapi/stack_tags.go
+++ b/provider/pkg/pulumiapi/stack_tags.go
@@ -33,6 +33,7 @@ func NewStackIdentifier(id string) (StackIdentifier, error) {
 type StackTagClient interface {
 	CreateStackTag(ctx context.Context, stack StackIdentifier, tag StackTag) error
 	GetStackTag(ctx context.Context, stackName StackIdentifier, tagName string) (*StackTag, error)
+	GetStackTags(ctx context.Context, stackName StackIdentifier) (map[string]string, error)
 	DeleteStackTag(ctx context.Context, stackName StackIdentifier, tagName string) error
 }
 

--- a/provider/pkg/resources/stack_tags_plural.go
+++ b/provider/pkg/resources/stack_tags_plural.go
@@ -1,3 +1,17 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
@@ -5,311 +19,62 @@ import (
 	"fmt"
 	"maps"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 
-	"google.golang.org/grpc/codes"
-	pbempty "google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/structpb"
+	"github.com/pulumi/pulumi-go-provider/infer"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
 )
 
-type PulumiServiceStackTagsResource struct {
-	Client *pulumiapi.Client
+type StackTags struct{}
+
+var (
+	_ infer.CustomCreate[StackTagsInput, StackTagsState] = &StackTags{}
+	_ infer.CustomUpdate[StackTagsInput, StackTagsState] = &StackTags{}
+	_ infer.CustomDelete[StackTagsState]                 = &StackTags{}
+	_ infer.CustomRead[StackTagsInput, StackTagsState]   = &StackTags{}
+)
+
+func (*StackTags) Annotate(a infer.Annotator) {
+	a.Describe(&StackTags{},
+		"Manages a set of stack tags as a single resource via a `tags` map, instead of one `StackTag` per key — "+
+			"useful for YAML programs.\n\n"+
+			"Only tags declared in `tags` are managed; tags added out-of-band (CLI, pulumibot, a singular `StackTag` "+
+			"resource) are left alone. Tag values are immutable in Pulumi Cloud, so a value change is implemented as "+
+			"delete-and-recreate.\n\n"+
+			"Importing with ID `{organization}/{project}/{stack}/tags` adopts every tag currently on the stack; "+
+			"declare `tags` explicitly after import so subsequent updates match your intent. See the "+
+			"[registry docs](https://www.pulumi.com/registry/packages/pulumiservice/api-docs/stacktags/) for full "+
+			"usage and examples.\n",
+	)
+	a.SetToken("index", "StackTags")
 }
 
-type PulumiServiceStackTagsInput struct {
-	Organization string            `pulumi:"organization"`
-	Project      string            `pulumi:"project"`
-	Stack        string            `pulumi:"stack"`
+type StackTagsInput struct {
+	Organization string            `pulumi:"organization" provider:"replaceOnChanges"`
+	Project      string            `pulumi:"project"      provider:"replaceOnChanges"`
+	Stack        string            `pulumi:"stack"        provider:"replaceOnChanges"`
 	Tags         map[string]string `pulumi:"tags"`
 }
 
-func (i *PulumiServiceStackTagsInput) ToPropertyMap() resource.PropertyMap {
-	return util.ToPropertyMap(*i)
+func (i *StackTagsInput) Annotate(a infer.Annotator) {
+	a.Describe(&i.Organization, "Organization name.")
+	a.Describe(&i.Project, "Project name.")
+	a.Describe(&i.Stack, "Stack name.")
+	a.Describe(&i.Tags, "Map of tag names to values. Each entry represents a stack tag.")
 }
 
-func (i *PulumiServiceStackTagsInput) ToRPC() (*structpb.Struct, error) {
-	return plugin.MarshalProperties(i.ToPropertyMap(), plugin.MarshalOptions{
-		KeepOutputValues: true,
-	})
+type StackTagsState = StackTagsInput
+
+func stackTagsResourceID(organization, project, stack string) string {
+	return path.Join(organization, project, stack, "tags")
 }
 
-func (st *PulumiServiceStackTagsResource) Name() string {
-	return "pulumiservice:index:StackTags"
-}
-
-func (st *PulumiServiceStackTagsResource) Check(req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (st *PulumiServiceStackTagsResource) Diff(req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	olds, err := plugin.UnmarshalProperties(
-		req.GetOldInputs(), plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-	if err != nil {
-		return nil, err
-	}
-
-	news, err := plugin.UnmarshalProperties(
-		req.GetNews(), plugin.MarshalOptions{KeepUnknowns: true, SkipNulls: true})
-	if err != nil {
-		return nil, err
-	}
-
-	diffs := olds.Diff(news)
-	if diffs == nil {
-		return &pulumirpc.DiffResponse{
-			Changes: pulumirpc.DiffResponse_DIFF_NONE,
-		}, nil
-	}
-
-	dd := plugin.NewDetailedDiffFromObjectDiff(diffs, false)
-
-	detailedDiffs := map[string]*pulumirpc.PropertyDiff{}
-	replaces := []string{}
-
-	for k, v := range dd {
-		if k == "organization" || k == "project" || k == "stack" {
-			v.Kind = v.Kind.AsReplace()
-			replaces = append(replaces, k)
-		}
-		detailedDiffs[k] = &pulumirpc.PropertyDiff{
-			Kind:      pulumirpc.PropertyDiff_Kind(v.Kind), //nolint:gosec // safe conversion from plugin.DiffKind
-			InputDiff: v.InputDiff,
-		}
-	}
-
-	changes := pulumirpc.DiffResponse_DIFF_SOME
-	if len(detailedDiffs) == 0 {
-		changes = pulumirpc.DiffResponse_DIFF_NONE
-	}
-
-	return &pulumirpc.DiffResponse{
-		Changes:             changes,
-		Replaces:            replaces,
-		DetailedDiff:        detailedDiffs,
-		DeleteBeforeReplace: len(replaces) > 0,
-		HasDetailedDiff:     true,
-	}, nil
-}
-
-func (st *PulumiServiceStackTagsResource) Create(req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	ctx := context.Background()
-	var input PulumiServiceStackTagsInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     input.Organization,
-		ProjectName: input.Project,
-		StackName:   input.Stack,
-	}
-	id := path.Join(input.Organization, input.Project, input.Stack, "tags")
-
-	// Create tags in sorted order so partial failures are deterministic.
-	created := map[string]string{}
-	tagNames := sortedKeys(input.Tags)
-	for _, name := range tagNames {
-		err := st.Client.CreateStackTag(ctx, stackName, pulumiapi.StackTag{Name: name, Value: input.Tags[name]})
-		if err != nil {
-			// Record the subset of tags that were successfully created so Pulumi
-			// can track them in state and the next `up` resumes from the right place.
-			// partial := input copies the value struct, then partial.Tags = created
-			// swaps in the subset without mutating the caller's input.
-			partial := input
-			partial.Tags = created
-			return nil, partialErrorStackTags(id, fmt.Errorf("failed to create tag %q: %w", name, err), partial, input)
-		}
-		created[name] = input.Tags[name]
-	}
-
-	return &pulumirpc.CreateResponse{
-		Id:         id,
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (st *PulumiServiceStackTagsResource) Read(req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	ctx := context.Background()
-
-	organization, project, stack, err := parseStackTagsID(req.Id)
-	if err != nil {
-		return nil, err
-	}
-
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     organization,
-		ProjectName: project,
-		StackName:   stack,
-	}
-
-	allTags, err := st.Client.GetStackTags(ctx, stackName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stack tags (%q): %w", req.Id, err)
-	}
-
-	// Parse current inputs to know which tags we manage.
-	var currentInput PulumiServiceStackTagsInput
-	if req.Inputs != nil {
-		inputMap, err := plugin.UnmarshalProperties(req.Inputs, plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal inputs: %w", err)
-		}
-		if err := util.FromPropertyMap(inputMap, &currentInput); err != nil {
-			// If we can't decode the previous inputs, don't silently fall into
-			// the import/adopt-all-tags path — that would let us take ownership
-			// of (and later delete) tags we never managed.
-			return nil, fmt.Errorf("failed to decode stored inputs for %q: %w", req.Id, err)
-		}
-	}
-
-	managedTags := make(map[string]string)
-	if len(currentInput.Tags) > 0 {
-		// We have previous state, only return tags we previously managed.
-		for tagName := range currentInput.Tags {
-			if value, exists := allTags[tagName]; exists {
-				managedTags[tagName] = value
-			}
-		}
-	} else {
-		// No previous state (import scenario): adopt every tag currently on the stack.
-		// The user is expected to declare the `tags` map explicitly after import so
-		// subsequent updates match their intent — see the schema description.
-		// Clone so we don't alias the API-client-owned map.
-		managedTags = maps.Clone(allTags)
-	}
-
-	state := PulumiServiceStackTagsInput{
-		Organization: organization,
-		Project:      project,
-		Stack:        stack,
-		Tags:         managedTags,
-	}
-
-	props, err := util.ToProperties(state)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal inputs to properties: %w", err)
-	}
-
-	return &pulumirpc.ReadResponse{
-		Id:         req.Id,
-		Properties: props,
-		Inputs:     props,
-	}, nil
-}
-
-func (st *PulumiServiceStackTagsResource) Update(req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	ctx := context.Background()
-
-	var oldInput PulumiServiceStackTagsInput
-	err := util.FromProperties(req.GetOlds(), &oldInput)
-	if err != nil {
-		return nil, err
-	}
-
-	var newInput PulumiServiceStackTagsInput
-	err = util.FromProperties(req.GetNews(), &newInput)
-	if err != nil {
-		return nil, err
-	}
-
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     newInput.Organization,
-		ProjectName: newInput.Project,
-		StackName:   newInput.Stack,
-	}
-	id := path.Join(newInput.Organization, newInput.Project, newInput.Stack, "tags")
-
-	// Compute the add/remove/modify sets. Pulumi Cloud tags are immutable per
-	// key, so a value change is a delete + create.
-	tagsToDelete := []string{}
-	tagsToCreate := map[string]string{}
-
-	for oldName, oldValue := range oldInput.Tags {
-		if newValue, exists := newInput.Tags[oldName]; !exists {
-			tagsToDelete = append(tagsToDelete, oldName)
-		} else if newValue != oldValue {
-			tagsToDelete = append(tagsToDelete, oldName)
-			tagsToCreate[oldName] = newValue
-		}
-	}
-	for newName, newValue := range newInput.Tags {
-		if _, exists := oldInput.Tags[newName]; !exists {
-			tagsToCreate[newName] = newValue
-		}
-	}
-
-	// Track the live tag set as we mutate it. If any API call fails we return
-	// this as the resource state so Pulumi knows exactly which tags exist.
-	currentTags := map[string]string{}
-	for k, v := range oldInput.Tags {
-		currentTags[k] = v
-	}
-
-	sort.Strings(tagsToDelete)
-	for _, tagName := range tagsToDelete {
-		err := st.Client.DeleteStackTag(ctx, stackName, tagName)
-		if err != nil {
-			state := newInput
-			state.Tags = currentTags
-			return nil, partialErrorStackTags(id, fmt.Errorf("failed to delete tag %q: %w", tagName, err), state, newInput)
-		}
-		delete(currentTags, tagName)
-	}
-
-	createNames := sortedKeys(tagsToCreate)
-	for _, name := range createNames {
-		value := tagsToCreate[name]
-		err := st.Client.CreateStackTag(ctx, stackName, pulumiapi.StackTag{Name: name, Value: value})
-		if err != nil {
-			state := newInput
-			state.Tags = currentTags
-			return nil, partialErrorStackTags(id, fmt.Errorf("failed to create tag %q: %w", name, err), state, newInput)
-		}
-		currentTags[name] = value
-	}
-
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (st *PulumiServiceStackTagsResource) Delete(req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	ctx := context.Background()
-	var input PulumiServiceStackTagsInput
-	err := util.FromProperties(req.GetProperties(), &input)
-	if err != nil {
-		return nil, err
-	}
-
-	stackName := pulumiapi.StackIdentifier{
-		OrgName:     input.Organization,
-		ProjectName: input.Project,
-		StackName:   input.Stack,
-	}
-
-	tagNames := sortedKeys(input.Tags)
-	for _, tagName := range tagNames {
-		err = st.Client.DeleteStackTag(ctx, stackName, tagName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete tag %q: %w", tagName, err)
-		}
-	}
-
-	return &pbempty.Empty{}, nil
-}
-
-// parseStackTagsID parses an ID of the form `organization/project/stack/tags`.
-func parseStackTagsID(id string) (organization, project, stack string, err error) {
+// parseStackTagsResourceID parses an ID of the form `organization/project/stack/tags`.
+func parseStackTagsResourceID(id string) (organization, project, stack string, err error) {
 	parts := strings.Split(id, "/")
 	if len(parts) != 4 || parts[3] != "tags" {
 		return "", "", "", fmt.Errorf("%q is invalid, must be in organization/project/stack/tags format", id)
@@ -317,32 +82,188 @@ func parseStackTagsID(id string) (organization, project, stack string, err error
 	return parts[0], parts[1], parts[2], nil
 }
 
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
+func (*StackTags) Create(
+	ctx context.Context,
+	req infer.CreateRequest[StackTagsInput],
+) (infer.CreateResponse[StackTagsState], error) {
+	id := stackTagsResourceID(req.Inputs.Organization, req.Inputs.Project, req.Inputs.Stack)
+
+	if req.DryRun {
+		return infer.CreateResponse[StackTagsState]{
+			ID:     id,
+			Output: req.Inputs,
+		}, nil
 	}
-	sort.Strings(keys)
-	return keys
+
+	client := config.GetClient(ctx)
+	stackIdentifier := pulumiapi.StackIdentifier{
+		OrgName:     req.Inputs.Organization,
+		ProjectName: req.Inputs.Project,
+		StackName:   req.Inputs.Stack,
+	}
+
+	// Create tags in sorted order so partial failures are deterministic.
+	created := map[string]string{}
+	for _, name := range slices.Sorted(maps.Keys(req.Inputs.Tags)) {
+		value := req.Inputs.Tags[name]
+		if err := client.CreateStackTag(ctx, stackIdentifier, pulumiapi.StackTag{Name: name, Value: value}); err != nil {
+			partial := req.Inputs
+			partial.Tags = created
+			return infer.CreateResponse[StackTagsState]{
+					ID:     id,
+					Output: partial,
+				}, infer.ResourceInitFailedError{
+					Reasons: []string{fmt.Sprintf("failed to create tag %q: %s", name, err.Error())},
+				}
+		}
+		created[name] = value
+	}
+
+	return infer.CreateResponse[StackTagsState]{
+		ID:     id,
+		Output: req.Inputs,
+	}, nil
 }
 
-// partialErrorStackTags wraps err so Pulumi records `state` as the resource's
-// last known state before failure. Without this, a Create that creates 2 of 5
-// tags and then fails would leave those 2 untracked and re-create them on retry.
-func partialErrorStackTags(id string, err error, state, inputs PulumiServiceStackTagsInput) error {
-	stateRPC, stateSerErr := state.ToRPC()
-	inputRPC, inputSerErr := inputs.ToRPC()
-	if stateSerErr != nil {
-		err = fmt.Errorf("err serializing state: %v (src error: %v)", stateSerErr, err)
+func (*StackTags) Update(
+	ctx context.Context,
+	req infer.UpdateRequest[StackTagsInput, StackTagsState],
+) (infer.UpdateResponse[StackTagsState], error) {
+	if req.DryRun {
+		return infer.UpdateResponse[StackTagsState]{Output: req.Inputs}, nil
 	}
-	if inputSerErr != nil {
-		err = fmt.Errorf("err serializing inputs: %v (src error: %v)", inputSerErr, err)
+
+	client := config.GetClient(ctx)
+	stackIdentifier := pulumiapi.StackIdentifier{
+		OrgName:     req.Inputs.Organization,
+		ProjectName: req.Inputs.Project,
+		StackName:   req.Inputs.Stack,
 	}
-	detail := pulumirpc.ErrorResourceInitFailed{
-		Id:         id,
-		Properties: stateRPC,
-		Reasons:    []string{err.Error()},
-		Inputs:     inputRPC,
+
+	// Compute the add/remove/modify sets. Pulumi Cloud tags are immutable per
+	// key, so a value change is a delete + create.
+	tagsToDelete := []string{}
+	tagsToCreate := map[string]string{}
+
+	for oldName, oldValue := range req.State.Tags {
+		if newValue, exists := req.Inputs.Tags[oldName]; !exists {
+			tagsToDelete = append(tagsToDelete, oldName)
+		} else if newValue != oldValue {
+			tagsToDelete = append(tagsToDelete, oldName)
+			tagsToCreate[oldName] = newValue
+		}
 	}
-	return rpcerror.WithDetails(rpcerror.New(codes.Unknown, err.Error()), &detail)
+	for newName, newValue := range req.Inputs.Tags {
+		if _, exists := req.State.Tags[newName]; !exists {
+			tagsToCreate[newName] = newValue
+		}
+	}
+
+	// Track the live tag set as we mutate it. If any API call fails we return
+	// this as the resource state so Pulumi knows exactly which tags exist.
+	currentTags := maps.Clone(req.State.Tags)
+	if currentTags == nil {
+		currentTags = map[string]string{}
+	}
+
+	partialOutput := func() StackTagsState {
+		state := req.Inputs
+		state.Tags = maps.Clone(currentTags)
+		return state
+	}
+
+	sort.Strings(tagsToDelete)
+	for _, tagName := range tagsToDelete {
+		if err := client.DeleteStackTag(ctx, stackIdentifier, tagName); err != nil {
+			return infer.UpdateResponse[StackTagsState]{Output: partialOutput()},
+				infer.ResourceInitFailedError{
+					Reasons: []string{fmt.Sprintf("failed to delete tag %q: %s", tagName, err.Error())},
+				}
+		}
+		delete(currentTags, tagName)
+	}
+
+	for _, name := range slices.Sorted(maps.Keys(tagsToCreate)) {
+		value := tagsToCreate[name]
+		if err := client.CreateStackTag(ctx, stackIdentifier, pulumiapi.StackTag{Name: name, Value: value}); err != nil {
+			return infer.UpdateResponse[StackTagsState]{Output: partialOutput()},
+				infer.ResourceInitFailedError{
+					Reasons: []string{fmt.Sprintf("failed to create tag %q: %s", name, err.Error())},
+				}
+		}
+		currentTags[name] = value
+	}
+
+	return infer.UpdateResponse[StackTagsState]{Output: req.Inputs}, nil
+}
+
+func (*StackTags) Delete(
+	ctx context.Context,
+	req infer.DeleteRequest[StackTagsState],
+) (infer.DeleteResponse, error) {
+	client := config.GetClient(ctx)
+	stackIdentifier := pulumiapi.StackIdentifier{
+		OrgName:     req.State.Organization,
+		ProjectName: req.State.Project,
+		StackName:   req.State.Stack,
+	}
+
+	for _, tagName := range slices.Sorted(maps.Keys(req.State.Tags)) {
+		if err := client.DeleteStackTag(ctx, stackIdentifier, tagName); err != nil {
+			return infer.DeleteResponse{}, fmt.Errorf("failed to delete tag %q: %w", tagName, err)
+		}
+	}
+	return infer.DeleteResponse{}, nil
+}
+
+func (*StackTags) Read(
+	ctx context.Context,
+	req infer.ReadRequest[StackTagsInput, StackTagsState],
+) (infer.ReadResponse[StackTagsInput, StackTagsState], error) {
+	organization, project, stack, err := parseStackTagsResourceID(req.ID)
+	if err != nil {
+		return infer.ReadResponse[StackTagsInput, StackTagsState]{}, err
+	}
+
+	client := config.GetClient(ctx)
+	allTags, err := client.GetStackTags(ctx, pulumiapi.StackIdentifier{
+		OrgName:     organization,
+		ProjectName: project,
+		StackName:   stack,
+	})
+	if err != nil {
+		return infer.ReadResponse[StackTagsInput, StackTagsState]{},
+			fmt.Errorf("failed to read stack tags (%q): %w", req.ID, err)
+	}
+
+	managedTags := map[string]string{}
+	if len(req.Inputs.Tags) > 0 {
+		// We have previous state; only return tags we previously managed.
+		for tagName := range req.Inputs.Tags {
+			if value, exists := allTags[tagName]; exists {
+				managedTags[tagName] = value
+			}
+		}
+	} else {
+		// No previous state (import scenario): adopt every tag currently on
+		// the stack. The user is expected to declare the `tags` map explicitly
+		// after import so subsequent updates match their intent.
+		managedTags = maps.Clone(allTags)
+		if managedTags == nil {
+			managedTags = map[string]string{}
+		}
+	}
+
+	state := StackTagsState{
+		Organization: organization,
+		Project:      project,
+		Stack:        stack,
+		Tags:         managedTags,
+	}
+
+	return infer.ReadResponse[StackTagsInput, StackTagsState]{
+		ID:     req.ID,
+		Inputs: state,
+		State:  state,
+	}, nil
 }

--- a/provider/pkg/resources/stack_tags_plural_test.go
+++ b/provider/pkg/resources/stack_tags_plural_test.go
@@ -1,719 +1,415 @@
+// Copyright 2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resources
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"path"
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil/rpcerror"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+	"github.com/pulumi/pulumi-go-provider/infer"
 
+	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/config"
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
-	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/util"
 )
 
-const (
-	testStackPath     = "/api/stacks/org/project/stack"
-	testStackTagsPath = "/api/stacks/org/project/stack/tags"
-)
-
-// extractTagNameFromPath extracts the tag name from a URL path like /api/stacks/org/project/stack/tags/tagname
-func extractTagNameFromPath(urlPath string) string {
-	return path.Base(urlPath)
+// stackTagsClientMock implements the slice of config.Client that StackTags uses.
+type stackTagsClientMock struct {
+	config.Client
+	createStackTagFunc func(ctx context.Context, stack pulumiapi.StackIdentifier, tag pulumiapi.StackTag) error
+	deleteStackTagFunc func(ctx context.Context, stack pulumiapi.StackIdentifier, tagName string) error
+	getStackTagsFunc   func(ctx context.Context, stack pulumiapi.StackIdentifier) (map[string]string, error)
 }
 
-func TestStackTagsPluralCreate(t *testing.T) {
-	t.Run("Creates all tags in the map", func(t *testing.T) {
-		var createdTags []pulumiapi.StackTag
-		var requestCount int
+func (m *stackTagsClientMock) CreateStackTag(
+	ctx context.Context, stack pulumiapi.StackIdentifier, tag pulumiapi.StackTag,
+) error {
+	return m.createStackTagFunc(ctx, stack, tag)
+}
 
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requestCount++
-			if r.Method == http.MethodPost && r.URL.Path == testStackTagsPath {
-				var tag pulumiapi.StackTag
-				err := json.NewDecoder(r.Body).Decode(&tag)
-				if err != nil {
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-				createdTags = append(createdTags, tag)
-				w.WriteHeader(http.StatusOK)
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer server.Close()
+func (m *stackTagsClientMock) DeleteStackTag(
+	ctx context.Context, stack pulumiapi.StackIdentifier, tagName string,
+) error {
+	return m.deleteStackTagFunc(ctx, stack, tagName)
+}
 
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
+func (m *stackTagsClientMock) GetStackTags(
+	ctx context.Context, stack pulumiapi.StackIdentifier,
+) (map[string]string, error) {
+	return m.getStackTagsFunc(ctx, stack)
+}
 
-		st := &PulumiServiceStackTagsResource{
-			Client: apiClient,
-		}
-
-		input := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-				"tag3": "value3",
-			},
-		}
-
-		properties, err := util.ToProperties(input)
-		require.NoError(t, err)
-
-		createReq := pulumirpc.CreateRequest{
-			Properties: properties,
-		}
-
-		resp, err := st.Create(&createReq)
-		require.NoError(t, err)
-		assert.Equal(t, "org/project/stack/tags", resp.Id)
-		assert.Equal(t, 3, len(createdTags))
-
-		// Verify all tags were created
-		tagMap := make(map[string]string)
-		for _, tag := range createdTags {
-			tagMap[tag.Name] = tag.Value
-		}
-		assert.Equal(t, "value1", tagMap["tag1"])
-		assert.Equal(t, "value2", tagMap["tag2"])
-		assert.Equal(t, "value3", tagMap["tag3"])
+func TestStackTagsResourceID(t *testing.T) {
+	t.Run("formats id", func(t *testing.T) {
+		assert.Equal(t, "org/proj/stk/tags", stackTagsResourceID("org", "proj", "stk"))
 	})
 }
 
-func TestStackTagsPluralCreatePartialFailure(t *testing.T) {
-	t.Run("Returns partial state when a tag creation fails mid-way", func(t *testing.T) {
-		// Fail the third tag (tags are created in sorted order: tag1, tag2, tag3).
-		var created []string
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method != http.MethodPost {
-				w.WriteHeader(http.StatusNotFound)
-				return
-			}
-			var tag pulumiapi.StackTag
-			if err := json.NewDecoder(r.Body).Decode(&tag); err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			if tag.Name == "tag3" {
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			created = append(created, tag.Name)
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
+func TestParseStackTagsResourceID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		org, proj, stk, err := parseStackTagsResourceID("org/proj/stk/tags")
 		require.NoError(t, err)
+		assert.Equal(t, "org", org)
+		assert.Equal(t, "proj", proj)
+		assert.Equal(t, "stk", stk)
+	})
 
-		st := &PulumiServiceStackTagsResource{Client: apiClient}
-
-		input := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-				"tag3": "value3",
-			},
-		}
-		properties, err := util.ToProperties(input)
-		require.NoError(t, err)
-
-		_, err = st.Create(&pulumirpc.CreateRequest{Properties: properties})
+	t.Run("missing tags suffix", func(t *testing.T) {
+		_, _, _, err := parseStackTagsResourceID("org/proj/stk")
 		require.Error(t, err)
-		assert.ElementsMatch(t, []string{"tag1", "tag2"}, created)
-
-		// The error must carry ErrorResourceInitFailed with the successfully-created
-		// subset so Pulumi records them in state and doesn't recreate them on retry.
-		rpcErr, ok := rpcerror.FromError(err)
-		require.True(t, ok, "expected a pulumi rpcerror")
-
-		var initFailed *pulumirpc.ErrorResourceInitFailed
-		for _, d := range rpcErr.Details() {
-			if f, ok := d.(*pulumirpc.ErrorResourceInitFailed); ok {
-				initFailed = f
-				break
-			}
-		}
-		require.NotNil(t, initFailed, "expected ErrorResourceInitFailed detail")
-		assert.Equal(t, "org/project/stack/tags", initFailed.Id)
-
-		partialProps, err := plugin.UnmarshalProperties(
-			initFailed.Properties, plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-		require.NoError(t, err)
-		var partial PulumiServiceStackTagsInput
-		require.NoError(t, util.FromPropertyMap(partialProps, &partial))
-		assert.Equal(t, map[string]string{"tag1": "value1", "tag2": "value2"}, partial.Tags)
-	})
-}
-
-func TestStackTagsPluralRead(t *testing.T) {
-	t.Run("Reads managed tags from stack", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodGet && r.URL.Path == testStackPath {
-				response := map[string]interface{}{
-					"tags": map[string]string{
-						"tag1":      "value1",
-						"tag2":      "value2",
-						"other-tag": "other-value",
-					},
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_ = json.NewEncoder(w).Encode(response)
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
-
-		st := &PulumiServiceStackTagsResource{
-			Client: apiClient,
-		}
-
-		// Simulate previous state with tag1 and tag2 managed
-		previousInput := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-			},
-		}
-		previousProps, err := util.ToProperties(previousInput)
-		require.NoError(t, err)
-
-		readReq := pulumirpc.ReadRequest{
-			Id:     "org/project/stack/tags",
-			Inputs: previousProps,
-		}
-
-		resp, err := st.Read(&readReq)
-		require.NoError(t, err)
-		assert.Equal(t, "org/project/stack/tags", resp.Id)
-
-		// Verify only managed tags are returned (not other-tag)
-		var output PulumiServiceStackTagsInput
-		props, err := plugin.UnmarshalProperties(resp.Properties, plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-		require.NoError(t, err)
-		err = util.FromPropertyMap(props, &output)
-		require.NoError(t, err)
-
-		assert.Equal(t, 2, len(output.Tags))
-		assert.Equal(t, "value1", output.Tags["tag1"])
-		assert.Equal(t, "value2", output.Tags["tag2"])
-		assert.NotContains(t, output.Tags, "other-tag")
 	})
 
-	t.Run("Import adopts every tag on the stack when there is no prior state", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodGet && r.URL.Path == testStackPath {
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{
-					"tags": map[string]string{
-						"env":    "prod",
-						"team":   "platform",
-						"region": "us-east-1",
-					},
-				})
-				return
-			}
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
-		st := &PulumiServiceStackTagsResource{Client: apiClient}
-
-		// req.Inputs is nil — the pulumi import path.
-		resp, err := st.Read(&pulumirpc.ReadRequest{Id: "org/project/stack/tags"})
-		require.NoError(t, err)
-		assert.Equal(t, "org/project/stack/tags", resp.Id)
-
-		props, err := plugin.UnmarshalProperties(
-			resp.Properties, plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-		require.NoError(t, err)
-		var output PulumiServiceStackTagsInput
-		require.NoError(t, util.FromPropertyMap(props, &output))
-
-		assert.Equal(t, map[string]string{
-			"env":    "prod",
-			"team":   "platform",
-			"region": "us-east-1",
-		}, output.Tags)
-	})
-
-	t.Run("Returns an error when stored inputs can't be decoded", func(t *testing.T) {
-		// No HTTP call should reach the server — Read must fail before talking to the API.
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Still satisfy the GET since Read calls GetStackTags before decoding inputs.
-			if r.Method == http.MethodGet && r.URL.Path == testStackPath {
-				_ = json.NewEncoder(w).Encode(map[string]interface{}{"tags": map[string]string{}})
-				return
-			}
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
-		st := &PulumiServiceStackTagsResource{Client: apiClient}
-
-		// Hand-craft inputs whose `tags` field is a string rather than a map.
-		// FromPropertyMap should reject the type mismatch.
-		malformed := resource.PropertyMap{
-			"organization": resource.NewStringProperty("org"),
-			"project":      resource.NewStringProperty("project"),
-			"stack":        resource.NewStringProperty("stack"),
-			"tags":         resource.NewStringProperty("not-a-map"),
-		}
-		props, err := plugin.MarshalProperties(malformed, plugin.MarshalOptions{})
-		require.NoError(t, err)
-
-		_, err = st.Read(&pulumirpc.ReadRequest{Id: "org/project/stack/tags", Inputs: props})
+	t.Run("wrong suffix", func(t *testing.T) {
+		_, _, _, err := parseStackTagsResourceID("org/proj/stk/notags")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode stored inputs")
+	})
+
+	t.Run("too many parts", func(t *testing.T) {
+		_, _, _, err := parseStackTagsResourceID("org/proj/stk/tags/extra")
+		require.Error(t, err)
 	})
 }
 
-func TestStackTagsPluralUpdate(t *testing.T) {
-	t.Run("Adds, removes, and modifies tags", func(t *testing.T) {
-		var createdTags []pulumiapi.StackTag
-		var deletedTags []string
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodPost && r.URL.Path == testStackTagsPath {
-				var tag pulumiapi.StackTag
-				err := json.NewDecoder(r.Body).Decode(&tag)
-				if err != nil {
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-				createdTags = append(createdTags, tag)
-				w.WriteHeader(http.StatusOK)
-			} else if r.Method == http.MethodDelete {
-				tagName := extractTagNameFromPath(r.URL.Path)
-				if tagName != "" {
-					deletedTags = append(deletedTags, tagName)
-				}
-				w.WriteHeader(http.StatusOK)
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
-
-		st := &PulumiServiceStackTagsResource{
-			Client: apiClient,
+func TestStackTagsCreate(t *testing.T) {
+	t.Run("creates all tags in sorted order", func(t *testing.T) {
+		var created []pulumiapi.StackTag
+		mock := &stackTagsClientMock{
+			createStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tag pulumiapi.StackTag) error {
+				created = append(created, tag)
+				return nil
+			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		oldInput := PulumiServiceStackTagsInput{
+		resp, err := (&StackTags{}).Create(ctx, infer.CreateRequest[StackTagsInput]{
+			Inputs: StackTagsInput{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"b": "2", "a": "1", "c": "3"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "org/project/stack/tags", resp.ID)
+		assert.Equal(t, []pulumiapi.StackTag{
+			{Name: "a", Value: "1"},
+			{Name: "b", Value: "2"},
+			{Name: "c", Value: "3"},
+		}, created)
+	})
+
+	t.Run("dry-run returns inputs and skips API calls", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			createStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, pulumiapi.StackTag) error {
+				t.Fatal("Create should not call API during dry run")
+				return nil
+			},
+		}
+		ctx := config.WithMockClient(context.Background(), mock)
+
+		resp, err := (&StackTags{}).Create(ctx, infer.CreateRequest[StackTagsInput]{
+			DryRun: true,
+			Inputs: StackTagsInput{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"a": "1"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "org/project/stack/tags", resp.ID)
+		assert.Equal(t, StackTagsState{
 			Organization: "org",
 			Project:      "project",
 			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-				"tag3": "value3",
+			Tags:         map[string]string{"a": "1"},
+		}, resp.Output)
+	})
+
+	t.Run("partial failure returns ResourceInitFailedError with successful tags", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			createStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tag pulumiapi.StackTag) error {
+				if tag.Name == "tag3" {
+					return errors.New("boom")
+				}
+				return nil
 			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		newInput := PulumiServiceStackTagsInput{
+		resp, err := (&StackTags{}).Create(ctx, infer.CreateRequest[StackTagsInput]{
+			Inputs: StackTagsInput{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"tag1": "v1", "tag2": "v2", "tag3": "v3"},
+			},
+		})
+		require.Error(t, err)
+
+		var initFailed infer.ResourceInitFailedError
+		require.True(t, errors.As(err, &initFailed))
+		require.Len(t, initFailed.Reasons, 1)
+		assert.Contains(t, initFailed.Reasons[0], "tag3")
+		assert.Equal(t, "org/project/stack/tags", resp.ID)
+		assert.Equal(t, StackTagsState{
 			Organization: "org",
 			Project:      "project",
 			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "new-value1", // Modified
-				"tag2": "value2",     // Unchanged
-				"tag4": "value4",     // Added
-				// tag3 removed
-			},
-		}
-
-		oldProps, err := util.ToProperties(oldInput)
-		require.NoError(t, err)
-		newProps, err := util.ToProperties(newInput)
-		require.NoError(t, err)
-
-		updateReq := pulumirpc.UpdateRequest{
-			Olds: oldProps,
-			News: newProps,
-		}
-
-		resp, err := st.Update(&updateReq)
-		require.NoError(t, err)
-		assert.NotNil(t, resp)
-
-		// Verify tag3 was deleted
-		assert.Contains(t, deletedTags, "tag3")
-
-		// Verify tag1 was deleted (for update) and recreated with new value
-		assert.Contains(t, deletedTags, "tag1")
-
-		// Verify new tags were created
-		createdMap := make(map[string]string)
-		for _, tag := range createdTags {
-			createdMap[tag.Name] = tag.Value
-		}
-		assert.Equal(t, "new-value1", createdMap["tag1"])
-		assert.Equal(t, "value4", createdMap["tag4"])
+			Tags:         map[string]string{"tag1": "v1", "tag2": "v2"},
+		}, resp.Output)
 	})
 }
 
-func TestStackTagsPluralUpdatePartialFailure(t *testing.T) {
-	// Helper: build a server that fails when a specific tag is created or deleted.
-	// Tags are processed in sorted order by the resource, so the failure point is
-	// predictable.
-	newServer := func(failDelete, failCreate string) *httptest.Server {
-		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch {
-			case r.Method == http.MethodPost && r.URL.Path == testStackTagsPath:
-				var tag pulumiapi.StackTag
-				if err := json.NewDecoder(r.Body).Decode(&tag); err != nil {
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-				if tag.Name == failCreate {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			case r.Method == http.MethodDelete:
-				if extractTagNameFromPath(r.URL.Path) == failDelete {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.WriteHeader(http.StatusOK)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-	}
-
-	extractPartialState := func(t *testing.T, err error) PulumiServiceStackTagsInput {
-		t.Helper()
-		rpcErr, ok := rpcerror.FromError(err)
-		require.True(t, ok, "expected a pulumi rpcerror")
-		var initFailed *pulumirpc.ErrorResourceInitFailed
-		for _, d := range rpcErr.Details() {
-			if f, ok := d.(*pulumirpc.ErrorResourceInitFailed); ok {
-				initFailed = f
-				break
-			}
-		}
-		require.NotNil(t, initFailed, "expected ErrorResourceInitFailed detail")
-		partialProps, err := plugin.UnmarshalProperties(
-			initFailed.Properties, plugin.MarshalOptions{KeepUnknowns: false, SkipNulls: true})
-		require.NoError(t, err)
-		var partial PulumiServiceStackTagsInput
-		require.NoError(t, util.FromPropertyMap(partialProps, &partial))
-		return partial
-	}
-
-	oldInput := PulumiServiceStackTagsInput{
+func TestStackTagsUpdate(t *testing.T) {
+	oldState := StackTagsState{
 		Organization: "org",
 		Project:      "project",
 		Stack:        "stack",
-		Tags: map[string]string{
-			"tag1": "v1",
-			"tag2": "v2",
-			"tag3": "v3",
-		},
+		Tags:         map[string]string{"tag1": "v1", "tag2": "v2", "tag3": "v3"},
 	}
-	// Remove tag1, change tag2, add tag4. Sorted deletes: [tag1, tag2]; sorted
-	// creates: [tag2, tag4].
-	newInput := PulumiServiceStackTagsInput{
+	// Remove tag1, change tag2, add tag4.
+	newInputs := StackTagsInput{
 		Organization: "org",
 		Project:      "project",
 		Stack:        "stack",
-		Tags: map[string]string{
-			"tag2": "v2-new",
-			"tag3": "v3",
-			"tag4": "v4",
-		},
+		Tags:         map[string]string{"tag2": "v2-new", "tag3": "v3", "tag4": "v4"},
 	}
 
-	t.Run("fails mid-delete: state reflects tags still on the server", func(t *testing.T) {
-		// Fail on delete of tag2 (second in sorted order). tag1 was already deleted.
-		server := newServer("tag2", "")
-		defer server.Close()
+	t.Run("applies add/delete/modify operations", func(t *testing.T) {
+		var deletes []string
+		var creates []pulumiapi.StackTag
+		mock := &stackTagsClientMock{
+			createStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tag pulumiapi.StackTag) error {
+				creates = append(creates, tag)
+				return nil
+			},
+			deleteStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tagName string) error {
+				deletes = append(deletes, tagName)
+				return nil
+			},
+		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
+		resp, err := (&StackTags{}).Update(ctx, infer.UpdateRequest[StackTagsInput, StackTagsState]{
+			State:  oldState,
+			Inputs: newInputs,
+		})
 		require.NoError(t, err)
-		st := &PulumiServiceStackTagsResource{Client: apiClient}
-
-		oldProps, err := util.ToProperties(oldInput)
-		require.NoError(t, err)
-		newProps, err := util.ToProperties(newInput)
-		require.NoError(t, err)
-
-		_, err = st.Update(&pulumirpc.UpdateRequest{Olds: oldProps, News: newProps})
-		require.Error(t, err)
-
-		partial := extractPartialState(t, err)
-		// tag1 was deleted; tag2 delete failed, so tag2 is still live; tag3 was
-		// untouched. No creates happened yet.
-		assert.Equal(t, map[string]string{"tag2": "v2", "tag3": "v3"}, partial.Tags)
+		// Deletes are sorted: tag1 (removed), tag2 (modified).
+		assert.Equal(t, []string{"tag1", "tag2"}, deletes)
+		// Creates are sorted: tag2 (modified), tag4 (added).
+		assert.Equal(t, []pulumiapi.StackTag{
+			{Name: "tag2", Value: "v2-new"},
+			{Name: "tag4", Value: "v4"},
+		}, creates)
+		assert.Equal(t, newInputs, resp.Output)
 	})
 
-	t.Run("fails mid-create: state reflects deletes plus successful creates", func(t *testing.T) {
-		// Fail on create of tag4 (second in sorted creates). By that point:
-		// deletes tag1, tag2 succeeded; create tag2="v2-new" succeeded.
-		server := newServer("", "tag4")
-		defer server.Close()
+	t.Run("dry-run skips API and returns inputs", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			createStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, pulumiapi.StackTag) error {
+				t.Fatal("Update should not call API during dry run")
+				return nil
+			},
+			deleteStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, string) error {
+				t.Fatal("Update should not call API during dry run")
+				return nil
+			},
+		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
+		resp, err := (&StackTags{}).Update(ctx, infer.UpdateRequest[StackTagsInput, StackTagsState]{
+			DryRun: true,
+			State:  oldState,
+			Inputs: newInputs,
+		})
 		require.NoError(t, err)
-		st := &PulumiServiceStackTagsResource{Client: apiClient}
-
-		oldProps, err := util.ToProperties(oldInput)
-		require.NoError(t, err)
-		newProps, err := util.ToProperties(newInput)
-		require.NoError(t, err)
-
-		_, err = st.Update(&pulumirpc.UpdateRequest{Olds: oldProps, News: newProps})
-		require.Error(t, err)
-
-		partial := extractPartialState(t, err)
-		assert.Equal(t, map[string]string{"tag2": "v2-new", "tag3": "v3"}, partial.Tags)
+		assert.Equal(t, newInputs, resp.Output)
 	})
-}
 
-func TestStackTagsPluralDelete(t *testing.T) {
-	t.Run("Deletes all managed tags", func(t *testing.T) {
-		var deletedTags []string
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodDelete {
-				tagName := extractTagNameFromPath(r.URL.Path)
-				if tagName != "" {
-					deletedTags = append(deletedTags, tagName)
+	t.Run("delete failure mid-update returns partial state with surviving tags", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			deleteStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tagName string) error {
+				if tagName == "tag2" {
+					return errors.New("delete boom")
 				}
-				w.WriteHeader(http.StatusOK)
-			} else {
-				w.WriteHeader(http.StatusNotFound)
-			}
-		}))
-		defer server.Close()
-
-		apiClient, err := pulumiapi.NewClient(server.Client(), "", server.URL)
-		require.NoError(t, err)
-
-		st := &PulumiServiceStackTagsResource{
-			Client: apiClient,
+				return nil
+			},
+			createStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, pulumiapi.StackTag) error {
+				t.Fatal("creates should not run after a delete failure")
+				return nil
+			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		input := PulumiServiceStackTagsInput{
+		resp, err := (&StackTags{}).Update(ctx, infer.UpdateRequest[StackTagsInput, StackTagsState]{
+			State:  oldState,
+			Inputs: newInputs,
+		})
+		require.Error(t, err)
+		var initFailed infer.ResourceInitFailedError
+		require.True(t, errors.As(err, &initFailed))
+		// tag1 was successfully deleted; tag2 failed and is still live; tag3
+		// has not been touched yet.
+		assert.Equal(t, StackTagsState{
 			Organization: "org",
 			Project:      "project",
 			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-				"tag3": "value3",
+			Tags:         map[string]string{"tag2": "v2", "tag3": "v3"},
+		}, resp.Output)
+	})
+
+	t.Run("create failure mid-update returns partial state with deletes plus successful creates", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			deleteStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, string) error {
+				return nil
+			},
+			createStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tag pulumiapi.StackTag) error {
+				if tag.Name == "tag4" {
+					return errors.New("create boom")
+				}
+				return nil
 			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		properties, err := util.ToProperties(input)
-		require.NoError(t, err)
-
-		deleteReq := pulumirpc.DeleteRequest{
-			Properties: properties,
-		}
-
-		_, err = st.Delete(&deleteReq)
-		require.NoError(t, err)
-
-		// Verify all tags were deleted
-		assert.Equal(t, 3, len(deletedTags))
-		assert.Contains(t, deletedTags, "tag1")
-		assert.Contains(t, deletedTags, "tag2")
-		assert.Contains(t, deletedTags, "tag3")
+		resp, err := (&StackTags{}).Update(ctx, infer.UpdateRequest[StackTagsInput, StackTagsState]{
+			State:  oldState,
+			Inputs: newInputs,
+		})
+		require.Error(t, err)
+		var initFailed infer.ResourceInitFailedError
+		require.True(t, errors.As(err, &initFailed))
+		// tag1, tag2 deletes succeeded; tag2 was recreated with the new value;
+		// tag3 is untouched; tag4 create failed.
+		assert.Equal(t, StackTagsState{
+			Organization: "org",
+			Project:      "project",
+			Stack:        "stack",
+			Tags:         map[string]string{"tag2": "v2-new", "tag3": "v3"},
+		}, resp.Output)
 	})
 }
 
-func TestStackTagsPluralDiff(t *testing.T) {
-	t.Run("Detects no changes when tags are identical", func(t *testing.T) {
-		st := &PulumiServiceStackTagsResource{}
-
-		input := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
+func TestStackTagsDelete(t *testing.T) {
+	t.Run("deletes all managed tags", func(t *testing.T) {
+		var deletes []string
+		mock := &stackTagsClientMock{
+			deleteStackTagFunc: func(_ context.Context, _ pulumiapi.StackIdentifier, tagName string) error {
+				deletes = append(deletes, tagName)
+				return nil
 			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		props, err := util.ToProperties(input)
+		_, err := (&StackTags{}).Delete(ctx, infer.DeleteRequest[StackTagsState]{
+			State: StackTagsState{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"a": "1", "b": "2"},
+			},
+		})
 		require.NoError(t, err)
-
-		diffReq := pulumirpc.DiffRequest{
-			OldInputs: props,
-			News:      props,
-		}
-
-		resp, err := st.Diff(&diffReq)
-		require.NoError(t, err)
-		assert.Equal(t, pulumirpc.DiffResponse_DIFF_NONE, resp.Changes)
+		assert.Equal(t, []string{"a", "b"}, deletes)
 	})
 
-	t.Run("Detects changes when tags are modified", func(t *testing.T) {
-		st := &PulumiServiceStackTagsResource{}
-
-		oldInput := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
+	t.Run("returns error if delete fails", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			deleteStackTagFunc: func(context.Context, pulumiapi.StackIdentifier, string) error {
+				return errors.New("boom")
 			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		newInput := PulumiServiceStackTagsInput{
-			Organization: "org",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "new-value1",
+		_, err := (&StackTags{}).Delete(ctx, infer.DeleteRequest[StackTagsState]{
+			State: StackTagsState{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"a": "1"},
 			},
-		}
-
-		oldProps, err := util.ToProperties(oldInput)
-		require.NoError(t, err)
-		newProps, err := util.ToProperties(newInput)
-		require.NoError(t, err)
-
-		diffReq := pulumirpc.DiffRequest{
-			OldInputs: oldProps,
-			News:      newProps,
-		}
-
-		resp, err := st.Diff(&diffReq)
-		require.NoError(t, err)
-		assert.Equal(t, pulumirpc.DiffResponse_DIFF_SOME, resp.Changes)
-		assert.NotNil(t, resp.DetailedDiff)
-	})
-
-	t.Run("Requires replacement when organization changes", func(t *testing.T) {
-		st := &PulumiServiceStackTagsResource{}
-
-		oldInput := PulumiServiceStackTagsInput{
-			Organization: "org1",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-			},
-		}
-
-		newInput := PulumiServiceStackTagsInput{
-			Organization: "org2",
-			Project:      "project",
-			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-			},
-		}
-
-		oldProps, err := util.ToProperties(oldInput)
-		require.NoError(t, err)
-		newProps, err := util.ToProperties(newInput)
-		require.NoError(t, err)
-
-		diffReq := pulumirpc.DiffRequest{
-			OldInputs: oldProps,
-			News:      newProps,
-		}
-
-		resp, err := st.Diff(&diffReq)
-		require.NoError(t, err)
-		assert.Equal(t, pulumirpc.DiffResponse_DIFF_SOME, resp.Changes)
-		assert.True(t, resp.DeleteBeforeReplace)
-		assert.Contains(t, resp.Replaces, "organization")
+		})
+		require.Error(t, err)
 	})
 }
 
-func TestStackTagsPluralCheck(t *testing.T) {
-	t.Run("Returns inputs without failures", func(t *testing.T) {
-		st := &PulumiServiceStackTagsResource{}
+func TestStackTagsRead(t *testing.T) {
+	t.Run("returns only managed tags when prior inputs exist", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			getStackTagsFunc: func(context.Context, pulumiapi.StackIdentifier) (map[string]string, error) {
+				return map[string]string{"tag1": "v1", "tag2": "v2", "extra": "x"}, nil
+			},
+		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		input := PulumiServiceStackTagsInput{
+		resp, err := (&StackTags{}).Read(ctx, infer.ReadRequest[StackTagsInput, StackTagsState]{
+			ID: "org/project/stack/tags",
+			Inputs: StackTagsInput{
+				Organization: "org",
+				Project:      "project",
+				Stack:        "stack",
+				Tags:         map[string]string{"tag1": "old1", "tag2": "old2"},
+			},
+		})
+		require.NoError(t, err)
+		expected := StackTagsState{
 			Organization: "org",
 			Project:      "project",
 			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
+			Tags:         map[string]string{"tag1": "v1", "tag2": "v2"},
+		}
+		assert.Equal(t, infer.ReadResponse[StackTagsInput, StackTagsState]{
+			ID:     "org/project/stack/tags",
+			Inputs: expected,
+			State:  expected,
+		}, resp)
+	})
+
+	t.Run("import adopts every tag when there are no prior inputs", func(t *testing.T) {
+		mock := &stackTagsClientMock{
+			getStackTagsFunc: func(context.Context, pulumiapi.StackIdentifier) (map[string]string, error) {
+				return map[string]string{"a": "1", "b": "2"}, nil
 			},
 		}
+		ctx := config.WithMockClient(context.Background(), mock)
 
-		props, err := util.ToProperties(input)
+		resp, err := (&StackTags{}).Read(ctx, infer.ReadRequest[StackTagsInput, StackTagsState]{
+			ID: "org/project/stack/tags",
+		})
 		require.NoError(t, err)
-
-		checkReq := pulumirpc.CheckRequest{
-			News: props,
-		}
-
-		resp, err := st.Check(&checkReq)
-		require.NoError(t, err)
-		assert.NotNil(t, resp)
-		assert.Nil(t, resp.Failures)
-		assert.Equal(t, props, resp.Inputs)
-	})
-}
-
-func TestStackTagsPluralName(t *testing.T) {
-	t.Run("Returns correct resource name", func(t *testing.T) {
-		st := &PulumiServiceStackTagsResource{}
-		assert.Equal(t, "pulumiservice:index:StackTags", st.Name())
-	})
-}
-
-func TestStackTagsPluralPropertyMapConversion(t *testing.T) {
-	t.Run("Converts to and from PropertyMap correctly", func(t *testing.T) {
-		input := PulumiServiceStackTagsInput{
+		expected := StackTagsState{
 			Organization: "org",
 			Project:      "project",
 			Stack:        "stack",
-			Tags: map[string]string{
-				"tag1": "value1",
-				"tag2": "value2",
-			},
+			Tags:         map[string]string{"a": "1", "b": "2"},
 		}
+		assert.Equal(t, infer.ReadResponse[StackTagsInput, StackTagsState]{
+			ID:     "org/project/stack/tags",
+			Inputs: expected,
+			State:  expected,
+		}, resp)
+	})
 
-		// Convert to PropertyMap
-		propMap := input.ToPropertyMap()
-		assert.NotNil(t, propMap)
-		assert.True(t, propMap["organization"].IsString())
-		assert.Equal(t, "org", propMap["organization"].StringValue())
-
-		// Convert back from PropertyMap via the shared util helper.
-		var output PulumiServiceStackTagsInput
-		require.NoError(t, util.FromPropertyMap(propMap, &output))
-		assert.Equal(t, input.Organization, output.Organization)
-		assert.Equal(t, input.Project, output.Project)
-		assert.Equal(t, input.Stack, output.Stack)
-		assert.Equal(t, input.Tags, output.Tags)
+	t.Run("invalid id returns error", func(t *testing.T) {
+		_, err := (&StackTags{}).Read(context.Background(),
+			infer.ReadRequest[StackTagsInput, StackTagsState]{ID: "bogus"})
+		require.Error(t, err)
 	})
 }

--- a/sdk/dotnet/StackTags.cs
+++ b/sdk/dotnet/StackTags.cs
@@ -66,6 +66,12 @@ namespace Pulumi.PulumiService
             var defaultOptions = new CustomResourceOptions
             {
                 Version = Utilities.Version,
+                ReplaceOnChanges =
+                {
+                    "organization",
+                    "project",
+                    "stack",
+                },
             };
             var merged = CustomResourceOptions.Merge(defaultOptions, options);
             // Override the ID if one was specified for consistency with other language SDKs.

--- a/sdk/go/pulumiservice/stackTags.go
+++ b/sdk/go/pulumiservice/stackTags.go
@@ -49,6 +49,12 @@ func NewStackTags(ctx *pulumi.Context,
 	if args.Tags == nil {
 		return nil, errors.New("invalid value for required argument 'Tags'")
 	}
+	replaceOnChanges := pulumi.ReplaceOnChanges([]string{
+		"organization",
+		"project",
+		"stack",
+	})
+	opts = append(opts, replaceOnChanges)
 	opts = internal.PkgResourceDefaultOpts(opts)
 	var resource StackTags
 	err := ctx.RegisterResource("pulumiservice:index:StackTags", name, args, &resource, opts...)

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/StackTags.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/StackTags.java
@@ -10,6 +10,7 @@ import com.pulumi.core.internal.Codegen;
 import com.pulumi.pulumiservice.StackTagsArgs;
 import com.pulumi.pulumiservice.Utilities;
 import java.lang.String;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -119,6 +120,11 @@ public class StackTags extends com.pulumi.resources.CustomResource {
     private static com.pulumi.resources.CustomResourceOptions makeResourceOptions(@Nullable com.pulumi.resources.CustomResourceOptions options, @Nullable Output<java.lang.String> id) {
         var defaultOptions = com.pulumi.resources.CustomResourceOptions.builder()
             .version(Utilities.getVersion())
+            .replaceOnChanges(List.of(
+                "organization",
+                "project",
+                "stack"
+            ))
             .build();
         return com.pulumi.resources.CustomResourceOptions.merge(defaultOptions, options, id);
     }

--- a/sdk/nodejs/stackTags.ts
+++ b/sdk/nodejs/stackTags.ts
@@ -89,6 +89,8 @@ export class StackTags extends pulumi.CustomResource {
             resourceInputs["tags"] = undefined /*out*/;
         }
         opts = pulumi.mergeOptions(utilities.resourceOptsDefaults(), opts);
+        const replaceOnChanges = { replaceOnChanges: ["organization", "project", "stack"] };
+        opts = pulumi.mergeOptions(opts, replaceOnChanges);
         super(StackTags.__pulumiType, name, resourceInputs, opts);
     }
 }

--- a/sdk/python/pulumi_pulumiservice/stack_tags.py
+++ b/sdk/python/pulumi_pulumiservice/stack_tags.py
@@ -165,6 +165,8 @@ class StackTags(pulumi.CustomResource):
             if tags is None and not opts.urn:
                 raise TypeError("Missing required property 'tags'")
             __props__.__dict__["tags"] = tags
+        replace_on_changes = pulumi.ResourceOptions(replace_on_changes=["organization", "project", "stack"])
+        opts = pulumi.ResourceOptions.merge(opts, replace_on_changes)
         super(StackTags, __self__).__init__(
             'pulumiservice:index:StackTags',
             resource_name,


### PR DESCRIPTION
## Summary
- Migrates `StackTags` (plural map-of-tags) resource to the `infer` framework.
- Preserves partial-failure semantics: Create and Update return `infer.ResourceInitFailedError` with the partially-applied tag set so Pulumi records exactly which tags exist if a mid-sequence API call fails.
- Preserves import semantics: importing with `{org}/{project}/{stack}/tags` adopts every tag currently on the stack; subsequent Reads only report tags present in `inputs.tags`.
- Adds `GetStackTags` to the `StackTagClient` interface so the infer-based Read can reach it through `config.Client`.
- Regenerates SDKs from the updated schema.

## Test plan
- [x] `make provider`
- [x] `make build_sdks`
- [x] `go test ./...` in `provider/pkg`
- [x] `make lint`
- [ ] CI integration tests