### PR TITLE
ci(refresh-v1-spec): auth via GitHub App so auto PR triggers CI

### DIFF
--- a/.github/workflows/refresh-v1-spec.yml
+++ b/.github/workflows/refresh-v1-spec.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write # For ESC secrets.
 
 concurrency:
   group: refresh-v1-spec
@@ -52,12 +53,33 @@ jobs:
             exit 1
           fi
 
+      # Auth via GitHub App token (not GITHUB_TOKEN) so the eventual push to
+      # auto/refresh-v1-spec and the gh-CLI PR open emit events that trigger
+      # downstream pull_request workflows. Pushes/PRs from GITHUB_TOKEN are
+      # silently suppressed from triggering other workflows.
+      - env:
+          ESC_ACTION_ENVIRONMENT: github-secrets/${{ github.repository_owner }}-${{ github.event.repository.name }}
+          ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: "false"
+          ESC_ACTION_OIDC_AUTH: "true"
+          ESC_ACTION_OIDC_ORGANIZATION: pulumi
+          ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+        id: esc-secrets
+        name: Fetch secrets from ESC
+        uses: pulumi/esc-action@9eb774255b1a4afb7855678ae8d4a77359da0d9b
+
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-auth
+        with:
+          app-id: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_APP_ID }}
+          private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout main
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-auth.outputs.token }}
 
       - name: Install mise
         uses: jdx/mise-action@590bfd78fa3e93efd2e7ea21d65d397118ac1430
@@ -132,7 +154,7 @@ jobs:
       - name: Ensure auto-release label exists
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
         run: |
           gh label create auto-release \
             --color FF6F00 \
@@ -171,7 +193,7 @@ jobs:
       - name: Open or update PR
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-auth.outputs.token }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- `refresh-v1-spec.yml` pushed the auto PR using `secrets.GITHUB_TOKEN`. GitHub suppresses downstream `pull_request` / `push` workflow triggers for events authored by `GITHUB_TOKEN`, so the resulting auto PR sat with no checks (no `v1-tests`, no `run-acceptance-tests`, no `lint`) and required a manual no-op commit before CI would fire — see #853.
- Mint a GitHub App installation token via ESC (same pattern as `tag-v1-release.yml`) and route the checkout, `gh label create`, and `gh pr create/edit` through it. App-installation tokens *do* emit triggering events.
- `mise-action` keeps `GITHUB_TOKEN`; it only needs read/rate-limit access.

## Test plan

- [ ] After merge, re-run `refresh-v1-spec` via workflow_dispatch and confirm the resulting PR shows `run-v1-tests`, `run-acceptance-tests`, and `lint` queued without any manual nudge.

> The auto-release branch (`auto/refresh-v1-spec`) is force-pushed by the workflow, so this fix only takes effect on the next run.