### PR TITLE
ci: source PULUMI_TEST_AWS_INSIGHTS_ROLE_ARN from .ci-mgmt.yaml

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -15,6 +15,11 @@ env:
 
   PULUMI_TEST_OWNER: service-provider-test-org
   PULUMI_TEST_USE_SERVICE: true
+
+  # Insights example tests assume an AWS role via Pulumi Cloud OIDC; the role
+  # ARN comes from the infra/test-aws-oidc stack. Sourced here so it survives
+  # workflow regeneration (the tests hard-fail when it is unset).
+  PULUMI_TEST_AWS_INSIGHTS_ROLE_ARN: ${{ steps.esc-secrets.outputs.PULUMI_TEST_AWS_INSIGHTS_ROLE_ARN }}
 providerDefaultBranch: main
 template: generic
 shards: 6


### PR DESCRIPTION
The Insights example tests assume an AWS role via Pulumi Cloud OIDC (`getInsightsRoleArn`, `examples/examples_utils_test.go`) and `t.Fatal` when `PULUMI_TEST_AWS_INSIGHTS_ROLE_ARN` is unset. The generated workflows pass it via `${{ steps.esc-secrets.outputs.PULUMI_TEST_AWS_INSIGHTS_ROLE_ARN }}`, and the value is present in the `github-secrets/pulumi-pulumi-pulumiservice` ESC environment under `environmentVariables`. However the workflow entry lived only in the generated `test.yml` and `prerequisites.yml`, never in `.ci-mgmt.yaml`, so any workflow regeneration drops it and the Insights tests then fail with the value unset.

This declares the var in the `.ci-mgmt.yaml` `env:` block alongside `PULUMI_ACCESS_TOKEN`, which ci-mgmt injects onto the generated run steps (where `steps.esc-secrets` is in scope). After this lands, regenerating the workflows keeps the wiring instead of dropping it. The generated `test.yml`/`prerequisites.yml` on `main` already contain the line, so this change introduces no diff to the generated files; it only makes the source of truth consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)