### PR TITLE
Declare provider binary build inputs in a regen-safe Make include

### DIFF
--- a/.mk/provider-build.mk
+++ b/.mk/provider-build.mk
@@ -1,0 +1,17 @@
+# Declare the provider binary's real inputs so incremental builds are correct.
+# Under useProviderBinarySchemaGen, ci-mgmt generates `bin/$(PROVIDER)` with no
+# prerequisites, so make never rebuilds it on source changes. This prerequisite-
+# only rule (no recipe) is merged into the generated rule without overriding it.
+# Lives here, not inline in the Makefile, to survive ci-mgmt regen (ci-mgmt#2285).
+#
+# Keep in sync with the provider's //go:embed directives. Do NOT list the
+# generated provider/cmd/$(PROVIDER)/schema.json: it is built FROM the binary,
+# so it would create a circular dependency.
+PROVIDER_SOURCES := $(shell find provider/cmd provider/pkg -name '*.go') \
+                    provider/pkg/cloud/spec.json \
+                    provider/pkg/cloud/metadata.json \
+                    provider/pkg/provider/manual-schema.json \
+                    provider/pkg/provider/README.md \
+                    go.mod go.sum
+
+bin/$(PROVIDER): $(PROVIDER_SOURCES)


### PR DESCRIPTION
## Summary

Under `useProviderBinarySchemaGen` the schema is derived from the built provider binary, so ci-mgmt generates `bin/$(PROVIDER)` with no prerequisites. Make then treats the binary as up to date once it exists and never rebuilds it when sources change, so an incremental `make provider` can leave a stale binary in place.

This declares the binary's real inputs as a prerequisite-only rule in a new `.mk/provider-build.mk`: the provider Go sources plus the files embedded into the binary via `//go:embed` (`spec.json`, `metadata.json`, `manual-schema.json`, and the provider `README.md`). The generated Makefile already ends with `include $(wildcard .mk/*.mk)`, so make merges these prerequisites into the generated `bin/$(PROVIDER)` rule without overriding its build recipe. Because it lives under `.mk/` instead of inline in the Makefile, it survives `make ci-mgmt` regeneration; an earlier inline version of this edit was lost on the following regeneration, which is what motivated moving it here.

The generated `provider/cmd/pulumi-resource-pulumiservice/schema.json` is deliberately omitted from the prerequisites: it is produced from the binary by `make schema`, so listing it would create a circular dependency.

## Verification

- `make -p -n provider` parses with no `overriding commands` or `circular dependency` warnings; the merged rule carries 833 prerequisites and the generated `schema.json` is correctly absent.
- Dry-run rebuild decisions are correct: an up-to-date binary reports `Nothing to be done`; touching an embedded source (`spec.json`) triggers a rebuild; touching the generated `schema.json` does not.

Part of pulumi/ci-mgmt#2285.
Part of pulumi/pulumi-pulumiservice#883.
