### PR TITLE
Update stale GitHub OIDC TLS thumbprint in examples

### DIFF
--- a/examples/api/oidc-issuer/csharp/Program.cs
+++ b/examples/api/oidc-issuer/csharp/Program.cs
@@ -22,7 +22,7 @@ return await Deployment.RunAsync(() =>
         OrgName = organizationName,
         Name = $"github_issuer_{issuerSuffix}",
         Url = "https://token.actions.githubusercontent.com",
-        Thumbprints = new[] { "b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486" },
+        Thumbprints = new[] { "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5" },
         MaxExpiration = maxExpiration,
     });
 

--- a/examples/api/oidc-issuer/go/main.go
+++ b/examples/api/oidc-issuer/go/main.go
@@ -36,7 +36,7 @@ func main() {
 			OrgName:       pulumi.String(organizationName),
 			Name:          pulumi.String("github_issuer_" + issuerSuffix),
 			Url:           pulumi.String("https://token.actions.githubusercontent.com"),
-			Thumbprints:   pulumi.StringArray{pulumi.String("b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486")},
+			Thumbprints:   pulumi.StringArray{pulumi.String("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5")},
 			MaxExpiration: pulumi.Int(maxExpiration),
 		})
 		if err != nil {

--- a/examples/api/oidc-issuer/java/src/main/java/generated_program/App.java
+++ b/examples/api/oidc-issuer/java/src/main/java/generated_program/App.java
@@ -27,7 +27,7 @@ public class App {
                     .orgName(organizationName)
                     .name("github_issuer_" + issuerSuffix)
                     .url("https://token.actions.githubusercontent.com")
-                    .thumbprints(List.of("b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"))
+                    .thumbprints(List.of("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"))
                     .maxExpiration(maxExpiration)
                     .build());
 

--- a/examples/api/oidc-issuer/python/__main__.py
+++ b/examples/api/oidc-issuer/python/__main__.py
@@ -19,7 +19,7 @@ github_issuer = ps_api.auth.OidcIssuer(
     org_name=organization_name,
     name=f"github_issuer_{issuer_suffix}",
     url="https://token.actions.githubusercontent.com",
-    thumbprints=["b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"],
+    thumbprints=["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     max_expiration=max_expiration,
 )
 

--- a/examples/api/oidc-issuer/typescript/index.ts
+++ b/examples/api/oidc-issuer/typescript/index.ts
@@ -17,7 +17,7 @@ const githubIssuer = new ps.api.auth.OidcIssuer("githubIssuer", {
     orgName: organizationName,
     name: `github_issuer_${issuerSuffix}`,
     url: "https://token.actions.githubusercontent.com",
-    thumbprints: ["b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"],
+    thumbprints: ["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     maxExpiration: maxExpiration,
 });
 

--- a/examples/api/oidc-issuer/yaml/Main.yaml
+++ b/examples/api/oidc-issuer/yaml/Main.yaml
@@ -14,7 +14,7 @@ resources:
       name: github_issuer_${issuerSuffix}
       url: https://token.actions.githubusercontent.com
       thumbprints:
-        - b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486
+        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
       maxExpiration: ${maxExpiration}
 outputs:
   pulumiIssuerName: ${pulumiIssuer.name}

--- a/examples/api/platform-bootstrap/csharp/Program.cs
+++ b/examples/api/platform-bootstrap/csharp/Program.cs
@@ -21,7 +21,7 @@ return await Deployment.RunAsync(() =>
         OrgName = organizationName,
         Name = $"github_issuer_{suffix}",
         Url = "https://token.actions.githubusercontent.com",
-        Thumbprints = new[] { "b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486" },
+        Thumbprints = new[] { "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5" },
         MaxExpiration = 3600,
     });
     new Ps.Api.Auth.OidcIssuer("pulumiSelfIssuer", new()

--- a/examples/api/platform-bootstrap/go/main.go
+++ b/examples/api/platform-bootstrap/go/main.go
@@ -47,7 +47,7 @@ func main() {
 			OrgName:       pulumi.String(organizationName),
 			Name:          pulumi.String("github_issuer_" + suffix),
 			Url:           pulumi.String("https://token.actions.githubusercontent.com"),
-			Thumbprints:   pulumi.StringArray{pulumi.String("b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486")},
+			Thumbprints:   pulumi.StringArray{pulumi.String("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5")},
 			MaxExpiration: pulumi.Int(3600),
 		}); err != nil {
 			return err

--- a/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
+++ b/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
@@ -49,7 +49,7 @@ public class App {
                     .orgName(organizationName)
                     .name("github_issuer_" + suffix)
                     .url("https://token.actions.githubusercontent.com")
-                    .thumbprints(List.of("b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"))
+                    .thumbprints(List.of("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"))
                     .maxExpiration(3600)
                     .build());
             new OidcIssuer("pulumiSelfIssuer",

--- a/examples/api/platform-bootstrap/python/__main__.py
+++ b/examples/api/platform-bootstrap/python/__main__.py
@@ -19,7 +19,7 @@ ps_api.auth.OidcIssuer(
     org_name=organization_name,
     name=f"github_issuer_{suffix}",
     url="https://token.actions.githubusercontent.com",
-    thumbprints=["b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"],
+    thumbprints=["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     max_expiration=3600,
 )
 ps_api.auth.OidcIssuer(

--- a/examples/api/platform-bootstrap/typescript/index.ts
+++ b/examples/api/platform-bootstrap/typescript/index.ts
@@ -18,7 +18,7 @@ new ps.api.auth.OidcIssuer("githubIssuer", {
     orgName: organizationName,
     name: `github_issuer_${suffix}`,
     url: "https://token.actions.githubusercontent.com",
-    thumbprints: ["b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"],
+    thumbprints: ["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     maxExpiration: 3600,
 });
 new ps.api.auth.OidcIssuer("pulumiSelfIssuer", {

--- a/examples/api/platform-bootstrap/yaml/Main.yaml
+++ b/examples/api/platform-bootstrap/yaml/Main.yaml
@@ -51,7 +51,7 @@ resources:
       name: github_issuer_${suffix}
       url: https://token.actions.githubusercontent.com
       thumbprints:
-        - b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486
+        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
       maxExpiration: 3600
   pulumiSelfIssuer:
     type: pulumiservice:api/auth:OidcIssuer

--- a/examples/cs-oidc-issuer/MyStack.cs
+++ b/examples/cs-oidc-issuer/MyStack.cs
@@ -39,7 +39,7 @@ class MyStack : Pulumi.Stack
           Name = "github_issuer",
           Url = "https://token.actions.githubusercontent.com",
           Thumbprints = {
-            "b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"
+            "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"
           },
           Policies = {
             new AuthPolicyDefinitionArgs

--- a/examples/ts-oidc-issuer/index.ts
+++ b/examples/ts-oidc-issuer/index.ts
@@ -29,7 +29,7 @@ const githubOidcIssuer = new service.OidcIssuer("github_issuer", {
   name: "github_issuer",
   url: "https://token.actions.githubusercontent.com",
   thumbprints: [
-    "b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486"
+    "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"
   ],
   policies: [
     {

--- a/examples/yaml-oidc-issuer/Pulumi.yaml
+++ b/examples/yaml-oidc-issuer/Pulumi.yaml
@@ -27,7 +27,7 @@ resources:
       name: github_issuer
       url: https://token.actions.githubusercontent.com
       thumbprints:
-        - b41ae0832808ebc94951437bf7e92b93ccb6479364daf894d46d6001bee7a486
+        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
       policies:
         - decision: deny
           rules:


### PR DESCRIPTION
GitHub rotated the TLS certificate on `token.actions.githubusercontent.com`, so the thumbprint hardcoded in the OIDC Issuer examples no longer matches what the Pulumi Cloud API calculates. Every `run-acceptance-tests` run has been failing since ~2026-07-12 (independent of PR contents, e.g. [this run](https://github.com/pulumi/pulumi-pulumiservice/actions/runs/29478838610) on an unrelated workflow-update PR) on `TestDotnetOidcIssuerExamples`, `TestYamlOidcIssuerExample`, and `TestNodejsOidcIssuerExample`:

```
400 API error: Bad Request: Calculated thumbprint 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5 does not match any of the provided. Make sure it is properly generated (SHA256).
```

This replaces the stale thumbprint (`b41ae083…`) with the current one everywhere it appears in `examples/`. The new value matches the live certificate:

```
$ openssl s_client -connect token.actions.githubusercontent.com:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
sha256 fingerprint=39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
```

The `api.pulumi.com` thumbprint (`57d3e89f…`) is still current and is left unchanged.