### PR TITLE
Compute OIDC issuer thumbprints dynamically in tests

### DIFF
--- a/examples/api/oidc-issuer/csharp/Program.cs
+++ b/examples/api/oidc-issuer/csharp/Program.cs
@@ -8,13 +8,18 @@ return await Deployment.RunAsync(() =>
     var organizationName = config.Get("organizationName") ?? "service-provider-test-org";
     var issuerSuffix = config.Get("issuerSuffix") ?? "dev";
     var maxExpiration = config.GetInt32("maxExpiration") ?? 3600;
+    // Thumbprints must match the certificate the issuer currently serves, so they
+    // have no static default. Compute one with:
+    //   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+    var pulumiThumbprint = config.Require("pulumiThumbprint");
+    var githubThumbprint = config.Require("githubThumbprint");
 
     var pulumiIssuer = new Ps.Api.Auth.OidcIssuer("pulumiIssuer", new()
     {
         OrgName = organizationName,
         Name = $"pulumi_issuer_{issuerSuffix}",
         Url = "https://api.pulumi.com/oidc",
-        Thumbprints = new[] { "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da" },
+        Thumbprints = new[] { pulumiThumbprint },
     });
 
     var githubIssuer = new Ps.Api.Auth.OidcIssuer("githubIssuer", new()
@@ -22,7 +27,7 @@ return await Deployment.RunAsync(() =>
         OrgName = organizationName,
         Name = $"github_issuer_{issuerSuffix}",
         Url = "https://token.actions.githubusercontent.com",
-        Thumbprints = new[] { "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5" },
+        Thumbprints = new[] { githubThumbprint },
         MaxExpiration = maxExpiration,
     });
 

--- a/examples/api/oidc-issuer/go/main.go
+++ b/examples/api/oidc-issuer/go/main.go
@@ -21,12 +21,17 @@ func main() {
 		if err != nil {
 			maxExpiration = 3600
 		}
+		// Thumbprints must match the certificate the issuer currently serves, so
+		// they have no static default. Compute one with:
+		//   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+		pulumiThumbprint := cfg.Require("pulumiThumbprint")
+		githubThumbprint := cfg.Require("githubThumbprint")
 
 		pulumiIssuer, err := auth.NewOidcIssuer(ctx, "pulumiIssuer", &auth.OidcIssuerArgs{
 			OrgName:     pulumi.String(organizationName),
 			Name:        pulumi.String("pulumi_issuer_" + issuerSuffix),
 			Url:         pulumi.String("https://api.pulumi.com/oidc"),
-			Thumbprints: pulumi.StringArray{pulumi.String("57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da")},
+			Thumbprints: pulumi.StringArray{pulumi.String(pulumiThumbprint)},
 		})
 		if err != nil {
 			return err
@@ -36,7 +41,7 @@ func main() {
 			OrgName:       pulumi.String(organizationName),
 			Name:          pulumi.String("github_issuer_" + issuerSuffix),
 			Url:           pulumi.String("https://token.actions.githubusercontent.com"),
-			Thumbprints:   pulumi.StringArray{pulumi.String("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5")},
+			Thumbprints:   pulumi.StringArray{pulumi.String(githubThumbprint)},
 			MaxExpiration: pulumi.Int(maxExpiration),
 		})
 		if err != nil {

--- a/examples/api/oidc-issuer/java/src/main/java/generated_program/App.java
+++ b/examples/api/oidc-issuer/java/src/main/java/generated_program/App.java
@@ -13,13 +13,18 @@ public class App {
             var organizationName = config.get("organizationName").orElse("service-provider-test-org");
             var issuerSuffix = config.get("issuerSuffix").orElse("dev");
             var maxExpiration = config.getInteger("maxExpiration").orElse(3600);
+            // Thumbprints must match the certificate the issuer currently serves, so
+            // they have no static default. Compute one with:
+            //   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+            var pulumiThumbprint = config.require("pulumiThumbprint");
+            var githubThumbprint = config.require("githubThumbprint");
 
             var pulumiIssuer = new OidcIssuer("pulumiIssuer",
                 OidcIssuerArgs.builder()
                     .orgName(organizationName)
                     .name("pulumi_issuer_" + issuerSuffix)
                     .url("https://api.pulumi.com/oidc")
-                    .thumbprints(List.of("57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"))
+                    .thumbprints(List.of(pulumiThumbprint))
                     .build());
 
             var githubIssuer = new OidcIssuer("githubIssuer",
@@ -27,7 +32,7 @@ public class App {
                     .orgName(organizationName)
                     .name("github_issuer_" + issuerSuffix)
                     .url("https://token.actions.githubusercontent.com")
-                    .thumbprints(List.of("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"))
+                    .thumbprints(List.of(githubThumbprint))
                     .maxExpiration(maxExpiration)
                     .build());
 

--- a/examples/api/oidc-issuer/python/__main__.py
+++ b/examples/api/oidc-issuer/python/__main__.py
@@ -5,13 +5,18 @@ config = pulumi.Config()
 organization_name = config.get("organizationName") or "service-provider-test-org"
 issuer_suffix = config.get("issuerSuffix") or "dev"
 max_expiration = config.get_int("maxExpiration") or 3600
+# Thumbprints must match the certificate the issuer currently serves, so they
+# have no static default. Compute one with:
+#   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+pulumi_thumbprint = config.require("pulumiThumbprint")
+github_thumbprint = config.require("githubThumbprint")
 
 pulumi_issuer = ps_api.auth.OidcIssuer(
     "pulumiIssuer",
     org_name=organization_name,
     name=f"pulumi_issuer_{issuer_suffix}",
     url="https://api.pulumi.com/oidc",
-    thumbprints=["57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"],
+    thumbprints=[pulumi_thumbprint],
 )
 
 github_issuer = ps_api.auth.OidcIssuer(
@@ -19,7 +24,7 @@ github_issuer = ps_api.auth.OidcIssuer(
     org_name=organization_name,
     name=f"github_issuer_{issuer_suffix}",
     url="https://token.actions.githubusercontent.com",
-    thumbprints=["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
+    thumbprints=[github_thumbprint],
     max_expiration=max_expiration,
 )
 

--- a/examples/api/oidc-issuer/typescript/index.ts
+++ b/examples/api/oidc-issuer/typescript/index.ts
@@ -5,19 +5,24 @@ const config = new pulumi.Config();
 const organizationName = config.get("organizationName") ?? "service-provider-test-org";
 const issuerSuffix = config.get("issuerSuffix") ?? "dev";
 const maxExpiration = config.getNumber("maxExpiration") ?? 3600;
+// Thumbprints must match the certificate the issuer currently serves, so they
+// have no static default. Compute one with:
+//   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+const pulumiThumbprint = config.require("pulumiThumbprint");
+const githubThumbprint = config.require("githubThumbprint");
 
 const pulumiIssuer = new ps.api.auth.OidcIssuer("pulumiIssuer", {
     orgName: organizationName,
     name: `pulumi_issuer_${issuerSuffix}`,
     url: "https://api.pulumi.com/oidc",
-    thumbprints: ["57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"],
+    thumbprints: [pulumiThumbprint],
 });
 
 const githubIssuer = new ps.api.auth.OidcIssuer("githubIssuer", {
     orgName: organizationName,
     name: `github_issuer_${issuerSuffix}`,
     url: "https://token.actions.githubusercontent.com",
-    thumbprints: ["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
+    thumbprints: [githubThumbprint],
     maxExpiration: maxExpiration,
 });
 

--- a/examples/api/oidc-issuer/yaml/Main.yaml
+++ b/examples/api/oidc-issuer/yaml/Main.yaml
@@ -6,7 +6,7 @@ resources:
       name: pulumi_issuer_${issuerSuffix}
       url: https://api.pulumi.com/oidc
       thumbprints:
-        - 57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da
+        - ${pulumiThumbprint}
   githubIssuer:
     type: pulumiservice:api/auth:OidcIssuer
     properties:
@@ -14,7 +14,7 @@ resources:
       name: github_issuer_${issuerSuffix}
       url: https://token.actions.githubusercontent.com
       thumbprints:
-        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
+        - ${githubThumbprint}
       maxExpiration: ${maxExpiration}
 outputs:
   pulumiIssuerName: ${pulumiIssuer.name}

--- a/examples/api/oidc-issuer/yaml/Pulumi.yaml
+++ b/examples/api/oidc-issuer/yaml/Pulumi.yaml
@@ -10,3 +10,10 @@ config:
   maxExpiration:
     type: integer
     default: 3600
+  # Thumbprints must match the certificate the issuer currently serves, so
+  # they have no static default. Compute one with:
+  #   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+  pulumiThumbprint:
+    type: string
+  githubThumbprint:
+    type: string

--- a/examples/api/platform-bootstrap/csharp/Program.cs
+++ b/examples/api/platform-bootstrap/csharp/Program.cs
@@ -21,7 +21,6 @@ return await Deployment.RunAsync(() =>
         OrgName = organizationName,
         Name = $"github_issuer_{suffix}",
         Url = "https://token.actions.githubusercontent.com",
-        Thumbprints = new[] { "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5" },
         MaxExpiration = 3600,
     });
     new Ps.Api.Auth.OidcIssuer("pulumiSelfIssuer", new()
@@ -29,7 +28,6 @@ return await Deployment.RunAsync(() =>
         OrgName = organizationName,
         Name = $"pulumi_issuer_{suffix}",
         Url = "https://api.pulumi.com/oidc",
-        Thumbprints = new[] { "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da" },
     });
 
     var platformTeam = new Ps.Api.Teams.Team("platformTeam", new()

--- a/examples/api/platform-bootstrap/go/main.go
+++ b/examples/api/platform-bootstrap/go/main.go
@@ -47,16 +47,14 @@ func main() {
 			OrgName:       pulumi.String(organizationName),
 			Name:          pulumi.String("github_issuer_" + suffix),
 			Url:           pulumi.String("https://token.actions.githubusercontent.com"),
-			Thumbprints:   pulumi.StringArray{pulumi.String("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5")},
 			MaxExpiration: pulumi.Int(3600),
 		}); err != nil {
 			return err
 		}
 		if _, err := auth.NewOidcIssuer(ctx, "pulumiSelfIssuer", &auth.OidcIssuerArgs{
-			OrgName:     pulumi.String(organizationName),
-			Name:        pulumi.String("pulumi_issuer_" + suffix),
-			Url:         pulumi.String("https://api.pulumi.com/oidc"),
-			Thumbprints: pulumi.StringArray{pulumi.String("57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da")},
+			OrgName: pulumi.String(organizationName),
+			Name:    pulumi.String("pulumi_issuer_" + suffix),
+			Url:     pulumi.String("https://api.pulumi.com/oidc"),
 		}); err != nil {
 			return err
 		}

--- a/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
+++ b/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
@@ -49,7 +49,6 @@ public class App {
                     .orgName(organizationName)
                     .name("github_issuer_" + suffix)
                     .url("https://token.actions.githubusercontent.com")
-                    .thumbprints(List.of("39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"))
                     .maxExpiration(3600)
                     .build());
             new OidcIssuer("pulumiSelfIssuer",
@@ -57,7 +56,6 @@ public class App {
                     .orgName(organizationName)
                     .name("pulumi_issuer_" + suffix)
                     .url("https://api.pulumi.com/oidc")
-                    .thumbprints(List.of("57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"))
                     .build());
 
             var platformTeam = new Team("platformTeam",

--- a/examples/api/platform-bootstrap/python/__main__.py
+++ b/examples/api/platform-bootstrap/python/__main__.py
@@ -19,7 +19,6 @@ ps_api.auth.OidcIssuer(
     org_name=organization_name,
     name=f"github_issuer_{suffix}",
     url="https://token.actions.githubusercontent.com",
-    thumbprints=["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     max_expiration=3600,
 )
 ps_api.auth.OidcIssuer(
@@ -27,7 +26,6 @@ ps_api.auth.OidcIssuer(
     org_name=organization_name,
     name=f"pulumi_issuer_{suffix}",
     url="https://api.pulumi.com/oidc",
-    thumbprints=["57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"],
 )
 
 platform_team = ps_api.teams.Team(

--- a/examples/api/platform-bootstrap/typescript/index.ts
+++ b/examples/api/platform-bootstrap/typescript/index.ts
@@ -18,14 +18,12 @@ new ps.api.auth.OidcIssuer("githubIssuer", {
     orgName: organizationName,
     name: `github_issuer_${suffix}`,
     url: "https://token.actions.githubusercontent.com",
-    thumbprints: ["39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"],
     maxExpiration: 3600,
 });
 new ps.api.auth.OidcIssuer("pulumiSelfIssuer", {
     orgName: organizationName,
     name: `pulumi_issuer_${suffix}`,
     url: "https://api.pulumi.com/oidc",
-    thumbprints: ["57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"],
 });
 
 // 3. Platform team + a stack-readonly role.

--- a/examples/api/platform-bootstrap/yaml/Main.yaml
+++ b/examples/api/platform-bootstrap/yaml/Main.yaml
@@ -50,8 +50,6 @@ resources:
       orgName: ${organizationName}
       name: github_issuer_${suffix}
       url: https://token.actions.githubusercontent.com
-      thumbprints:
-        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
       maxExpiration: 3600
   pulumiSelfIssuer:
     type: pulumiservice:api/auth:OidcIssuer
@@ -59,8 +57,6 @@ resources:
       orgName: ${organizationName}
       name: pulumi_issuer_${suffix}
       url: https://api.pulumi.com/oidc
-      thumbprints:
-        - 57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da
 
   # --- 4. Platform team + a stack-readonly role ----------------------------
   platformTeam:

--- a/examples/cs-oidc-issuer/MyStack.cs
+++ b/examples/cs-oidc-issuer/MyStack.cs
@@ -9,15 +9,20 @@ class MyStack : Pulumi.Stack
     {
         var serviceOrg = "service-provider-test-org3";
 
+        // Thumbprints must match the certificate the issuer currently serves, so they
+        // are supplied via config rather than hardcoded. Compute one with:
+        //   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+        var config = new Pulumi.Config();
+        var pulumiThumbprint = config.Require("pulumiThumbprint");
+        var githubThumbprint = config.Require("githubThumbprint");
+
         // A Pulumi OIDC Issuer with a basic policy
         var pulumiOidcIssuer = new OidcIssuer("pulumi_issuer", new OidcIssuerArgs
         {
             Organization = serviceOrg,
             Name = "pulumi_issuer",
             Url = "https://api.pulumi.com/oidc",
-            Thumbprints = {
-              "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"
-            },
+            Thumbprints = { pulumiThumbprint },
             Policies = {
               new AuthPolicyDefinitionArgs
               {
@@ -38,9 +43,7 @@ class MyStack : Pulumi.Stack
           Organization = serviceOrg,
           Name = "github_issuer",
           Url = "https://token.actions.githubusercontent.com",
-          Thumbprints = {
-            "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"
-          },
+          Thumbprints = { githubThumbprint },
           Policies = {
             new AuthPolicyDefinitionArgs
             {

--- a/examples/examples_api_test.go
+++ b/examples/examples_api_test.go
@@ -854,6 +854,8 @@ func oidcIssuerConfig() map[string]string {
 		"organizationName": ServiceProviderTestOrg,
 		"issuerSuffix":     generateRandomFiveDigits(),
 		"maxExpiration":    "3600",
+		"pulumiThumbprint": tlsThumbprint("api.pulumi.com"),
+		"githubThumbprint": tlsThumbprint("token.actions.githubusercontent.com"),
 	}
 }
 

--- a/examples/examples_dotnet_test.go
+++ b/examples/examples_dotnet_test.go
@@ -49,6 +49,10 @@ func TestDotnetEnvironmentsExamples(t *testing.T) {
 func TestDotnetOidcIssuerExamples(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: path.Join(getCwd(t), "cs-oidc-issuer"),
+		Config: map[string]string{
+			"pulumiThumbprint": tlsThumbprint("api.pulumi.com"),
+			"githubThumbprint": tlsThumbprint("token.actions.githubusercontent.com"),
+		},
 		Dependencies: []string{
 			"Pulumi.PulumiService",
 		},

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -154,6 +154,8 @@ func TestNodejsOidcIssuerExample(t *testing.T) {
 		opttest.YarnLink("@pulumi/pulumiservice"),
 		opttest.StackName(randomStackName()),
 	)
+	test.SetConfig(t, "pulumiThumbprint", tlsThumbprint("api.pulumi.com"))
+	test.SetConfig(t, "githubThumbprint", tlsThumbprint("token.actions.githubusercontent.com"))
 	runPulumiTest(t, test)
 }
 

--- a/examples/examples_utils_test.go
+++ b/examples/examples_utils_test.go
@@ -2,6 +2,8 @@ package examples
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -34,6 +36,22 @@ func generateRandomFiveDigits() string {
 // exists" on init.
 func randomStackName() string {
 	return "test-" + uuid.NewString()[:8]
+}
+
+// tlsThumbprint returns the SHA256 fingerprint (hex) of the TLS certificate
+// currently served by host — the value Pulumi Cloud calculates when an OIDC
+// issuer is registered. Issuers rotate certificates (GitHub serves 90-day
+// Let's Encrypt certs as of July 2026), so tests compute thumbprints at
+// runtime instead of pinning literals that go stale on every rotation.
+// Panics on failure so it is usable from apiCase Config funcs, which don't
+// receive a *testing.T.
+func tlsThumbprint(host string) string {
+	conn, err := tls.Dial("tcp", host+":443", nil)
+	if err != nil {
+		panic(fmt.Sprintf("computing TLS thumbprint for %s: %v", host, err))
+	}
+	defer conn.Close()
+	return fmt.Sprintf("%x", sha256.Sum256(conn.ConnectionState().PeerCertificates[0].Raw))
 }
 
 // getOrgName returns the organization name from PULUMI_TEST_OWNER env var,

--- a/examples/examples_yaml_test.go
+++ b/examples/examples_yaml_test.go
@@ -462,6 +462,10 @@ func TestYamlOidcIssuerExample(t *testing.T) {
 	cwd := getCwd(t)
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: path.Join(cwd, ".", "yaml-oidc-issuer"),
+		Config: map[string]string{
+			"pulumiThumbprint": tlsThumbprint("api.pulumi.com"),
+			"githubThumbprint": tlsThumbprint("token.actions.githubusercontent.com"),
+		},
 	})
 }
 

--- a/examples/ts-oidc-issuer/index.ts
+++ b/examples/ts-oidc-issuer/index.ts
@@ -1,15 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
 import * as service from "@pulumi/pulumiservice";
 
 const serviceOrg = "service-provider-test-org2";
+
+// Thumbprints must match the certificate the issuer currently serves, so they
+// are supplied via config rather than hardcoded. Compute one with:
+//   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+const config = new pulumi.Config();
+const pulumiThumbprint = config.require("pulumiThumbprint");
+const githubThumbprint = config.require("githubThumbprint");
 
 // A Pulumi OIDC Issuer with a basic policy
 const pulumiOidcIssuer = new service.OidcIssuer("pulumi_issuer", {
   organization: serviceOrg,
   name: "pulumi_issuer",
   url: "https://api.pulumi.com/oidc",
-  thumbprints: [
-    "57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da"
-  ],
+  thumbprints: [pulumiThumbprint],
   policies: [
     {
       decision: "allow",
@@ -28,9 +34,7 @@ const githubOidcIssuer = new service.OidcIssuer("github_issuer", {
   organization: serviceOrg,
   name: "github_issuer",
   url: "https://token.actions.githubusercontent.com",
-  thumbprints: [
-    "39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5"
-  ],
+  thumbprints: [githubThumbprint],
   policies: [
     {
       decision: "deny",

--- a/examples/yaml-oidc-issuer/Pulumi.yaml
+++ b/examples/yaml-oidc-issuer/Pulumi.yaml
@@ -2,6 +2,15 @@ name: yaml-oidc-issuer
 runtime: yaml
 description: A minimal example of provisioning OIDC Issuer via Pulumi YAML
 
+# Thumbprints must match the certificate the issuer currently serves, so they
+# are supplied via config rather than hardcoded. Compute one with:
+#   openssl s_client -connect <issuer-host>:443 </dev/null | openssl x509 -fingerprint -sha256 -noout
+config:
+  pulumiThumbprint:
+    type: string
+  githubThumbprint:
+    type: string
+
 resources:
 # A Pulumi OIDC Issuer with a basic policy
   pulumi_issuer:
@@ -11,7 +20,7 @@ resources:
       name: pulumi_issuer
       url: https://api.pulumi.com/oidc
       thumbprints:
-        - 57d3e89f6b25dde3c174dc558e2b2623306a9d81f88a12e8ae7090a86c12f1da
+        - ${pulumiThumbprint}
       policies:
         - decision: allow
           rules:
@@ -27,7 +36,7 @@ resources:
       name: github_issuer
       url: https://token.actions.githubusercontent.com
       thumbprints:
-        - 39517789ff0132a9212bafea4dc37401eae58b1bfac9756109d14301c90a6ab5
+        - ${githubThumbprint}
       policies:
         - decision: deny
           rules:


### PR DESCRIPTION
Follow-up to #989. Pinned TLS thumbprints in the OIDC Issuer examples break on every certificate rotation, and GitHub now serves 90-day Let's Encrypt certificates on `token.actions.githubusercontent.com` — so #989's refreshed value will go stale again around September 2026, and every ~2 months after.

This makes every remaining thumbprint use dynamic:

- **Tested examples** (`yaml-oidc-issuer`, `ts-oidc-issuer`, `cs-oidc-issuer`, `api/oidc-issuer` in all six languages) now take `pulumiThumbprint`/`githubThumbprint` via config. A new `tlsThumbprint` test helper computes the current values at test time — the same SHA256-of-served-certificate calculation Pulumi Cloud performs at issuer registration — and injects them through each harness (`ProgramTestOptions.Config`, `pulumitest.SetConfig`, `oidcIssuerConfig`). The examples document the `openssl` one-liner for computing a value by hand.
- **`api/platform-bootstrap`** (CI-skipped composite, no test to inject config): thumbprints removed. The field is optional — Pulumi Cloud computes the thumbprint from the certificate the issuer serves when it's omitted (the `pulumi` org's own production GitHub issuer stores none).
- Drive-by: `cs-oidc-issuer` needed `new Pulumi.Config()` — bare `Config` is ambiguous with `Pulumi.PulumiService.Config`.

Verified locally: `go vet` across all build tags; `pulumi preview` of `yaml-oidc-issuer` with injected config (3 resources, clean); the `tlsThumbprint` helper exercised live via the yaml test path; `dotnet build` of `cs-oidc-issuer`; `tsc --noEmit` of both TS examples against the local SDK; `go build` of `api/oidc-issuer/go`; `py_compile` of both Python examples. (`api/platform-bootstrap/go` doesn't compile on `main` — pre-existing `esc.Environment` field drift, untouched here.) Full integration tests need the staging org, so CI is the final check.

No CHANGELOG entry: test/example-only change.