### PR TITLE
Fix esc.Environment output drift in platform-bootstrap, re-enable preview

### DIFF
--- a/examples/api/platform-bootstrap/csharp/Program.cs
+++ b/examples/api/platform-bootstrap/csharp/Program.cs
@@ -83,20 +83,21 @@ return await Deployment.RunAsync(() =>
         SourceURL = "https://github.com/pulumi/examples",
     });
 
+    var sharedEnvName = $"credentials-{suffix}";
     var sharedCredentials = new Ps.Api.Esc.Environment("sharedCredentials", new()
     {
         OrgName = organizationName,
         Project = "shared",
-        Name = $"credentials-{suffix}",
+        Name = sharedEnvName,
     });
     new Ps.Api.Esc.EnvironmentTag("stableTag", new()
     {
         OrgName = organizationName,
-        ProjectName = sharedCredentials.Project,
-        EnvName = sharedCredentials.Name,
+        ProjectName = "shared",
+        EnvName = sharedEnvName,
         Name = "stable",
         Value = "1",
-    });
+    }, new CustomResourceOptions { DependsOn = { sharedCredentials } });
 
     var stagingStack = new Ps.Api.Stacks.Stack("stagingStack", new()
     {
@@ -111,7 +112,7 @@ return await Deployment.RunAsync(() =>
         StackName = "prod",
     });
 
-    var sharedEnvRef = Output.Format($"{sharedCredentials.Project}/{sharedCredentials.Name}");
+    var sharedEnvRef = $"shared/{sharedEnvName}";
 
     new Ps.Api.Stacks.Config("stagingConfig", new()
     {
@@ -119,14 +120,14 @@ return await Deployment.RunAsync(() =>
         ProjectName = stagingStack.ProjectName,
         StackName = stagingStack.StackName,
         Environment = sharedEnvRef,
-    });
+    }, new CustomResourceOptions { DependsOn = { sharedCredentials } });
     new Ps.Api.Stacks.Config("prodConfig", new()
     {
         OrgName = organizationName,
         ProjectName = prodStack.ProjectName,
         StackName = prodStack.StackName,
         Environment = sharedEnvRef,
-    });
+    }, new CustomResourceOptions { DependsOn = { sharedCredentials } });
 
     foreach (var (k, v) in new[] {
         ("owner", "platform-team"), ("tier", "gold"), ("cost-center", "platform"),
@@ -194,7 +195,7 @@ return await Deployment.RunAsync(() =>
         Enabled = prodApprovalEnabled,
         Rule = gateRule,
         Target = gateTarget,
-    });
+    }, new CustomResourceOptions { DependsOn = { sharedCredentials } });
 
     var deployRequest = ImmutableDictionary<string, object>.Empty
         .Add("operation", "update")

--- a/examples/api/platform-bootstrap/go/main.go
+++ b/examples/api/platform-bootstrap/go/main.go
@@ -122,21 +122,22 @@ func main() {
 			return err
 		}
 
+		sharedEnvName := "credentials-" + suffix
 		sharedCredentials, err := esc.NewEnvironment(ctx, "sharedCredentials", &esc.EnvironmentArgs{
 			OrgName: pulumi.String(organizationName),
 			Project: pulumi.String("shared"),
-			Name:    pulumi.String("credentials-" + suffix),
+			Name:    pulumi.String(sharedEnvName),
 		})
 		if err != nil {
 			return err
 		}
 		if _, err := esc.NewEnvironmentTag(ctx, "stableTag", &esc.EnvironmentTagArgs{
 			OrgName:     pulumi.String(organizationName),
-			ProjectName: sharedCredentials.Project,
-			EnvName:     sharedCredentials.Name,
+			ProjectName: pulumi.String("shared"),
+			EnvName:     pulumi.String(sharedEnvName),
 			Name:        pulumi.String("stable"),
 			Value:       pulumi.String("1"),
-		}); err != nil {
+		}, pulumi.DependsOn([]pulumi.Resource{sharedCredentials})); err != nil {
 			return err
 		}
 
@@ -157,14 +158,14 @@ func main() {
 			return err
 		}
 
-		sharedEnvRef := pulumi.Sprintf("%s/%s", sharedCredentials.Project, sharedCredentials.Name)
+		sharedEnvRef := pulumi.String("shared/" + sharedEnvName)
 
 		if _, err := stacks.NewConfig(ctx, "stagingConfig", &stacks.ConfigArgs{
 			OrgName:     pulumi.String(organizationName),
 			ProjectName: stagingStack.ProjectName,
 			StackName:   stagingStack.StackName,
 			Environment: sharedEnvRef,
-		}); err != nil {
+		}, pulumi.DependsOn([]pulumi.Resource{sharedCredentials})); err != nil {
 			return err
 		}
 		if _, err := stacks.NewConfig(ctx, "prodConfig", &stacks.ConfigArgs{
@@ -172,7 +173,7 @@ func main() {
 			ProjectName: prodStack.ProjectName,
 			StackName:   prodStack.StackName,
 			Environment: sharedEnvRef,
-		}); err != nil {
+		}, pulumi.DependsOn([]pulumi.Resource{sharedCredentials})); err != nil {
 			return err
 		}
 
@@ -248,7 +249,7 @@ func main() {
 				"actionTypes":   pulumi.StringArray{pulumi.String("update")},
 				"qualifiedName": sharedEnvRef,
 			},
-		}); err != nil {
+		}, pulumi.DependsOn([]pulumi.Resource{sharedCredentials})); err != nil {
 			return err
 		}
 

--- a/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
+++ b/examples/api/platform-bootstrap/java/src/main/java/generated_program/App.java
@@ -110,20 +110,22 @@ public class App {
                     .sourceURL("https://github.com/pulumi/examples")
                     .build());
 
+            var sharedEnvName = "credentials-" + suffix;
             var sharedCredentials = new Environment("sharedCredentials",
                 EnvironmentArgs.builder()
                     .orgName(organizationName)
                     .project("shared")
-                    .name("credentials-" + suffix)
+                    .name(sharedEnvName)
                     .build());
             new EnvironmentTag("stableTag",
                 EnvironmentTagArgs.builder()
                     .orgName(organizationName)
-                    .projectName(sharedCredentials.project())
-                    .envName(sharedCredentials.name())
+                    .projectName("shared")
+                    .envName(sharedEnvName)
                     .name("stable")
                     .value("1")
-                    .build());
+                    .build(),
+                CustomResourceOptions.builder().dependsOn(sharedCredentials).build());
 
             var stagingStack = new Stack("stagingStack",
                 StackArgs.builder()
@@ -138,8 +140,7 @@ public class App {
                     .stackName("prod")
                     .build());
 
-            Output<String> sharedEnvRef = Output.format("%s/%s",
-                sharedCredentials.project(), sharedCredentials.name());
+            String sharedEnvRef = "shared/" + sharedEnvName;
 
             new Config("stagingConfig",
                 ConfigArgs.builder()
@@ -147,14 +148,16 @@ public class App {
                     .projectName(stagingStack.projectName())
                     .stackName(stagingStack.stackName())
                     .environment(sharedEnvRef)
-                    .build());
+                    .build(),
+                CustomResourceOptions.builder().dependsOn(sharedCredentials).build());
             new Config("prodConfig",
                 ConfigArgs.builder()
                     .orgName(organizationName)
                     .projectName(prodStack.projectName())
                     .stackName(prodStack.stackName())
                     .environment(sharedEnvRef)
-                    .build());
+                    .build(),
+                CustomResourceOptions.builder().dependsOn(sharedCredentials).build());
 
             for (var entry : Map.of("owner", "platform-team", "tier", "gold", "cost-center", "platform").entrySet()) {
                 new Tag("prodTag-" + entry.getKey(),
@@ -210,7 +213,8 @@ public class App {
                         "entityType", "environment",
                         "actionTypes", List.of("update"),
                         "qualifiedName", sharedEnvRef))
-                    .build());
+                    .build(),
+                CustomResourceOptions.builder().dependsOn(sharedCredentials).build());
 
             new ScheduledDeployment("prodNightlyDeploy",
                 ScheduledDeploymentArgs.builder()
@@ -243,7 +247,7 @@ public class App {
             ctx.export("ciTokenId", ciToken.tokenId());
             ctx.export("agentPoolName", runnersPool.name());
             ctx.export("templatesName", templates.name());
-            ctx.export("sharedCredsEnv", sharedEnvRef);
+            ctx.export("sharedCredsEnv", Output.of(sharedEnvRef));
             ctx.export("prodStackId", prodStack.id());
         });
     }

--- a/examples/api/platform-bootstrap/python/__main__.py
+++ b/examples/api/platform-bootstrap/python/__main__.py
@@ -90,10 +90,11 @@ shared_credentials = ps_api.esc.Environment(
 ps_api.esc.EnvironmentTag(
     "stableTag",
     org_name=organization_name,
-    project_name=shared_credentials.project,
-    env_name=shared_credentials.name,
+    project_name="shared",
+    env_name=f"credentials-{suffix}",
     name="stable",
     value="1",
+    opts=pulumi.ResourceOptions(depends_on=[shared_credentials]),
 )
 
 staging_stack = ps_api.stacks.Stack(
@@ -109,7 +110,7 @@ prod_stack = ps_api.stacks.Stack(
     stack_name="prod",
 )
 
-shared_env_ref = pulumi.Output.concat(shared_credentials.project, "/", shared_credentials.name)
+shared_env_ref = f"shared/credentials-{suffix}"
 
 ps_api.stacks.Config(
     "stagingConfig",
@@ -117,6 +118,7 @@ ps_api.stacks.Config(
     project_name=staging_stack.project_name,
     stack_name=staging_stack.stack_name,
     environment=shared_env_ref,
+    opts=pulumi.ResourceOptions(depends_on=[shared_credentials]),
 )
 ps_api.stacks.Config(
     "prodConfig",
@@ -124,6 +126,7 @@ ps_api.stacks.Config(
     project_name=prod_stack.project_name,
     stack_name=prod_stack.stack_name,
     environment=shared_env_ref,
+    opts=pulumi.ResourceOptions(depends_on=[shared_credentials]),
 )
 
 for k, v in [("owner", "platform-team"), ("tier", "gold"), ("cost-center", "platform")]:
@@ -182,6 +185,7 @@ ps_api.Gate(
         "actionTypes": ["update"],
         "qualifiedName": shared_env_ref,
     },
+    opts=pulumi.ResourceOptions(depends_on=[shared_credentials]),
 )
 
 ps_api.deployments.ScheduledDeployment(

--- a/examples/api/platform-bootstrap/typescript/index.ts
+++ b/examples/api/platform-bootstrap/typescript/index.ts
@@ -77,18 +77,19 @@ const templates = new ps.api.OrgTemplateCollection("templates", {
 });
 
 // 7. Shared ESC credentials env + a "stable" tag on it.
+const sharedEnvName = `credentials-${suffix}`;
 const sharedCredentials = new ps.api.esc.Environment("sharedCredentials", {
     orgName: organizationName,
     project: "shared",
-    name: `credentials-${suffix}`,
+    name: sharedEnvName,
 });
 new ps.api.esc.EnvironmentTag("stableTag", {
     orgName: organizationName,
-    projectName: sharedCredentials.project,
-    envName: sharedCredentials.name,
+    projectName: "shared",
+    envName: sharedEnvName,
     name: "stable",
     value: "1",
-});
+}, { dependsOn: sharedCredentials });
 
 // 8. Two stacks (staging + prod).
 const stagingStack = new ps.api.stacks.Stack("stagingStack", {
@@ -103,19 +104,19 @@ const prodStack = new ps.api.stacks.Stack("prodStack", {
 });
 
 // 9. StackConfig: bind each stack to the shared ESC env.
-const sharedEnvRef = pulumi.interpolate`${sharedCredentials.project}/${sharedCredentials.name}`;
+const sharedEnvRef = `shared/${sharedEnvName}`;
 new ps.api.stacks.Config("stagingConfig", {
     orgName: organizationName,
     projectName: stagingStack.projectName,
     stackName: stagingStack.stackName,
     environment: sharedEnvRef,
-});
+}, { dependsOn: sharedCredentials });
 new ps.api.stacks.Config("prodConfig", {
     orgName: organizationName,
     projectName: prodStack.projectName,
     stackName: prodStack.stackName,
     environment: sharedEnvRef,
-});
+}, { dependsOn: sharedCredentials });
 
 // 10. Tags on prod.
 for (const [k, v] of Object.entries({
@@ -177,7 +178,7 @@ new ps.api.Gate("credsApprovalGate", {
         actionTypes: ["update"],
         qualifiedName: sharedEnvRef,
     },
-});
+}, { dependsOn: sharedCredentials });
 
 // 14. Nightly redeploy of prod (depends on prodDeploySettings).
 new ps.api.deployments.ScheduledDeployment("prodNightlyDeploy", {

--- a/examples/api/platform-bootstrap/yaml/Main.yaml
+++ b/examples/api/platform-bootstrap/yaml/Main.yaml
@@ -129,10 +129,13 @@ resources:
     type: pulumiservice:api/esc:EnvironmentTag
     properties:
       orgName: ${organizationName}
-      projectName: ${sharedCredentials.project}
-      envName: ${sharedCredentials.name}
+      projectName: shared
+      envName: credentials-${suffix}
       name: stable
       value: "1"
+    options:
+      dependsOn:
+        - ${sharedCredentials}
 
   # --- 10. Stacks: staging + prod ------------------------------------------
   stagingStack:
@@ -155,14 +158,20 @@ resources:
       orgName: ${organizationName}
       projectName: ${stagingStack.projectName}
       stackName: ${stagingStack.stackName}
-      environment: ${sharedCredentials.project}/${sharedCredentials.name}
+      environment: shared/credentials-${suffix}
+    options:
+      dependsOn:
+        - ${sharedCredentials}
   prodConfig:
     type: pulumiservice:api/stacks:Config
     properties:
       orgName: ${organizationName}
       projectName: ${prodStack.projectName}
       stackName: ${prodStack.stackName}
-      environment: ${sharedCredentials.project}/${sharedCredentials.name}
+      environment: shared/credentials-${suffix}
+    options:
+      dependsOn:
+        - ${sharedCredentials}
 
   # --- 12. Tags on prod ----------------------------------------------------
   prodOwnerTag:
@@ -242,7 +251,10 @@ resources:
         entityType: environment
         actionTypes:
           - update
-        qualifiedName: ${sharedCredentials.project}/${sharedCredentials.name}
+        qualifiedName: shared/credentials-${suffix}
+    options:
+      dependsOn:
+        - ${sharedCredentials}
 
   # --- 16. ScheduledDeployment: nightly redeploy of prod -------------------
   prodNightlyDeploy:
@@ -291,5 +303,5 @@ outputs:
   ciTokenId: ${ciToken.tokenId}
   agentPoolName: ${runnersPool.name}
   templatesName: ${templates.name}
-  sharedCredsEnv: ${sharedCredentials.project}/${sharedCredentials.name}
+  sharedCredsEnv: shared/credentials-${suffix}
   prodStackId: ${prodStack.id}

--- a/examples/examples_api_test.go
+++ b/examples/examples_api_test.go
@@ -264,9 +264,9 @@ var apiCases = []apiCase{
 		PreviewOnlyAll: true, // Custom VCS registration needs valid creds in the referenced ESC env.
 	},
 	{
-		Name:       "platform-bootstrap",
-		Config:     platformBootstrapConfig,
-		SkipReason: "Composite demo (~18 resources, ~290 lines yaml) kept around as documentation but not exercised by CI. Resources are individually covered by the focused examples above.",
+		Name:           "platform-bootstrap",
+		Config:         platformBootstrapConfig,
+		PreviewOnlyAll: true,
 	},
 	{
 		Name:    "esc-webhook",


### PR DESCRIPTION
The `api/esc` `Environment` resource exposes only `yaml` as an output — the `project` and `name` outputs it had when the platform-bootstrap example was written are gone. Every language variant referenced `sharedCredentials.project`/`.name` (EnvironmentTag, both StackConfigs, the approval-gate target, and the stack output), so none of them compile against the current SDKs. Nobody noticed because the example is fully skipped in CI.

- References now use the literal values passed at creation (`shared` / `credentials-${suffix}`), with explicit `dependsOn: sharedCredentials` restoring the create-order dependencies the output references used to carry.
- The test entry goes back to `PreviewOnlyAll: true` (its state before `b41bdeb1`), so CI's preview lane compiles all six variants and catches this class of drift. Full E2E stays off — that's separately blocked on OrgTemplateCollection having no read op.

Verified locally: `go build` (local SDK), `dotnet build` (local SDK project reference), `tsc --noEmit` (local SDK), `py_compile`, `go vet -tags api`, and a full `pulumi preview` of the yaml variant (27 resources, outputs resolve). Java is compile-checked by the re-enabled preview lane in CI.

No CHANGELOG entry: example/test-only change.