### PR TITLE
Run gofmt on api Go examples

### DIFF
--- a/examples/api/deployment-settings/go/main.go
+++ b/examples/api/deployment-settings/go/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
 	deployments "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/deployments"
+	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )

--- a/examples/api/platform-bootstrap/go/main.go
+++ b/examples/api/platform-bootstrap/go/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	api "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api"
-	teams "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/teams"
-	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
-	auth "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/auth"
 	agents "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/agents"
-	tokens "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/tokens"
+	auth "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/auth"
 	deployments "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/deployments"
 	esc "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/esc"
+	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
+	teams "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/teams"
+	tokens "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )

--- a/examples/api/schedules/go/main.go
+++ b/examples/api/schedules/go/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
 	deployments "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/deployments"
+	stacks "github.com/pulumi/pulumi-pulumiservice/sdk/go/pulumiservice/api/stacks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )


### PR DESCRIPTION
`gofmt -w` on the three files that failed `gofmt -l` (import ordering only, no semantic changes): `examples/api/{deployment-settings,platform-bootstrap,schedules}/go/main.go`.

No CHANGELOG entry: formatting-only change.