### PR TITLE
Migrate Configure from deprecated Variables to Args

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -369,10 +368,20 @@ func (k *pulumiserviceProvider) Configure(
 
 	sc := PulumiServiceConfig{}
 	sc.Config = make(map[string]string)
-	// Migrating to the non-deprecated GetArgs changes key naming and value
-	// encoding, which is out of scope for a lint fix.
-	for key, val := range req.GetVariables() { //nolint:staticcheck
-		sc.Config[strings.TrimPrefix(key, "pulumiservice:config:")] = val
+	args, err := plugin.UnmarshalProperties(req.GetArgs(), plugin.MarshalOptions{
+		KeepResources: true,
+		SkipNulls:     true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling configure args: %w", err)
+	}
+	for key, val := range args {
+		// The engine sends the provider "version" alongside the config
+		// properties; only string config values are meaningful here.
+		if key == "version" || !val.IsString() {
+			continue
+		}
+		sc.Config[string(key)] = val.StringValue()
 	}
 
 	httpClient := http.Client{

--- a/provider/pkg/provider/provider_test.go
+++ b/provider/pkg/provider/provider_test.go
@@ -139,25 +139,21 @@ func TestConfigure_SetsAccessToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Build config variables map as expected by Configure
-	configVars := map[string]string{ //nolint:gosec // G101: test fixture, not a real credential.
-		"pulumiservice:config:accessToken": "pul-test0token",
-	}
+	// Build config args as the engine sends them: plain keys, secrets kept.
+	configArgs, err := plugin.MarshalProperties(resource.PropertyMap{
+		accessTokenKey: resource.MakeSecret(resource.NewStringProperty("pul-test0token")),
+	}, plugin.MarshalOptions{KeepSecrets: true})
+	require.NoError(t, err)
 
-	// Call Configure
-	_, err = provider.Configure(ctx, &pulumirpc.ConfigureRequest{
-		Variables: configVars,
+	// Configure the raw provider directly: MakeProvider wraps it, which
+	// hides the client field this test asserts on.
+	raw := &pulumiserviceProvider{}
+	_, err = raw.Configure(ctx, &pulumirpc.ConfigureRequest{
+		Args: configArgs,
 	})
 	require.NoError(t, err)
 
-	// Assert that AccessToken is set on the provider
-	// We need to cast to the concrete type to access AccessToken field
-	concreteProvider, ok := provider.(*pulumiserviceProvider)
-	if !ok {
-		// The provider is wrapped, so we need to check if client was set instead
-		t.Skip("Provider is wrapped, cannot directly access AccessToken field")
-	}
-	assert.NotNil(t, concreteProvider.client, "client should be initialized after Configure")
+	assert.NotNil(t, raw.client, "client should be initialized after Configure")
 }
 
 // TestProvider_LayeredSchema verifies the unified provider serves three


### PR DESCRIPTION
Follow-up to #838, which suppressed the `SA1019` staticcheck finding on `ConfigureRequest.GetVariables` with a `//nolint` because the migration is a behavioral change, not a lint fix. This PR is that migration.

`ConfigureRequest.Variables` is deprecated in favor of `Args`. The engine sends `Args` as a property struct with plain keys (no `pkg:config:` prefix), typed values, and secrets kept, so `Configure` now unmarshals it with `plugin.UnmarshalProperties` and copies the string values into the existing config map. Behavior is unchanged: the provider reads only the `accessToken` and `apiUrl` string keys, and `KeepSecrets: false` unwraps secret config values just as the engine's `Variables` path stripped secrets before sending.

The `TestConfigure_SetsAccessToken` unit test previously skipped its assertion (the wrapped provider cannot be cast to the concrete type); it now configures the raw provider directly, with a secret-wrapped token to cover the unwrap path, so the client assertion actually runs.