### PR TITLE
Document that OrganizationRole manages only uxPurpose="role"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Improvements
 
+- Documented that `OrganizationRole` manages only permission descriptors with `uxPurpose="role"`, and pointed at `pulumiservice:api:Role` for the other kinds (for example `policy`). The restriction was already enforced but undocumented, so the guard's error read as a provider limitation rather than a pointer to the resource that does support it. No behavior change. [#1022](https://github.com/pulumi/pulumi-pulumiservice/issues/1022)
 - Refreshed the embedded Pulumi Cloud OpenAPI spec. The previous spec still described the `/api/preview/registry/policypacks` routes, which Pulumi Cloud has since removed in favor of the GA `/api/registry/policypacks` routes; code written against the vendored spec was calling routes that no longer resolve.
 - Added `pulumiservice.api.neo.UsageCap` for capping an organization's monthly Neo spend. It is a `PUT`-shaped singleton keyed on `{orgName}`, so create and update are the same call, and it requires `import` to adopt a cap that already exists rather than overwriting it. Deleting the resource removes the cap rather than restoring a prior value. The per-member equivalent is intentionally not exposed: Pulumi Cloud offers only a collection GET for member caps, leaving the resource with no read operation and therefore no refresh, no import, and no working `requireImport` guard.
 - `api.agents.Task` gained a `role` input/output for running a task under an assumed RBAC role, and a `vcsProvider` output identifying the version control system a task targets.

--- a/provider/cmd/pulumi-resource-pulumiservice/schema.json
+++ b/provider/cmd/pulumi-resource-pulumiservice/schema.json
@@ -5864,7 +5864,7 @@
       ]
     },
     "pulumiservice:index:OrganizationRole": {
-      "description": "A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.\n\nRequires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.",
+      "description": "A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.\n\nRequires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.\n\nThis resource manages only permission descriptors with `uxPurpose=\"role\"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.",
       "properties": {
         "description": {
           "type": "string",

--- a/provider/pkg/resources/organization_role.go
+++ b/provider/pkg/resources/organization_role.go
@@ -54,7 +54,11 @@ func (*OrganizationRole) Annotate(a infer.Annotator) {
 			"to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.\n\n"+
 			"Requires the Custom Roles feature to be enabled on the organization. See the "+
 			"[Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for "+
-			"the shape of the `permissions` descriptor.",
+			"the shape of the `permissions` descriptor.\n\n"+
+			"This resource manages only permission descriptors with `uxPurpose=\"role\"`. Pulumi Cloud uses "+
+			"`uxPurpose` to split the permission-descriptor table into roles and other kinds (for example "+
+			"`policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the "+
+			"other kinds.",
 	)
 }
 
@@ -361,7 +365,8 @@ func orgRoleCoreFromAPI(
 	if role.UxPurpose != "" && role.UxPurpose != apitype.PermissionDescriptorUXPurposeRole {
 		return OrganizationRoleCore{}, fmt.Errorf(
 			"descriptor %q is not a role (uxPurpose=%q); `OrganizationRole` "+
-				"only manages entries with uxPurpose=\"role\"",
+				"only manages entries with uxPurpose=\"role\". Use `pulumiservice:api:Role`, "+
+				"which exposes `uxPurpose`, to manage this descriptor",
 			role.ID, role.UxPurpose,
 		)
 	}

--- a/sdk/dotnet/OrganizationRole.cs
+++ b/sdk/dotnet/OrganizationRole.cs
@@ -13,6 +13,8 @@ namespace Pulumi.PulumiService
     /// A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.
     /// 
     /// Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
+    /// 
+    /// This resource manages only permission descriptors with `uxPurpose="role"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
     /// </summary>
     [PulumiServiceResourceType("pulumiservice:index:OrganizationRole")]
     public partial class OrganizationRole : global::Pulumi.CustomResource

--- a/sdk/go/pulumiservice/organizationRole.go
+++ b/sdk/go/pulumiservice/organizationRole.go
@@ -15,6 +15,8 @@ import (
 // A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.
 //
 // Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
+//
+// This resource manages only permission descriptors with `uxPurpose="role"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
 type OrganizationRole struct {
 	pulumi.CustomResourceState
 

--- a/sdk/java/src/main/java/com/pulumi/pulumiservice/OrganizationRole.java
+++ b/sdk/java/src/main/java/com/pulumi/pulumiservice/OrganizationRole.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
  * 
  * Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
  * 
+ * This resource manages only permission descriptors with `uxPurpose=&#34;role&#34;`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
+ * 
  */
 @ResourceType(type="pulumiservice:index:OrganizationRole")
 public class OrganizationRole extends com.pulumi.resources.CustomResource {

--- a/sdk/nodejs/organizationRole.ts
+++ b/sdk/nodejs/organizationRole.ts
@@ -8,6 +8,8 @@ import * as utilities from "./utilities";
  * A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.
  *
  * Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
+ *
+ * This resource manages only permission descriptors with `uxPurpose="role"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
  */
 export class OrganizationRole extends pulumi.CustomResource {
     /**

--- a/sdk/python/pulumi_pulumiservice/organization_role.py
+++ b/sdk/python/pulumi_pulumiservice/organization_role.py
@@ -143,6 +143,8 @@ class OrganizationRole(pulumi.CustomResource):
 
         Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
 
+        This resource manages only permission descriptors with `uxPurpose="role"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
+
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] description: Human-readable description of what the role grants.
@@ -173,6 +175,8 @@ class OrganizationRole(pulumi.CustomResource):
         A custom (fine-grained) role defined on a Pulumi Cloud organization. Custom roles allow precise permission control beyond the built-in `admin` / `member` / `billing-manager` roles. Assign them to members via the `OrganizationMember.roleId` field or to teams via `TeamRoleAssignment`.
 
         Requires the Custom Roles feature to be enabled on the organization. See the [Pulumi Cloud RBAC docs](https://www.pulumi.com/docs/pulumi-cloud/access-management/rbac/) for the shape of the `permissions` descriptor.
+
+        This resource manages only permission descriptors with `uxPurpose="role"`. Pulumi Cloud uses `uxPurpose` to split the permission-descriptor table into roles and other kinds (for example `policy`). Use `pulumiservice:api:Role`, which exposes `uxPurpose` directly, to manage the other kinds.
 
         :param str resource_name: The name of the resource.
         :param OrganizationRoleArgs args: The arguments to use to populate this resource's properties.


### PR DESCRIPTION
Documents an existing restriction. No behavior change.

- `OrganizationRole` hardcodes `uxPurpose="role"` on create and rejects other kinds on read, but the resource description never said so.
- The guard's error now names `pulumiservice:api:Role`, which exposes `uxPurpose` directly, so a user who hits it can self-serve.

Fixes #1022

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./pkg/...` (no failures)
- [x] `schema.json` regenerated from the provider binary; diff is the one description string
- [x] SDKs regenerated; diff is the same description in the five `OrganizationRole` files
