### PR TITLE
Store DeploymentSettings git auth credentials as secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,15 @@
 
 ### Bug Fixes
 
+- Fixed `DeploymentSettings` git auth credentials being written to state in plaintext when the program supplies them as non-secret values. All four `sourceContext.git.gitAuth` credentials (`sshAuth.sshPrivateKey`, `sshAuth.password`, `basicAuth.username` and `basicAuth.password`) are declared `secret` in the schema, but that flag only drives SDK codegen for a resource's own top-level properties and reaches a property nested inside a type only in the .NET SDK — so in every other language a plain value was recorded verbatim in the stack's state `inputs`. The provider now marks all four secret in `Check`, and `basicAuth.username` is handled as an encrypted twin-value secret on create, refresh and import like the other three. [#1037](https://github.com/pulumi/pulumi-pulumiservice/issues/1037)
+
+  Upgrade behavior for existing stacks:
+
+  - State `inputs` heal on the next `pulumi up`, with no diff shown.
+  - `sshPrivateKey` and both passwords were always sent to Pulumi Cloud flagged as secrets, so they were already encrypted at rest and their state `outputs` already read `[secret]`.
+  - `basicAuth.username` was previously sent unflagged, so Pulumi Cloud stored it unencrypted. Because the change of secretness alone produces no diff, the value stays unencrypted server-side — and plaintext in state `outputs` — until the `DeploymentSettings` resource is next actually updated for some other reason.
+
+  Two things this fix cannot undo: a stack that is never updated again keeps its plaintext inputs, and earlier state versions retained by the backend still contain the plaintext. **Anyone who has committed a state file, or uses a backend where prior state versions are readable, should rotate the affected credentials.**
 - Fixed `OidcIssuer` panicking during `pulumi preview` when its `url` input was an unknown value, such as another resource's output. The provider read the unknown input as a concrete string during `Check` and crashed; previews now complete and resolve `url` as computed. [#831](https://github.com/pulumi/pulumi-pulumiservice/pull/831)
 - Fixed `AgentPool.agentPoolId` output never being populated. The provider previously wrote the value under a state key that did not match the schema, so `pool.agentPoolId` was always undefined. Existing stacks pick up the correct value on the next `pulumi refresh`.
 - Fixed TeamEnvironmentPermission spurious replacement on upgrade from 0.29.2 caused by the optional `maxOpenDuration` field being serialized as an empty string in Check and Read [#751](https://github.com/pulumi/pulumi-pulumiservice/issues/751)

--- a/examples/examples_nodejs_test.go
+++ b/examples/examples_nodejs_test.go
@@ -48,7 +48,17 @@ func TestDeploymentSettingsExample(t *testing.T) {
 	test.SetConfig(t, "my_secret", "my_secret_value")
 	test.SetConfig(t, "password", "my_password")
 	test.SetConfig(t, "imagePassword", "my_image_password")
-	runPulumiTest(t, test)
+
+	// The example passes sshPrivateKey as a plaintext literal. The provider must
+	// still store it as a secret: for a property nested inside a type the
+	// schema's `"secret": true` only reaches the .NET SDK, so for this Node.js
+	// program only Check keeps it out of the state file.
+	// Guards https://github.com/pulumi/pulumi-pulumiservice/issues/1037.
+	runPulumiTestAfterUp(t, test, func(t *testing.T, test *pulumitest.PulumiTest) {
+		inputs := stateInputs(t, test, "pulumiservice:index:DeploymentSettings")
+		assertStateSecret(t, inputs, "sourceContext", "git", "gitAuth", "sshAuth", "sshPrivateKey")
+		assertStateSecret(t, inputs, "sourceContext", "git", "gitAuth", "sshAuth", "password")
+	})
 }
 
 func TestTeamStackPermissionsExample(t *testing.T) {

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -1,9 +1,13 @@
 package examples
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/providertest/providers"
 	"github.com/pulumi/providertest/pulumitest"
@@ -11,6 +15,8 @@ import (
 	"github.com/pulumi/providertest/pulumitest/assertrefresh"
 	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	psp "github.com/pulumi/pulumi-pulumiservice/provider/pkg/provider"
@@ -56,8 +62,23 @@ func yarnInstall(t *testing.T, dir string) {
 // runPulumiTest performs the same basic steps as
 // [github.com/pulumi/pulumi/pkg/v3/testing/integration.ProgramTest].
 func runPulumiTest(t *testing.T, test *pulumitest.PulumiTest) auto.UpResult {
+	return runPulumiTestAfterUp(t, test, nil)
+}
+
+// runPulumiTestAfterUp is runPulumiTest with a hook that runs against the live
+// stack right after `up`, for assertions that need the stack state before it is
+// destroyed.
+func runPulumiTestAfterUp(
+	t *testing.T,
+	test *pulumitest.PulumiTest,
+	afterUp func(t *testing.T, test *pulumitest.PulumiTest),
+) auto.UpResult {
 	// Run the Pulumi program
 	upResult := test.Up(t)
+
+	if afterUp != nil {
+		afterUp(t, test)
+	}
 
 	// Run preview to ensure no changes after initial deployment
 	previewResult := test.Preview(t)
@@ -71,4 +92,40 @@ func runPulumiTest(t *testing.T, test *pulumitest.PulumiTest) auto.UpResult {
 	test.Destroy(t)
 
 	return upResult
+}
+
+// stateInputs returns the state inputs of the single resource of the given type.
+func stateInputs(t *testing.T, test *pulumitest.PulumiTest, resourceType string) map[string]any {
+	t.Helper()
+
+	var deployment apitype.DeploymentV3
+	exported := test.ExportStack(t)
+	require.NoError(t, json.Unmarshal(exported.Deployment, &deployment))
+
+	for _, res := range deployment.Resources {
+		if string(res.Type) == resourceType {
+			return res.Inputs
+		}
+	}
+	t.Fatalf("no %s resource found in the exported stack", resourceType)
+	return nil
+}
+
+// assertStateSecret asserts that the value at path within inputs is stored as an
+// encrypted secret rather than plaintext.
+func assertStateSecret(t *testing.T, inputs map[string]any, path ...string) {
+	t.Helper()
+
+	value := any(inputs)
+	for _, key := range path {
+		object, ok := value.(map[string]any)
+		require.Truef(t, ok, "%v: %q is not nested under an object", path, key)
+		value, ok = object[key]
+		require.Truef(t, ok, "%v: %q is missing from the state inputs", path, key)
+	}
+
+	object, ok := value.(map[string]any)
+	require.Truef(t, ok, "%v is %#v, not a secret envelope", path, value)
+	assert.Equalf(t, resource.SecretSig, object[resource.SigKey],
+		"%v is not stored as a secret in state", path)
 }

--- a/provider/pkg/resources/deployment_setting_test.go
+++ b/provider/pkg/resources/deployment_setting_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 
 	"github.com/pulumi/pulumi-pulumiservice/provider/pkg/pulumiapi"
@@ -105,6 +106,275 @@ func TestDeploymentSettings(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, resp.Id, "abc/def/123")
 	})
+}
+
+// checkGitAuth runs Check over deployment settings carrying gitAuth and hands
+// back the checked gitAuth property map.
+func checkGitAuth(t *testing.T, gitAuth resource.PropertyMap) resource.PropertyMap {
+	t.Helper()
+
+	propertyMap := resource.PropertyMap{
+		gcOrganization: resource.NewStringProperty("an-org"),
+		gcProject:      resource.NewStringProperty("a-project"),
+		gcStack:        resource.NewStringProperty("a-stack"),
+		gcSourceContext: resource.NewObjectProperty(resource.PropertyMap{
+			gcGit: resource.NewObjectProperty(resource.PropertyMap{
+				"repoUrl": resource.NewStringProperty("https://github.com/pulumi/deploy-demos.git"),
+				gcGitAuth: resource.NewObjectProperty(gitAuth),
+			}),
+		}),
+	}
+
+	news, err := plugin.MarshalProperties(propertyMap, util.StandardMarshal)
+	assert.NoError(t, err)
+
+	resp, err := (&PulumiServiceDeploymentSettingsResource{}).Check(&pulumirpc.CheckRequest{News: news})
+	assert.NoError(t, err)
+	assert.Empty(t, resp.Failures)
+
+	checked, err := plugin.UnmarshalProperties(resp.GetInputs(), util.KeepSecretsUnmarshal)
+	assert.NoError(t, err)
+
+	sourceContext := checked[gcSourceContext]
+	assert.True(t, sourceContext.IsObject(), "sourceContext should be present")
+	git := sourceContext.ObjectValue()[gcGit]
+	assert.True(t, git.IsObject(), "git should be present")
+	checkedGitAuth := git.ObjectValue()[gcGitAuth]
+	assert.True(t, checkedGitAuth.IsObject(), "gitAuth should be present")
+
+	return checkedGitAuth.ObjectValue()
+}
+
+// assertSecret asserts that prop is a secret wrapping the given plaintext.
+func assertSecret(t *testing.T, prop resource.PropertyValue, want string) {
+	t.Helper()
+	assert.True(t, prop.IsSecret(), "expected a secret, got %v", prop)
+	assert.Equal(t, want, prop.SecretValue().Element.StringValue())
+}
+
+// The schema's `"secret": true` on these fields is codegen-only, and for a
+// property nested inside a type only the .NET SDK acts on it, so Check has to
+// promote them. Without this, a plaintext literal lands in the state file
+// verbatim for every other language.
+func TestDeploymentSettingsCheckGitAuthSecrets(t *testing.T) {
+	t.Run("promotes plaintext sshAuth credentials", func(t *testing.T) {
+		gitAuth := checkGitAuth(t, resource.PropertyMap{
+			gcSSHAuth: resource.NewObjectProperty(resource.PropertyMap{
+				gcSSHPrivateKey: resource.NewStringProperty("a-private-key"),
+				gcPassword:      resource.NewStringProperty("a-key-password"),
+			}),
+		})
+
+		sshAuth := gitAuth[gcSSHAuth].ObjectValue()
+		assertSecret(t, sshAuth[gcSSHPrivateKey], "a-private-key")
+		assertSecret(t, sshAuth[gcPassword], "a-key-password")
+	})
+
+	t.Run("promotes plaintext basicAuth credentials", func(t *testing.T) {
+		gitAuth := checkGitAuth(t, resource.PropertyMap{
+			gcBasicAuth: resource.NewObjectProperty(resource.PropertyMap{
+				gcUsername: resource.NewStringProperty("alice"),
+				gcPassword: resource.NewStringProperty("hunter2"),
+			}),
+		})
+
+		basicAuth := gitAuth[gcBasicAuth].ObjectValue()
+		assertSecret(t, basicAuth[gcUsername], "alice")
+		assertSecret(t, basicAuth[gcPassword], "hunter2")
+	})
+
+	t.Run("leaves already secret credentials untouched", func(t *testing.T) {
+		gitAuth := checkGitAuth(t, resource.PropertyMap{
+			gcSSHAuth: resource.NewObjectProperty(resource.PropertyMap{
+				gcSSHPrivateKey: resource.MakeSecret(resource.NewStringProperty("a-private-key")),
+			}),
+			gcBasicAuth: resource.NewObjectProperty(resource.PropertyMap{
+				gcUsername: resource.MakeSecret(resource.NewStringProperty("alice")),
+				gcPassword: resource.MakeSecret(resource.NewStringProperty("hunter2")),
+			}),
+		})
+
+		// Not double-wrapped: the element is still the string, not another secret.
+		assertSecret(t, gitAuth[gcSSHAuth].ObjectValue()[gcSSHPrivateKey], "a-private-key")
+		assertSecret(t, gitAuth[gcBasicAuth].ObjectValue()[gcUsername], "alice")
+		assertSecret(t, gitAuth[gcBasicAuth].ObjectValue()[gcPassword], "hunter2")
+	})
+
+	t.Run("optional sshAuth password stays absent", func(t *testing.T) {
+		gitAuth := checkGitAuth(t, resource.PropertyMap{
+			gcSSHAuth: resource.NewObjectProperty(resource.PropertyMap{
+				gcSSHPrivateKey: resource.NewStringProperty("a-private-key"),
+			}),
+		})
+
+		sshAuth := gitAuth[gcSSHAuth].ObjectValue()
+		assertSecret(t, sshAuth[gcSSHPrivateKey], "a-private-key")
+		assert.NotContains(t, sshAuth, resource.PropertyKey(gcPassword))
+	})
+}
+
+// The executor image registry password is nested inside a type too, so it needs
+// the same promotion in Check as the git auth credentials.
+func TestDeploymentSettingsCheckExecutorImageCredentialsSecret(t *testing.T) {
+	credentials := func(password resource.PropertyValue) resource.PropertyMap {
+		t.Helper()
+
+		propertyMap := resource.PropertyMap{
+			gcOrganization: resource.NewStringProperty("an-org"),
+			gcProject:      resource.NewStringProperty("a-project"),
+			gcStack:        resource.NewStringProperty("a-stack"),
+			gcExecutorContext: resource.NewObjectProperty(resource.PropertyMap{
+				"executorImage": resource.NewStringProperty("myreg.example.com/custom-pulumi:latest"),
+				gcCredentials: resource.NewObjectProperty(resource.PropertyMap{
+					gcUsername: resource.NewStringProperty(testRegistryUsername),
+					gcPassword: password,
+				}),
+			}),
+		}
+
+		news, err := plugin.MarshalProperties(propertyMap, util.StandardMarshal)
+		assert.NoError(t, err)
+
+		resp, err := (&PulumiServiceDeploymentSettingsResource{}).Check(&pulumirpc.CheckRequest{News: news})
+		assert.NoError(t, err)
+		assert.Empty(t, resp.Failures)
+
+		checked, err := plugin.UnmarshalProperties(resp.GetInputs(), util.KeepSecretsUnmarshal)
+		assert.NoError(t, err)
+
+		executorContext := checked[gcExecutorContext]
+		assert.True(t, executorContext.IsObject(), "executorContext should be present")
+		checkedCredentials := executorContext.ObjectValue()[gcCredentials]
+		assert.True(t, checkedCredentials.IsObject(), "credentials should be present")
+
+		return checkedCredentials.ObjectValue()
+	}
+
+	t.Run("promotes a plaintext password", func(t *testing.T) {
+		checked := credentials(resource.NewStringProperty(testRegistryPassword))
+
+		assertSecret(t, checked[gcPassword], testRegistryPassword)
+		// The username is not a credential the schema marks secret.
+		assert.Equal(t, resource.NewStringProperty(testRegistryUsername), checked[gcUsername])
+	})
+
+	t.Run("leaves an already secret password untouched", func(t *testing.T) {
+		checked := credentials(resource.MakeSecret(resource.NewStringProperty(testRegistryPassword)))
+
+		// Not double-wrapped: the element is still the string, not another secret.
+		assertSecret(t, checked[gcPassword], testRegistryPassword)
+	})
+}
+
+// basicAuthSettings builds deployment settings carrying git basic auth.
+func basicAuthSettings(username, password pulumiapi.SecretValue) pulumiapi.DeploymentSettings {
+	return pulumiapi.DeploymentSettings{
+		SourceContext: &pulumiapi.SourceContext{
+			Git: &pulumiapi.SourceContextGit{
+				RepoURL: "https://github.com/pulumi/deploy-demos.git",
+				GitAuth: &pulumiapi.GitAuthConfig{
+					BasicAuth: &pulumiapi.BasicAuth{UserName: username, Password: password},
+				},
+			},
+		},
+	}
+}
+
+// plaintextBasicAuth is what the user's program supplies.
+func plaintextBasicAuth() pulumiapi.DeploymentSettings {
+	return basicAuthSettings(
+		pulumiapi.SecretValue{Secret: true, Value: "alice"},
+		pulumiapi.SecretValue{Secret: true, Value: "hunter2"},
+	)
+}
+
+// redactedBasicAuth is what the settings API hands back: the plaintext replaced
+// by a marker, with the ciphertext alongside it.
+func redactedBasicAuth() pulumiapi.DeploymentSettings {
+	redacted := pulumiapi.SecretValue{
+		Secret:     true,
+		Value:      testRedactedSecret,
+		Ciphertext: []byte("ciphertext-from-the-service"),
+	}
+	return basicAuthSettings(redacted, redacted)
+}
+
+// basicAuthPropertyMap digs the git basic auth back out of an encoded property map.
+func basicAuthPropertyMap(t *testing.T, encoded resource.PropertyMap) resource.PropertyMap {
+	t.Helper()
+
+	value := encoded[gcSourceContext]
+	for _, key := range []resource.PropertyKey{gcGit, gcGitAuth, gcBasicAuth} {
+		assert.Truef(t, value.IsObject(), "expected an object before %q", key)
+		value = value.ObjectValue()[key]
+	}
+	assert.True(t, value.IsObject(), "basicAuth should be present")
+	return value.ObjectValue()
+}
+
+// The username is a twin-value secret like the password: Pulumi Cloud encrypts
+// it and never hands the plaintext back, so it has to survive the same
+// create/refresh/import paths.
+func TestDeploymentSettingsBasicAuthRoundtrip(t *testing.T) {
+	settings := plaintextBasicAuth()
+	initial := PulumiServiceDeploymentSettingsInput{DeploymentSettings: settings}
+
+	// Create mode: plaintext inputs are available, no prior cipher state yet.
+	encoded := initial.ToPropertyMap(&settings, nil, true)
+	decoded := (&PulumiServiceDeploymentSettingsResource{}).ToPulumiServiceDeploymentSettingsInput(encoded)
+
+	assert.EqualValues(t, initial, decoded)
+	assertSecret(t, basicAuthPropertyMap(t, encoded)[gcUsername], "alice")
+}
+
+// On refresh the API hands back the credentials redacted plus their ciphertext,
+// never the plaintext. The user's plaintext input must be carried forward so
+// refresh reports no change.
+func TestDeploymentSettingsBasicAuthRefresh(t *testing.T) {
+	fromAPI := redactedBasicAuth()
+	priorState := redactedBasicAuth()
+	plaintextInputs := plaintextBasicAuth()
+
+	input := PulumiServiceDeploymentSettingsInput{DeploymentSettings: fromAPI}
+
+	inputs := basicAuthPropertyMap(t, input.ToPropertyMap(&plaintextInputs, &priorState, true))
+	assertSecret(t, inputs[gcUsername], "alice")
+	assertSecret(t, inputs[gcPassword], "hunter2")
+
+	outputs := basicAuthPropertyMap(t, input.ToPropertyMap(&plaintextInputs, &priorState, false))
+	assert.Equal(t, testRedactedSecret, util.GetSecretOrStringValue(outputs[gcUsername]),
+		"outputs hold what the service returned, not the plaintext")
+}
+
+// Import has no inputs at all, so both credentials are replaced with the
+// placeholder that prompts the user to fill them in.
+func TestDeploymentSettingsBasicAuthImport(t *testing.T) {
+	settings := redactedBasicAuth()
+	input := PulumiServiceDeploymentSettingsInput{DeploymentSettings: settings}
+
+	inputs := basicAuthPropertyMap(t, input.ToPropertyMap(nil, nil, true))
+	assertSecret(t, inputs[gcUsername], "<REPLACE WITH ACTUAL SECRET VALUE>")
+	assertSecret(t, inputs[gcPassword], "<REPLACE WITH ACTUAL SECRET VALUE>")
+}
+
+// Settings with no sourceContext at all must pass through Check unchanged.
+func TestDeploymentSettingsCheckWithoutSourceContext(t *testing.T) {
+	propertyMap := resource.PropertyMap{
+		gcOrganization: resource.NewStringProperty("an-org"),
+		gcProject:      resource.NewStringProperty("a-project"),
+		gcStack:        resource.NewStringProperty("a-stack"),
+	}
+
+	news, err := plugin.MarshalProperties(propertyMap, util.StandardMarshal)
+	assert.NoError(t, err)
+
+	resp, err := (&PulumiServiceDeploymentSettingsResource{}).Check(&pulumirpc.CheckRequest{News: news})
+	assert.NoError(t, err)
+	assert.Empty(t, resp.Failures)
+
+	checked, err := plugin.UnmarshalProperties(resp.GetInputs(), util.KeepSecretsUnmarshal)
+	assert.NoError(t, err)
+	assert.Equal(t, propertyMap, checked)
 }
 
 func TestDeploymentSettingsRoundtrip(t *testing.T) {

--- a/provider/pkg/resources/deployment_settings.go
+++ b/provider/pkg/resources/deployment_settings.go
@@ -22,6 +22,20 @@ const (
 	gcAWS          = "aws"
 )
 
+// Property names along the paths to the nested credentials.
+const (
+	gcSourceContext   = "sourceContext"
+	gcGit             = "git"
+	gcGitAuth         = "gitAuth"
+	gcSSHAuth         = "sshAuth"
+	gcSSHPrivateKey   = "sshPrivateKey"
+	gcBasicAuth       = "basicAuth"
+	gcUsername        = "username"
+	gcPassword        = "password"
+	gcExecutorContext = "executorContext"
+	gcCredentials     = "credentials"
+)
+
 type PulumiServiceDeploymentSettingsInput struct {
 	pulumiapi.DeploymentSettings
 	Stack pulumiapi.StackIdentifier
@@ -144,9 +158,32 @@ func (ds *PulumiServiceDeploymentSettingsInput) ToPropertyMap(
 				if ds.SourceContext.Git.GitAuth.BasicAuth != nil {
 					basicAuthPropertyMap := resource.PropertyMap{}
 					if ds.SourceContext.Git.GitAuth.BasicAuth.UserName.Value != "" {
-						basicAuthPropertyMap["username"] = resource.NewPropertyValue(
-							ds.SourceContext.Git.GitAuth.BasicAuth.UserName.Value,
-						)
+						if mergeMode {
+							var plaintextValue *pulumiapi.SecretValue
+							var currentCipherValue *pulumiapi.SecretValue
+							if currentStateCipherSettings.SourceContext != nil &&
+								currentStateCipherSettings.SourceContext.Git != nil &&
+								currentStateCipherSettings.SourceContext.Git.GitAuth != nil &&
+								currentStateCipherSettings.SourceContext.Git.GitAuth.BasicAuth != nil {
+								plaintextValue = &plaintextInputSettings.SourceContext.Git.GitAuth.BasicAuth.UserName
+								currentCipherValue = &currentStateCipherSettings.SourceContext.Git.GitAuth.BasicAuth.UserName
+							}
+							util.MergeSecretValue(
+								basicAuthPropertyMap,
+								gcUsername,
+								ds.SourceContext.Git.GitAuth.BasicAuth.UserName,
+								plaintextValue,
+								currentCipherValue,
+								isInput,
+							)
+						} else if createMode {
+							util.CreateSecretValue(basicAuthPropertyMap, gcUsername, ds.SourceContext.Git.GitAuth.BasicAuth.UserName,
+								plaintextInputSettings.SourceContext.Git.GitAuth.BasicAuth.UserName, isInput)
+						} else {
+							util.ImportSecretValue(
+								basicAuthPropertyMap, gcUsername, ds.SourceContext.Git.GitAuth.BasicAuth.UserName, isInput,
+							)
+						}
 					}
 					if ds.SourceContext.Git.GitAuth.BasicAuth.Password.Value != "" {
 						if mergeMode {
@@ -560,12 +597,10 @@ func toSourceContext(inputMap resource.PropertyMap) *pulumiapi.SourceContext {
 	}
 
 	scInput := util.GetSecretOrObjectValue(inputMap["sourceContext"])
-	cascadeSecret := inputMap["sourceContext"].IsSecret()
 	var sc pulumiapi.SourceContext
 
 	if scInput["git"].HasValue() {
 		gitInput := util.GetSecretOrObjectValue(scInput["git"])
-		cascadeSecret = cascadeSecret || scInput["git"].IsSecret()
 		var g pulumiapi.SourceContextGit
 
 		if gitInput["repoUrl"].HasValue() {
@@ -583,7 +618,6 @@ func toSourceContext(inputMap resource.PropertyMap) *pulumiapi.SourceContext {
 
 		if gitInput["gitAuth"].HasValue() {
 			authInput := util.GetSecretOrObjectValue(gitInput["gitAuth"])
-			cascadeSecret = cascadeSecret || gitInput["gitAuth"].IsSecret()
 			var a pulumiapi.GitAuthConfig
 
 			if authInput["sshAuth"].HasValue() {
@@ -608,13 +642,14 @@ func toSourceContext(inputMap resource.PropertyMap) *pulumiapi.SourceContext {
 
 			if authInput["basicAuth"].HasValue() {
 				basicInput := util.GetSecretOrObjectValue(authInput["basicAuth"])
-				cascadeSecret = cascadeSecret || authInput["basicAuth"].IsSecret()
 				var b pulumiapi.BasicAuth
 
-				if basicInput["username"].HasValue() {
+				if basicInput["username"].HasValue() || basicInput["usernameCipher"].HasValue() {
+					// Secret must be set, otherwise Pulumi Cloud stores the value in
+					// plaintext: it only encrypts SecretValues flagged as secret.
 					b.UserName = pulumiapi.SecretValue{
 						Value:  util.GetSecretOrStringValue(basicInput["username"]),
-						Secret: cascadeSecret || basicInput["username"].IsSecret(),
+						Secret: true,
 					}
 				}
 				if basicInput["password"].HasValue() || basicInput["passwordCipher"].HasValue() {
@@ -879,20 +914,19 @@ func (ds *PulumiServiceDeploymentSettingsResource) Check(
 		}
 	}
 
-	// Force the executor image registry password to be secret. The engine records
-	// whatever Check hands back as the resource's inputs in the state file, and
-	// nothing upstream of here marks it: the schema's `"secret": true` only drives
-	// SDK codegen, which cannot express `additionalSecretOutputs` for a property
-	// nested inside a type. So a program passing a plaintext literal would
-	// otherwise have that literal written to state verbatim.
-	if news["executorContext"].HasValue() {
-		executorContext := util.GetSecretOrObjectValue(news["executorContext"])
-		if executorContext["credentials"].HasValue() {
-			credentials := util.GetSecretOrObjectValue(executorContext["credentials"])
-			if credentials["password"].HasValue() && !credentials["password"].IsSecret() {
-				credentials["password"] = resource.MakeSecret(credentials["password"])
-			}
-		}
+	// Force the nested credentials to be secret. Their `"secret": true` in the
+	// schema is codegen-only, and for a property nested inside a type only the
+	// .NET SDK acts on it — so in every other language a program passing a
+	// plaintext literal would have that literal written to state verbatim. See
+	// util.MakeNestedSecret.
+	for _, path := range [][]resource.PropertyKey{
+		{gcSourceContext, gcGit, gcGitAuth, gcSSHAuth, gcSSHPrivateKey},
+		{gcSourceContext, gcGit, gcGitAuth, gcSSHAuth, gcPassword},
+		{gcSourceContext, gcGit, gcGitAuth, gcBasicAuth, gcUsername},
+		{gcSourceContext, gcGit, gcGitAuth, gcBasicAuth, gcPassword},
+		{gcExecutorContext, gcCredentials, gcPassword},
+	} {
+		util.MakeNestedSecret(news, path...)
 	}
 
 	checkedNews, err := plugin.MarshalProperties(news, util.StandardMarshal)

--- a/provider/pkg/util/secret.go
+++ b/provider/pkg/util/secret.go
@@ -86,6 +86,47 @@ func GetSecretOrObjectValue(prop resource.PropertyValue) resource.PropertyMap {
 	}
 }
 
+// MakeNestedSecret promotes the value at path to a secret, if it is present and
+// is not already one. Intermediate levels may themselves be secret-wrapped
+// objects. A missing level, a level that is not an object, or a missing leaf is
+// a no-op.
+//
+// A nested property cannot be relied on to be marked secret by the schema. The
+// `"secret": true` flag only drives SDK codegen, and for a property nested
+// inside a `#/types/...` object only the .NET generator acts on it (it wraps the
+// setter in Output.CreateSecret); Node.js, Python, Go and Java emit nothing. So
+// a provider that wants a nested property kept out of plaintext state has to
+// promote it here, in Check: the engine records whatever Check hands back as the
+// resource's inputs in the state file.
+func MakeNestedSecret(props resource.PropertyMap, path ...resource.PropertyKey) {
+	if len(path) == 0 {
+		return
+	}
+
+	for _, key := range path[:len(path)-1] {
+		value, ok := props[key]
+		if !ok || !value.HasValue() {
+			return
+		}
+		if value.IsSecret() {
+			value = value.SecretValue().Element
+		}
+		if !value.IsObject() {
+			return
+		}
+		// PropertyMap is a Go map, so the walk hands back the live nested map and
+		// the assignment below is visible from the root. No write-back needed.
+		props = value.ObjectValue()
+	}
+
+	leaf := path[len(path)-1]
+	value, ok := props[leaf]
+	if !ok || !value.HasValue() || value.IsSecret() {
+		return
+	}
+	props[leaf] = resource.MakeSecret(value)
+}
+
 // This is a value for imported secrets, to hint that value needs to be replaced
 // in generated code
 const replaceMe = "<REPLACE WITH ACTUAL SECRET VALUE>"

--- a/provider/pkg/util/secret_test.go
+++ b/provider/pkg/util/secret_test.go
@@ -132,3 +132,93 @@ func TestGetSecretOrObjectValue(t *testing.T) {
 		assert.Equal(t, "secret-value", result["key"].StringValue())
 	})
 }
+
+// nested builds {"a": {"b": {"c": leaf}}}.
+func nested(leaf resource.PropertyValue) resource.PropertyMap {
+	return resource.PropertyMap{
+		"a": resource.NewObjectProperty(resource.PropertyMap{
+			"b": resource.NewObjectProperty(resource.PropertyMap{
+				"c": leaf,
+			}),
+		}),
+	}
+}
+
+func TestMakeNestedSecret(t *testing.T) {
+	t.Run("promotes a plaintext leaf", func(t *testing.T) {
+		props := nested(resource.NewStringProperty("hunter2"))
+
+		MakeNestedSecret(props, "a", "b", "c")
+
+		leaf := props["a"].ObjectValue()["b"].ObjectValue()["c"]
+		assert.True(t, leaf.IsSecret(), "leaf should have been promoted")
+		assert.Equal(t, "hunter2", leaf.SecretValue().Element.StringValue())
+	})
+
+	t.Run("leaves an already secret leaf untouched", func(t *testing.T) {
+		props := nested(resource.MakeSecret(resource.NewStringProperty("hunter2")))
+
+		MakeNestedSecret(props, "a", "b", "c")
+
+		leaf := props["a"].ObjectValue()["b"].ObjectValue()["c"]
+		assert.True(t, leaf.IsSecret())
+		// Not double-wrapped: the element is still the string, not another secret.
+		assert.Equal(t, "hunter2", leaf.SecretValue().Element.StringValue())
+	})
+
+	t.Run("walks through a secret intermediate object", func(t *testing.T) {
+		props := resource.PropertyMap{
+			"a": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+				"b": resource.NewObjectProperty(resource.PropertyMap{
+					"c": resource.NewStringProperty("hunter2"),
+				}),
+			})),
+		}
+
+		MakeNestedSecret(props, "a", "b", "c")
+
+		leaf := props["a"].SecretValue().Element.ObjectValue()["b"].ObjectValue()["c"]
+		assert.True(t, leaf.IsSecret())
+		assert.Equal(t, "hunter2", leaf.SecretValue().Element.StringValue())
+	})
+
+	t.Run("no-op when the path is missing", func(t *testing.T) {
+		props := nested(resource.NewStringProperty("hunter2"))
+		before := props.Copy()
+
+		MakeNestedSecret(props, "a", "nope", "c")
+		MakeNestedSecret(props, "a", "b", "nope")
+		MakeNestedSecret(props, "nope")
+
+		assert.Equal(t, before, props)
+	})
+
+	t.Run("no-op when an intermediate level is not an object", func(t *testing.T) {
+		props := resource.PropertyMap{
+			"a": resource.NewStringProperty("not-an-object"),
+		}
+		before := props.Copy()
+
+		MakeNestedSecret(props, "a", "b", "c")
+
+		assert.Equal(t, before, props)
+	})
+
+	t.Run("no-op on an empty path", func(t *testing.T) {
+		props := nested(resource.NewStringProperty("hunter2"))
+		before := props.Copy()
+
+		MakeNestedSecret(props)
+
+		assert.Equal(t, before, props)
+	})
+
+	t.Run("no-op on a null leaf", func(t *testing.T) {
+		props := nested(resource.NewNullProperty())
+		before := props.Copy()
+
+		MakeNestedSecret(props, "a", "b", "c")
+
+		assert.Equal(t, before, props)
+	})
+}


### PR DESCRIPTION
Fixes #1037.

## The bug

`DeploymentSettings` declares four `sourceContext.git.gitAuth` credentials as `"secret": true` in `manual-schema.json`, but nothing enforced it at runtime. A program passing any of them as a plain value had the literal written verbatim into the stack's state `inputs`.

The schema flag only drives SDK codegen, and codegen reads it for a resource's own top-level properties. For a property nested inside a `#/types/...` object, **only the .NET generator acts on it** (it wraps the setter in `Output.CreateSecret`); Node.js, Python, Go and Java emit nothing. `DeploymentSettings` is a legacy raw-gRPC resource, so it gets no help from `infer` either — its `Check` passed `req.News` through untouched apart from normalizing the OIDC duration.

> Note: issue #1037 states codegen ignores the flag for nested properties in *all* languages. Regenerating the SDKs showed that's not true for .NET — C# programs were never exposed to this.

## The fix

- **`util.MakeNestedSecret(props, path...)`** — a path-based promoter that walks through secret-wrapped intermediates and no-ops on a missing or non-object level. There was no property-path helper in `util/` before; every resource hand-rolled `HasValue()` + `GetSecretOrObjectValue` chains.
- **`Check`** now promotes all four credentials via that helper.
- **`basicAuth.username` needed more than a `Check` change.** It was the one credential sent to Pulumi Cloud unflagged (`Secret: cascadeSecret || IsSecret()`), so the service stored it unencrypted and handed the plaintext straight back. Now that `Check` marks it secret, the service encrypts it and redacts it to `[secret]` on read — so the plain `NewPropertyValue` in `ToPropertyMap` would have written that marker into state as the username. It now goes through the same `Merge`/`Create`/`ImportSecretValue` path as the other three, and `toSourceContext` hardcodes `Secret: true` to match. This also drops the now-dead `cascadeSecret` tracking in `toSourceContext`, which had no remaining reader.

The schema is unchanged, so there is no SDK regeneration in this PR.

## Verification

Unit: `TestMakeNestedSecret` (7 cases), `TestDeploymentSettingsCheckGitAuthSecrets`, and create/refresh/import roundtrips for `basicAuth`. These are the first `Check` tests this resource has had. Confirmed non-vacuous — with the promotion disabled, `TestDeploymentSettingsCheckGitAuthSecrets` fails with `expected a secret, got {a-private-key}`.

Integration: `TestDeploymentSettingsExample` gains a post-`up` state assertion (via a new `runPulumiTestAfterUp` hook) that the plaintext `sshPrivateKey: "key"` the example already passes lands in state as a secret envelope.

Also verified end-to-end against app.pulumi.com with a `basicAuth` program:

| | before | after |
| --- | --- | --- |
| `username` in state `inputs` | `GITUSER-LITERAL-alice` | ciphertext |
| `password` in state `inputs` | `GITPASS-LITERAL-hunter2` | ciphertext |
| `refresh` / `preview` / re-`up` | — | `3 unchanged` |

And the upgrade path, by deploying with a provider built from `main` and then switching binaries: state inputs heal to ciphertext on the next `up`, reported as `3 unchanged`.

## Upgrade behavior

- State `inputs` heal on the next `pulumi up`, no diff shown.
- `sshPrivateKey` and both passwords were always sent flagged as secrets, so they were already encrypted at rest and their `outputs` already read `[secret]`.
- `basicAuth.username` is the exception worth calling out: because a change of secretness alone produces no diff, the value stays unencrypted server-side — and plaintext in state `outputs` — until the resource is next actually updated for some other reason. Verified: forcing an unrelated `repoDir` change flips the output to `[secret]`.

No state migration or version bump.

## Follow-up

#1038 covers the same class of gap on `pulumiservice:api/deployments:Settings`, which types `sourceContext` as `pulumi.json#/Any` and makes no secrecy claim at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
